### PR TITLE
Update plugin.py

### DIFF
--- a/EPGTranslator/src/plugin.py
+++ b/EPGTranslator/src/plugin.py
@@ -1116,7 +1116,7 @@ def My_setEvent(self, event):
 # A playback of a recording will, and has valid getEventId() and
 # getServiceName() results.
 #
-    uref = make_uref(event.getEventId(), self.currentService.getServiceName())
+    uref = make_uref(event.getEventId(), self.serviceRef.getServiceName())
     (t_title, t_descr) = AfCache.fetch(uref)
     if t_descr == None: # Not there...
 


### PR DESCRIPTION
Openatv 7.1 crashlog opening eventviews

File "/usr/lib/enigma2/python/Plugins/Extensions/EPGTranslator/plugin.py", line 1119, in My_setEvent
AttributeError: 'EventViewEPGSelect' object has no attribute 'currentService'
[ePyObject] (PyObject_CallObject(<bound method ActionMap.action of <Components.ActionMap.HelpableActionMap object at 0xa5d31cb8>>,('EPGSelectActions', 'info')) failed)

changed

Line 1119:     uref = make_uref(event.getEventId(), self.currentService.getServiceName())
to
Line 1119:     uref = make_uref(event.getEventId(), self.serviceRef.getServiceName())