### PR TITLE
[Piconsupdater] fix: using SNP instead of SRP in case of internetstreams

### DIFF
--- a/PiconsUpdater/src/DownloadPicons.py
+++ b/PiconsUpdater/src/DownloadPicons.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import os
 from _collections import deque
-from . import _, printToConsole, PICON_TYPE_NAME, PICON_TYPE_KEY
+from . import _, printToConsole, getPiconsPath, getTmpLocalPicon, PICON_TYPE_NAME, PICON_TYPE_KEY
 from .DownloadJob import DownloadJob
 from .EventDispatcher import dispatchEvent
 from .DiskUtils import getCleanFileName
@@ -29,6 +30,13 @@ class DownloadPicons:
         self.queueDownloadList = deque()
 
     def downloadPicons(self):
+        for i in ['4097', '5001', '5002', '5003']:  # essential remove of obstructive Picon-filenames
+            obstructive = getTmpLocalPicon('%s_0_1_0_0_0_0_0_0_0' % i)
+            if os.path.isfile(obstructive):
+                os.remove(obstructive)
+            obstructive = getPiconsPath().getValue() + '/%s_0_1_0_0_0_0_0_0_0.png' % i
+            if os.path.isfile(obstructive):
+                os.remove(obstructive)
         self.queueDownloadList = deque()
         printToConsole('Picons to download: %d' % len(self.serviceList))
         for service in self.serviceList:
@@ -37,6 +45,8 @@ class DownloadPicons:
                 piconName = getCleanFileName(service.getServiceName())
             else:
                 piconName = channelKey
+            if any(channelKey.find(i) + 1 for i in ['4097', '5001', '5002', '5003']): # Internetstream found, therefore use SNP:
+                channelKey = piconName.replace('-','')
             if not piconName:
                 continue
             urlPng = self.piconsUrl % piconName

--- a/PiconsUpdater/src/Picon.py
+++ b/PiconsUpdater/src/Picon.py
@@ -8,7 +8,7 @@ from PIL import Image
 from .reflection import add_reflection
 from Components.config import config
 from .BouquetParser import getChannelKey
-from .DiskUtils import getFiles
+from .DiskUtils import getFiles, getCleanFileName
 from .EventDispatcher import dispatchEvent
 from .JobProgressView import JobProgressView
 from . import _, printToConsole, getPiconsPath, getTmpLocalPicon
@@ -37,6 +37,8 @@ class MergePiconJob:
         self.executionQueueList = deque()
         for service in self.serviceList:
             piconName = getChannelKey(service)
+            if any(piconName.find(i) + 1 for i in ['4097', '5001', '5002', '5003']): # Internetstream found, therefore use SNP:
+                piconName = getCleanFileName(service.getServiceName()).replace('-','')
             piconFile = getTmpLocalPicon(piconName)
             if os.path.isfile(piconFile):
                 job = MergeVO(piconFile, self.targetPicon % piconName)


### PR DESCRIPTION
In case the referencetype of servicereference contains one of these entries ["4097", "5001", "5002", "5003"], Picons of these streams will be stored with SNP-filename (e.g. "streamingsoundtracks.png") instead of the useless and obstructive SRP-filenames, e.g. "**4097_0_1_0_0_0_0_0_0_0.png**".

Therefore, this obstructive SRP-filename will be removed in following folders before downloading Picons:
- /usr/share/enigma2/picon
- /var/volatile/tmp/piconsupdater/picons-all