### PR TITLE
Change frequency for 28.2 providers

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
@@ -4,7 +4,7 @@
 	<protocol>sky</protocol>
 	<transponder
 		orbital_position="282"
-		frequency="11778000"
+		frequency="11934000"
 		symbol_rate="27500000"
 		polarization="1"
 		fec_inner="2"

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -4,7 +4,7 @@
 	<protocol>sky</protocol>
 	<transponder
 		orbital_position="282"
-		frequency="11778000"
+		frequency="11934000"
 		symbol_rate="27500000"
 		polarization="1"
 		fec_inner="2"

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk_zzl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk_zzl.xml
@@ -4,7 +4,7 @@
 	<protocol>sky</protocol>
 	<transponder 
 		orbital_position="282"
-		frequency="11778000"
+		frequency="11934000"
 		symbol_rate="27500000"
 		polarization="1"
 		fec_inner="2"


### PR DESCRIPTION
There have been some posts about ABM not locking. So cahnging frequency to that of intro channel.