### PR TITLE
[LCD4Linux] update v5.0-r8x

### DIFF
--- a/LCD4linux/src/plugin.py
+++ b/LCD4linux/src/plugin.py
@@ -33,6 +33,7 @@ from Components.Pixmap import Pixmap
 from Components.AVSwitch import AVSwitch
 from Components.Lcd import LCD
 from Components.SystemInfo import SystemInfo
+from Components.Renderer.Picon import getPiconName
 from Screens.InputBox import InputBox
 from Screens.MessageBox import MessageBox
 from Screens.InfoBar import InfoBar
@@ -12109,31 +12110,12 @@ def LCD4linuxPIC(self, session):
 					name2 = self.Lchannel_name + ".png"
 					name4 = self.Lchannel_name + ".png"
 					name3 = self.Lchannel_name2.replace('\x87', '').replace('\x86', '') + ".png"
-				# try to find fallback to picon to relating SD-station via 'lamedb5'
-				name5 = ''
-				name6 = ''
-				name7 = ''
-				if os.path.exists(LCD4enigma2 + 'lamedb5'):
-					channel_fbname = self.Lchannel_name.replace('HD', '').rstrip()
-					with open(LCD4enigma2 + 'lamedb5', 'r') as file:
-						lamedb5 = file.readlines()
-					for line in lamedb5:
-						line = line.split(',')
-						if len(line) > 1:
-							if line[1] == ('"' + channel_fbname + '"'):
-								line = line[0].split(':')
-								fields = picon.split("_", 2)
-								fields[2] = '1'
-								name5 = name5.join("_".join(fields)) + '_' + line[1].upper() + '_' + line[3].upper().lstrip('0') + '_' + line[4].lstrip('0') + '_' + line[2].upper() + '_0_0_0.png'
-								name6 = channel_fbname + '.png'
-								name7 = channel_fbname.replace(' ', '').lower() + '.png'
+					name5 = getPiconName(self.LsreftoString)
 				PIC.append(os.path.join(P2, name3))
 				PIC.append(os.path.join(P2, name2))
 				PIC.append(os.path.join(P2, name))
 				PIC.append(os.path.join(P2, name4))
 				PIC.append(os.path.join(P2, name5))
-				PIC.append(os.path.join(P2, name6))
-				PIC.append(os.path.join(P2, name7))
 				fields = picon.split("_", 3)
 				if fields[0] in ("4097", "5001", "5002", "5003"):
 					fields[0] = "1"
@@ -12145,8 +12127,6 @@ def LCD4linuxPIC(self, session):
 					PIC.append(os.path.join(P2A, name))
 					PIC.append(os.path.join(P2A, name4))
 					PIC.append(os.path.join(P2A, name5))
-					PIC.append(os.path.join(P2A, name6))
-					PIC.append(os.path.join(P2A, name7))
 					fields = picon.split("_", 3)
 					if fields[0] in ("4097", "5001", "5002", "5003"):
 						fields[0] = "1"


### PR DESCRIPTION
- extended picon-fallback! LCD4Linux will also check picon-filenames by using openATV-functionality "getPiconName()"