### PR TITLE
[Wetek] Create IPBox Remote Entry in RCUSelect plugin

### DIFF
--- a/RCUSelect/src/plugin.py
+++ b/RCUSelect/src/plugin.py
@@ -59,7 +59,8 @@ class RCUSelect(Screen):
 		_("Mutant HD2400 RCU"),
 		_("Octagon SF8 RCU"),
 		_("Technomate Nano RCU"),
-		_("xtrend ET10000 RCU")]
+		_("xtrend ET10000 RCU"),
+		_("AB IPBox 9900/99/55 HD RCU")]
 		self.SetOSDList()
 		self.MakeKeymapBckUp()
 
@@ -116,6 +117,8 @@ class RCUSelect(Screen):
 					os.system("cp -f /etc/amremote/gilx3.conf /etc/amremote/wetek.conf &")
 				elif self.rcuv == 'Gigablue 800 UE Plus RCU':
 					os.system("cp -f /etc/amremote/gb800ueplus.conf /etc/amremote/wetek.conf &")
+				elif self.rcuv == 'AB IPBox 9900/99/55 HD RCU':
+					os.system("cp -f /etc/amremote/wetek_ipbox9900remote.conf /etc/amremote/wetek.conf &")	
 				else:
 					os.system("cp -f /etc/amremote/wetek2.conf /etc/amremote/wetek.conf &")
 				f = open("/etc/amremote/.choice", "w")


### PR DESCRIPTION
Hello,
this commit adds new entry for AB IPBox 9900/99/55 HD IR Remotes into RCUSelect plugin. This change is dependant on pull request oe-alliance/oe-alliance-core#129.

Thanks.