### PR TITLE
[TVSpielfilm] V6.9 tiny bugfix

### DIFF
--- a/TVSpielfilm/src/plugin.py
+++ b/TVSpielfilm/src/plugin.py
@@ -5011,7 +5011,6 @@ class TVSTipps(TVSAllScreen):
 			self.session.openWithCallback(self.returnInfo, TVSProgrammView, self.infolink, False, True)
 
 	def returnInfo(self):
-		self.show()
 		self.getNextTimer.start(5000, False)
 
 	def nextTipp(self):


### PR DESCRIPTION
- screen 'Tipp des Tages' no longer overlap other screens after pressing 'green' to go to the tip details and back to main menu.