### PR TITLE
[LCD4linux] v5.0-r18 weather display & options improved

### DIFF
--- a/LCD4linux/po/LCD4linux.pot
+++ b/LCD4linux/po/LCD4linux.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,3923 +14,4161 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
 
-
-#: plugin.py:263
-msgid "Fri"
-msgstr ""
-
-#: plugin.py:263
-msgid "Mon"
-msgstr ""
-
-#: plugin.py:263
-msgid "Sat"
-msgstr ""
-
-#: plugin.py:263
-msgid "Sun"
-msgstr ""
-
-#: plugin.py:263
-msgid "Thur"
-msgstr ""
-
-#: plugin.py:263
-msgid "Tue"
-msgstr ""
-
-#: plugin.py:263
-msgid "Wed"
-msgstr ""
-
-#: plugin.py:288
-msgid "black"
-msgstr ""
-
-#: plugin.py:288
-msgid "white"
-msgstr ""
-
-#: plugin.py:289
-msgid "gray"
-msgstr ""
-
-#: plugin.py:289
-msgid "silver"
-msgstr ""
-
-#: plugin.py:289
-msgid "slategray"
-msgstr ""
-
-#: plugin.py:290
-msgid "aquamarine"
-msgstr ""
-
-#: plugin.py:291
-msgid "gold"
-msgstr ""
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr ""
-
-#: plugin.py:291
-msgid "yellow"
-msgstr ""
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr ""
-
-#: plugin.py:292
-msgid "darkred"
-msgstr ""
-
-#: plugin.py:292
-msgid "indianred"
-msgstr ""
-
-#: plugin.py:292
-msgid "orange"
-msgstr ""
-
-#: plugin.py:292
-msgid "orangered"
-msgstr ""
-
-#: plugin.py:292
-msgid "red"
-msgstr ""
-
-#: plugin.py:292
-msgid "tomato"
-msgstr ""
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr ""
-
-#: plugin.py:293
-msgid "green"
-msgstr ""
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr ""
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr ""
-
-#: plugin.py:293
-msgid "lime"
-msgstr ""
-
-#: plugin.py:294
-msgid "blue"
-msgstr ""
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr ""
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr ""
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr ""
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr ""
-
-#: plugin.py:294
-msgid "indigo"
-msgstr ""
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr ""
-
-#: plugin.py:295
-msgid "cyan"
-msgstr ""
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr ""
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr ""
-
-#: plugin.py:295
-msgid "magenta"
-msgstr ""
-
-#: plugin.py:295
-msgid "violet"
-msgstr ""
-
-#: plugin.py:296
-msgid "brown"
-msgstr ""
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr ""
-
-#: plugin.py:296
-msgid "olive"
-msgstr ""
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr ""
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr ""
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr ""
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr ""
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr ""
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr ""
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr ""
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr ""
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr ""
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr ""
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr ""
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr ""
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr ""
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr ""
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr ""
-
-#: plugin.py:302
-msgid "2h"
-msgstr ""
-
-#: plugin.py:302
-msgid "3h"
-msgstr ""
-
-#: plugin.py:302
-msgid "3min"
-msgstr ""
-
-#: plugin.py:302
-msgid "40s"
-msgstr ""
-
-#: plugin.py:302
-msgid "4min"
-msgstr ""
-
-#: plugin.py:302
-msgid "50s"
-msgstr ""
-
-#: plugin.py:302
-msgid "5h"
-msgstr ""
-
-#: plugin.py:302
-msgid "5s"
-msgstr ""
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr ""
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr ""
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr ""
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr ""
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr ""
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr ""
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr ""
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr ""
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr ""
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr ""
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr ""
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr ""
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr ""
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr ""
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr ""
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr ""
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr ""
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr ""
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr ""
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr ""
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr ""
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr ""
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr ""
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr ""
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr ""
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr ""
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr ""
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr ""
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr ""
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr ""
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr ""
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr ""
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr ""
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr ""
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr ""
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr ""
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr ""
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr ""
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr ""
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr ""
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr ""
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr ""
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr ""
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr ""
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr ""
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr ""
-
-#: plugin.py:314
-msgid "128x32"
-msgstr ""
-
-#: plugin.py:314
-msgid "128x64"
-msgstr ""
-
-#: plugin.py:314
-msgid "132x64"
-msgstr ""
-
-#: plugin.py:314
-msgid "220x176"
-msgstr ""
-
-#: plugin.py:314
-msgid "255x64"
-msgstr ""
-
-#: plugin.py:314
-msgid "400x240"
-msgstr ""
-
-#: plugin.py:314
-msgid "480x320"
-msgstr ""
-
-#: plugin.py:314
-msgid "720x405"
-msgstr ""
-
-#: plugin.py:314
-msgid "800x480"
-msgstr ""
-
-#: plugin.py:314
-msgid "96x64"
-msgstr ""
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr ""
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr ""
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr ""
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr ""
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr ""
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr ""
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr ""
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr ""
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr ""
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr ""
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr ""
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr ""
-
-#: plugin.py:317
-msgid "All"
-msgstr ""
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr ""
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr ""
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr ""
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr ""
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr ""
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr ""
-
-#: plugin.py:320
-msgid "Bar"
-msgstr ""
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr ""
-
-#: plugin.py:320
-msgid "Knob"
-msgstr ""
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr ""
-
-#: plugin.py:321
-msgid "Analog"
-msgstr ""
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr ""
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr ""
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr ""
-
-#: plugin.py:321
-msgid "Date"
-msgstr ""
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr ""
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr ""
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr ""
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr ""
-
-#: plugin.py:321
-msgid "Time"
-msgstr ""
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr ""
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr ""
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr ""
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr ""
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr ""
-
-#: plugin.py:323
-msgid "Extended"
-msgstr ""
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr ""
-
-#: plugin.py:323
-msgid "Short"
-msgstr ""
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr ""
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr ""
-
-#: plugin.py:324
-msgid "Month"
-msgstr ""
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr ""
-
-#: plugin.py:324
-msgid "Week"
-msgstr ""
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr ""
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr ""
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr ""
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr ""
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr ""
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr ""
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr ""
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr ""
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr ""
-
-#: plugin.py:326
-msgid "Underline"
-msgstr ""
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr ""
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr ""
-
-#: plugin.py:327
-msgid "Dates"
-msgstr ""
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr ""
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr ""
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr ""
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr ""
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr ""
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr ""
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr ""
-
-#: plugin.py:329
-msgid "C"
-msgstr ""
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr ""
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr ""
-
-#: plugin.py:329
-msgid "rpm"
-msgstr ""
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr ""
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr ""
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr ""
-
-#: plugin.py:330
-msgid "db"
-msgstr ""
-
-#: plugin.py:330
-msgid "db + %"
-msgstr ""
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr ""
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr ""
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr ""
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr ""
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr ""
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr ""
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr ""
-
-#: plugin.py:332
-msgid "show run"
-msgstr ""
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr ""
-
-#: plugin.py:333
-msgid "Always All"
-msgstr ""
-
-#: plugin.py:333
-msgid "Always New"
-msgstr ""
-
-#: plugin.py:333
-msgid "Only New"
-msgstr ""
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr ""
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr ""
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr ""
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr ""
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr ""
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr ""
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr ""
-
-#: plugin.py:335
-msgid "100%"
-msgstr ""
-
-#: plugin.py:337
-msgid "1-2"
-msgstr ""
-
-#: plugin.py:337
-msgid "1-3"
-msgstr ""
-
-#: plugin.py:337
-msgid "1-4"
-msgstr ""
-
-#: plugin.py:337
-msgid "1-5"
-msgstr ""
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr ""
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr ""
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr ""
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr ""
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr ""
-
-#: plugin.py:339
-msgid "Channel"
-msgstr ""
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr ""
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr ""
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr ""
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr ""
-
-#: plugin.py:340
-msgid "same color"
-msgstr ""
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr ""
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr ""
-
-#: plugin.py:342
-msgid "vertically"
-msgstr ""
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr ""
-
-#: plugin.py:343
-msgid "4"
-msgstr ""
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr ""
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr ""
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr ""
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr ""
-
-#: plugin.py:344
-msgid "14"
-msgstr ""
-
-#: plugin.py:344
-msgid "7"
-msgstr ""
-
-#: plugin.py:344
-msgid "all"
-msgstr ""
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr ""
-
-#: plugin.py:345
-msgid "Corner"
-msgstr ""
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr ""
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr ""
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr ""
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr ""
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr ""
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr ""
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr ""
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr ""
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr ""
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr ""
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr ""
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr ""
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr ""
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr ""
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr ""
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr ""
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr ""
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr ""
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr ""
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr ""
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr ""
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr ""
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr ""
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr ""
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr ""
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr ""
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr ""
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr ""
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr ""
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr ""
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr ""
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr ""
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr ""
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr ""
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr ""
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr ""
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr ""
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr ""
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr ""
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr ""
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr ""
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr ""
-
-#: plugin.py:386
-msgid "random"
-msgstr ""
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr ""
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr ""
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr ""
-
-#: plugin.py:389
-msgid "0.5"
-msgstr ""
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr ""
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr ""
-
-#: plugin.py:392
-msgid "JPG"
-msgstr ""
-
-#: plugin.py:392
-msgid "PNG"
-msgstr ""
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr ""
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr ""
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr ""
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr ""
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr ""
-
-#: plugin.py:413
-msgid "EPG"
-msgstr ""
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr ""
-
-#: plugin.py:427
-msgid "normal"
-msgstr ""
-
-#: plugin.py:427
-msgid "reduced"
-msgstr ""
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr ""
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr ""
-
-#: plugin.py:431
-msgid "Reload"
-msgstr ""
-
-#: plugin.py:435
-msgid "1 - normal"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
 msgstr ""
 
-#: plugin.py:435
-msgid "2 - side by side"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
 msgstr ""
 
-#: plugin.py:436
-msgid "MSN"
+#: ..\WebConfigSite.py:28
+msgid "Font"
 msgstr ""
 
-#: plugin.py:436
-msgid "OpenWeatherMap"
+#: ..\WebConfigSite.py:28
+msgid "Key"
 msgstr ""
 
-#: plugin.py:436
-msgid "WeatherUnlocked"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
 msgstr ""
 
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
 msgstr ""
 
-#: plugin.py:446
-msgid "yes + %"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
 msgstr ""
 
-#: plugin.py:451
-msgid "yes, long"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
 msgstr ""
 
-#: plugin.py:451
-msgid "yes, short"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
 msgstr ""
 
-#: plugin.py:458
-msgid "km/h"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
 msgstr ""
 
-#: plugin.py:458
-msgid "m/s"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
 msgstr ""
 
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
 msgstr ""
 
-#: plugin.py:477
-msgid "Coversearch"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
 msgstr ""
 
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr ""
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr ""
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr ""
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr ""
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr ""
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr ""
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr ""
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr ""
-
-#: plugin.py:496
-msgid "Standby"
-msgstr ""
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr ""
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr ""
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr ""
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr ""
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr ""
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr ""
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr ""
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr ""
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr ""
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr ""
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr ""
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr ""
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr ""
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr ""
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr ""
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr ""
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr ""
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr ""
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr ""
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr ""
-
-#: plugin.py:618
-msgid "disabled"
-msgstr ""
-
-#: plugin.py:621
-msgid "Radio"
-msgstr ""
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr ""
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr ""
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr ""
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr ""
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr ""
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr ""
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr ""
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr ""
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr ""
-
-#: plugin.py:625
-msgid "any Key"
-msgstr ""
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr ""
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr ""
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr ""
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr ""
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr ""
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr ""
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr ""
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr ""
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr ""
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr ""
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr ""
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr ""
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr ""
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr ""
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr ""
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr ""
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr ""
-
-#: plugin.py:817
-msgid "Position"
-msgstr ""
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr ""
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr ""
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr ""
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr ""
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr ""
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr ""
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr ""
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr ""
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr ""
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr ""
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr ""
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr ""
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr ""
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr ""
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr ""
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr ""
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr ""
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr ""
-
-#: plugin.py:2639
-msgid "E"
-msgstr ""
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr ""
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr ""
-
-#: plugin.py:2639
-msgid "N"
-msgstr ""
-
-#: plugin.py:2639
-msgid "NE"
-msgstr ""
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr ""
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr ""
-
-#: plugin.py:2639
-msgid "NW"
-msgstr ""
-
-#: plugin.py:2639
-msgid "S"
-msgstr ""
-
-#: plugin.py:2639
-msgid "SE"
-msgstr ""
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr ""
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr ""
-
-#: plugin.py:2639
-msgid "SW"
-msgstr ""
-
-#: plugin.py:2639
-msgid "W"
-msgstr ""
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr ""
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr ""
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr ""
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr ""
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr ""
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr ""
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr ""
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr ""
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr ""
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr ""
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr ""
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr ""
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr ""
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr ""
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr ""
-
-#: plugin.py:5545
-msgid "Save"
-msgstr ""
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr ""
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr ""
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr ""
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr ""
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr ""
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr ""
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr ""
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr ""
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr ""
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr ""
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr ""
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr ""
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr ""
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr ""
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr ""
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr ""
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr ""
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr ""
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr ""
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr ""
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr ""
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr ""
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr ""
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr ""
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr ""
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr ""
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr ""
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr ""
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr ""
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr ""
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr ""
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr ""
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr ""
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr ""
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr ""
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr ""
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr ""
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr ""
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr ""
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr ""
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr ""
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr ""
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr ""
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr ""
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr ""
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr ""
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr ""
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr ""
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr ""
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr ""
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr ""
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr ""
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr ""
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr ""
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr ""
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr ""
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr ""
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr ""
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr ""
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr ""
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr ""
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr ""
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr ""
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr ""
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr ""
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr ""
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr ""
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr ""
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr ""
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr ""
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr ""
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr ""
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr ""
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr ""
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr ""
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr ""
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr ""
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr ""
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr ""
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr ""
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr ""
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr ""
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr ""
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr ""
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr ""
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr ""
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr ""
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr ""
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr ""
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr ""
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr ""
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr ""
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr ""
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr ""
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr ""
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr ""
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr ""
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr ""
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr ""
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr ""
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr ""
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr ""
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr ""
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr ""
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr ""
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr ""
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr ""
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr ""
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr ""
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr ""
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr ""
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr ""
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr ""
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr ""
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr ""
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr ""
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr ""
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr ""
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr ""
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr ""
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr ""
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr ""
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr ""
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr ""
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr ""
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr ""
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr ""
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr ""
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr ""
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr ""
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr ""
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr ""
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr ""
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr ""
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr ""
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr ""
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr ""
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr ""
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr ""
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr ""
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr ""
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr ""
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr ""
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr ""
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr ""
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr ""
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr ""
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr ""
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr ""
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr ""
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr ""
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr ""
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr ""
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr ""
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr ""
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr ""
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr ""
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr ""
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr ""
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr ""
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr ""
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr ""
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr ""
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr ""
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr ""
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr ""
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr ""
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr ""
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr ""
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr ""
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr ""
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr ""
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr ""
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr ""
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr ""
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr ""
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr ""
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr ""
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr ""
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr ""
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr ""
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr ""
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr ""
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr ""
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr ""
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr ""
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr ""
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr ""
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr ""
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr ""
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr ""
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr ""
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr ""
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr ""
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr ""
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr ""
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr ""
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr ""
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr ""
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr ""
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr ""
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr ""
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr ""
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr ""
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr ""
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr ""
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr ""
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr ""
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr ""
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr ""
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr ""
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr ""
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr ""
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr ""
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr ""
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr ""
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr ""
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr ""
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr ""
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr ""
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr ""
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr ""
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr ""
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr ""
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr ""
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr ""
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr ""
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr ""
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr ""
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr ""
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr ""
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr ""
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr ""
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr ""
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr ""
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr ""
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr ""
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr ""
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr ""
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr ""
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr ""
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr ""
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr ""
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr ""
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr ""
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr ""
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr ""
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr ""
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr ""
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr ""
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr ""
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr ""
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr ""
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr ""
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr ""
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr ""
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr ""
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr ""
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr ""
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr ""
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr ""
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr ""
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr ""
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr ""
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr ""
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr ""
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr ""
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr ""
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr ""
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr ""
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr ""
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr ""
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr ""
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr ""
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr ""
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr ""
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr ""
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr ""
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr ""
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr ""
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr ""
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr ""
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr ""
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr ""
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr ""
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr ""
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr ""
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr ""
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr ""
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896
+#: ..\plugin.py:7404
 msgid "Weather"
 msgstr ""
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr ""
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr ""
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr ""
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr ""
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927
+#: ..\plugin.py:7435
 msgid "Netatmo"
 msgstr ""
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr ""
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr ""
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr ""
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr ""
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr ""
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr ""
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr ""
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr ""
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr ""
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr ""
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr ""
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr ""
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr ""
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr ""
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr ""
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr ""
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr ""
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr ""
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr ""
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr ""
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr ""
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr ""
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr ""
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr ""
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr ""
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr ""
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr ""
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr ""
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr ""
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr ""
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr ""
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr ""
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr ""
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr ""
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr ""
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr ""
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr ""
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr ""
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr ""
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr ""
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr ""
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086
+#: ..\plugin.py:7632
 msgid "Mail"
 msgstr ""
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr ""
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr ""
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr ""
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101
+#: ..\plugin.py:7647
 msgid "Remote Box"
 msgstr ""
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr ""
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129
+#: ..\plugin.py:7675
 msgid "FritzCall"
 msgstr ""
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr ""
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr ""
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr ""
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143
+#: ..\plugin.py:7689
 msgid "Calendar"
 msgstr ""
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr ""
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr ""
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr ""
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr ""
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr ""
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr ""
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr ""
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr ""
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr ""
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr ""
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr ""
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr ""
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr ""
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr ""
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498
+#: ..\plugin.py:5641 ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr ""
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489
+#: ..\plugin.py:5883 ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr ""
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr ""
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr ""
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr ""
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr ""
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr ""
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr ""
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr ""
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr ""
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr ""
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr ""
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr ""
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr ""
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr ""
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr ""
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr ""
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr ""
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr ""
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr ""
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr ""
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr ""
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr ""
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr ""
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr ""
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr ""
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr ""
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr ""
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr ""
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr ""
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr ""
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr ""
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr ""
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr ""
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr ""
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr ""
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr ""
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr ""
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr ""
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr ""
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr ""
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr ""
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr ""
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr ""
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr ""
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr ""
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr ""
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr ""
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr ""
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr ""
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr ""
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr ""
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr ""
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr ""
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr ""
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr ""
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr ""
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr ""
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr ""
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr ""
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr ""
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr ""
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr ""
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr ""
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr ""
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr ""
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr ""
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr ""
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr ""
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr ""
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr ""
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr ""
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr ""
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr ""
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr ""
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr ""
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr ""
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr ""
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr ""
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr ""
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr ""
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr ""
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr ""
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr ""
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr ""
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr ""
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr ""
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr ""
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr ""
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr ""
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr ""
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr ""
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr ""
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr ""
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr ""
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr ""
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr ""
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr ""
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr ""
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr ""
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr ""
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr ""
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr ""
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr ""
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr ""
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr ""
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr ""
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr ""
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr ""
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr ""
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr ""
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr ""
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr ""
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr ""
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr ""
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr ""
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr ""
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr ""
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr ""
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr ""
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr ""
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr ""
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr ""
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr ""
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr ""
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr ""
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr ""
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr ""
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr ""
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr ""
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr ""
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr ""
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr ""
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr ""
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr ""
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr ""
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr ""
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr ""
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr ""
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr ""
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr ""
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr ""
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr ""
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr ""
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr ""
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr ""
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr ""
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr ""
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr ""
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr ""
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr ""
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr ""
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr ""
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr ""
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr ""
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr ""
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr ""
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr ""
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr ""
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr ""
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr ""
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr ""
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr ""
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr ""
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr ""
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr ""
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr ""
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr ""
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr ""
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr ""
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr ""
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr ""
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr ""
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr ""
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr ""
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr ""
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr ""
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr ""
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr ""
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr ""
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr ""
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr ""
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr ""
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr ""
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr ""
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr ""
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr ""
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr ""
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr ""
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr ""
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr ""
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr ""
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr ""
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr ""
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr ""
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr ""
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr ""
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr ""
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr ""
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr ""
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr ""
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr ""
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr ""
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr ""
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr ""
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr ""
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr ""
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr ""
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr ""
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr ""
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr ""
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr ""
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr ""
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr ""
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr ""
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr ""
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr ""
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr ""
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr ""
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr ""
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr ""
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr ""
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr ""
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr ""
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr ""
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr ""
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr ""
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr ""
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr ""
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr ""
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr ""
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr ""
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr ""
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr ""
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr ""
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr ""
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr ""
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr ""
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr ""
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr ""
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr ""
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr ""
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr ""
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr ""
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr ""
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr ""
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr ""
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr ""
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr ""
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr ""
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr ""
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr ""
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr ""
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr ""
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr ""
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr ""
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr ""
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr ""
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr ""
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr ""
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr ""
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr ""
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr ""
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr ""
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr ""
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr ""
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr ""
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr ""
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr ""
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr ""
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr ""
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr ""
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr ""
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr ""
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr ""
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr ""
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr ""
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr ""
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr ""
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr ""
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr ""
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr ""
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr ""
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr ""
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr ""
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr ""
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr ""
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr ""
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr ""
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr ""
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr ""
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr ""
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr ""
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr ""
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr ""
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr ""
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr ""
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr ""
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr ""
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr ""
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr ""
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr ""
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr ""
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr ""
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr ""
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr ""
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr ""
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr ""
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr ""
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr ""
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr ""
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr ""
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr ""
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr ""
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr ""
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr ""
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr ""
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr ""
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr ""
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr ""
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr ""
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr ""
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr ""
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr ""
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr ""
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr ""
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr ""
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr ""
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr ""
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr ""
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr ""
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr ""
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr ""
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr ""
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr ""
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr ""
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr ""
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr ""
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr ""
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr ""
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr ""
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr ""
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr ""
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr ""
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr ""
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr ""
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr ""
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr ""
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr ""
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr ""
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr ""
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr ""
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr ""
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr ""
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr ""
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr ""
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr ""
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr ""
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr ""
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr ""
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr ""
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr ""
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr ""
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr ""
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr ""
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr ""
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr ""
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr ""
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr ""
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr ""
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr ""
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr ""
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr ""
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr ""
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr ""
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr ""
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr ""
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr ""
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr ""
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr ""
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr ""
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr ""
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr ""
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr ""
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr ""
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr ""
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr ""
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr ""
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr ""
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr ""
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr ""
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr ""
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr ""
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr ""
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr ""
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr ""
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr ""
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr ""
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr ""
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr ""
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr ""
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr ""
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr ""
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr ""
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr ""
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr ""
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr ""
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr ""
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr ""
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr ""
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr ""
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr ""
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr ""
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr ""
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr ""
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr ""
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr ""
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr ""
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr ""
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr ""
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr ""
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr ""
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr ""
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr ""
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr ""
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr ""
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr ""
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr ""
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr ""
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr ""
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr ""
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr ""
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr ""
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr ""
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr ""
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr ""
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr ""
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr ""
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr ""
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr ""
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr ""
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr ""
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr ""
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr ""
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr ""
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr ""
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr ""
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr ""
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr ""
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr ""
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr ""
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr ""
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr ""
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr ""
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr ""
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr ""
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr ""
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr ""
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr ""
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr ""
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr ""
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr ""
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr ""
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr ""
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr ""
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr ""
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr ""
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr ""
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr ""
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr ""
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr ""
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr ""
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr ""
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr ""
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr ""
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr ""
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr ""
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr ""
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr ""
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr ""
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr ""
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr ""
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr ""
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr ""
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr ""
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr ""
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr ""
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr ""
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr ""
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr ""
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr ""
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr ""
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr ""
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr ""
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr ""
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr ""
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr ""
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr ""
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr ""
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr ""
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr ""
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr ""
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr ""
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr ""
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr ""
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr ""
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr ""
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr ""
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr ""
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr ""
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr ""
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr ""
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr ""
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr ""
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr ""
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr ""
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr ""
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr ""
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr ""
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr ""
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr ""
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr ""
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr ""
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr ""
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr ""
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr ""
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr ""
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr ""
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr ""
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr ""
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr ""
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr ""
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr ""
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr ""
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr ""
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr ""
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr ""
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr ""
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr ""
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr ""
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr ""
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr ""
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr ""
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr ""
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr ""
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr ""
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr ""
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr ""
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr ""
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr ""
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr ""
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr ""
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr ""
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr ""
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr ""
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr ""
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr ""
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr ""
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr ""
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr ""
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr ""
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr ""
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr ""
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr ""
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr ""
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr ""
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr ""
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr ""
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr ""
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr ""
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr ""
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr ""
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr ""
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr ""
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr ""
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr ""
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr ""
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr ""
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr ""
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr ""
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr ""
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr ""
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr ""
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr ""
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr ""
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr ""
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr ""
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr ""
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr ""
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr ""
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr ""
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr ""
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr ""
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr ""
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr ""
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr ""
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr ""
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr ""
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr ""
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr ""
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr ""
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr ""
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr ""
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr ""
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr ""
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr ""
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr ""
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr ""
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr ""
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr ""
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr ""
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr ""
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr ""
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr ""
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr ""
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr ""
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr ""
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr ""
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr ""
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr ""
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr ""
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr ""
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr ""
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr ""
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr ""
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr ""
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr ""
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr ""
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr ""
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr ""
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr ""
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr ""
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr ""
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr ""
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr ""
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr ""
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr ""
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr ""
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr ""
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr ""
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr ""
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr ""
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr ""
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr ""
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr ""
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr ""
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr ""
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr ""
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr ""
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr ""
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr ""
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr ""
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr ""
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr ""
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr ""
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr ""
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr ""
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr ""
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr ""
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr ""
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr ""
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr ""
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr ""
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr ""
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr ""
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr ""
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr ""
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr ""
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr ""
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr ""
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr ""
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 msgstr ""
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr ""
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr ""
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr ""
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr ""
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr ""
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr ""
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr ""
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr ""
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr ""
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr ""
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr ""
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr ""
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr ""
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr ""
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr ""
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr ""
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr ""
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr ""
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr ""
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr ""
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr ""
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr ""
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr ""

--- a/LCD4linux/po/cs.po
+++ b/LCD4linux/po/cs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD 4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 17:59+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:57+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: none\n"
 "Language: cs\n"
@@ -11,3831 +11,4064 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Pá"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Po"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "So"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Druh písma"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Ne"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Klíč"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Čt"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Út"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "St"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Obrázek"
 
-#: plugin.py:288
-msgid "black"
-msgstr "černá"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Vyskakovací text"
 
-#: plugin.py:288
-msgid "white"
-msgstr "bílá"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "šedá"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Tuner"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "stříbrná"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW Konvertor"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "břidlicově šedá"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "aquamarine"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Obrazovka"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "zlatá"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "zelenožlutá"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "žlutá"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "tmavě ooranžová"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "tmavě červená"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indiánská červená"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "oranžová"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "oranžově červená"
-
-#: plugin.py:292
-msgid "red"
-msgstr "červená"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "rajčatová"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "tmavě zelená"
-
-#: plugin.py:293
-msgid "green"
-msgstr "zelená"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "zelený trávník"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "svetlejší zelená"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "limetka"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "modrá"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "modrofialová"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "kadetská modrá"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "chrpa modrá"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "tmavě modrá"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "světlejší modrá"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "světle modrá"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "tmavá orchidej"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "tmavě růžová"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "purpurová"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "fialová"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "hnědá"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "mokasín"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olivová"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "růžově hnědá"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "pískově hnědá"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Obrazovka 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Obrazovka 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Obrazovka 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Obrazovka 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Obrazovka 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Obrazovka 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Obrazovka 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Obrazovka 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Obrazovka 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Obrazovka 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Obrazovka 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Obrazovka 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Obrazovka 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Obrazovka 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Obrazovka 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Obrazovka 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Obrazovka 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Obrazovka 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Obrazovka 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Obrazovka 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Obrazovka 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Obrazovka 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Obrazovka 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Obrazovka 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Obrazovka 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Obrazovka 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Obrazovka 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Obrazovka 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Obrazovka 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "vypnuto"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Obrazovka 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Obrazovka 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Obrazovka 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "zapnuto"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (nebo kompaktibilní LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (nebo kompaktibilní LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (nebo kompaktibilní LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (nebo kompaktibilní LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Zabudovaný TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Zabudovaný box-skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "jen obrázek 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "jen obrázek 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "jen obrázek 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "jen obrázek 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "jen obrázek vlastní velikosti"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "jen obrázek vlastní velikosti 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Zabudovaný Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 dny 1 řádek"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 dny 2 řádky"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 dny 1 řádek"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 dny 2 řádky"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 dny svislý pohled"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 dnů 1 řádek"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 dnů 2 řádky"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 svislý pohled na dny"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Aktuální teplota (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Aktuální teplota (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Aktuální"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Aktuální teplota"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Vše"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Teplota"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Teplota+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Teplota+Co2+Tlak"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Teplota+Vlhkost"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Modul 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Modul 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Modul 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Modul 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Modul 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Modul 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Modul 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Modul 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Modul 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Modul 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Modul 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Modul 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Modul 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Module 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Modul 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Modul 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Module 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Module 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Modul 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Modul 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Modul 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Modul 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Modul 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "definováno uživatelem"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Sloupec"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Sloupec+hodnota"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Knoflík"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Knoflík+hodnota"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analogové"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analogové + datum"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analogové + datum + všední den"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analogové + datum + všední den 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Datum"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Datum+ čas"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Datum+čas+Všední den"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Datum prvních kapek"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Návrh kapek pro všední den"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Čas"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Čas+Všední den"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Všední den"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "vycentorovat"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "levý"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "v pravo"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Rozšířený"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Rozšířený (méně info.)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Krátký"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Krátký (rozšířený)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Krátký +rozšířený"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Měsíc"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Měsíc+hlavička"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Týden"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Týden+Hlavička"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "žádný kalendář"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Datumy 1 řádek"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Datumy 3 řádek"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Datumy 5 řádek"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Datumy 9 řádek"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Kompaktní datumy 2 řádky"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Kompaktní datumy 3 řádky"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "žádné termíny"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Podtrhnutí"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Podtrhnutí 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Rámeček"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Datumy"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Kompaktní datumy"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Kompaktní datumy bez ikon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Datumy bez ikony"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "žádná ikona"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "žádná ikona, s cílovým číslem"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "s ikonou"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "s ikonou & cílovým číslem"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + otáčky"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + otáčky/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "otáčky"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "otáčky/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "ne"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "zobrazit aktivní"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "zobrazit aktivní+čekající"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Vždy vše"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Vždy nové"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "jen nové"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Všechny informace"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "jen vzdálenost"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Vzdálenost + osvětlení"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Vzdálenost + fáze měsíce"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "jen osvětlení"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Osvětlení+Fáze měsíce"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "jen měsíční fáze"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Kanál"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Kanál + titulek"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+kanál"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+kanál+název"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "stejná barva"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "ano 25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "ano"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "svisle"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "vodorovně"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Celkový"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "vše"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Roh"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Roh + časový posun"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Časový posun"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "jen ukazatel průběhu"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "a zbývající minuty"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "a zbývající minuty (velikost 1,5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "a zbývající minuty (velikost 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "s procenty minut"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "s procenty (velikost 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "s procenty (velikost 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "a zbývající minuty (nad)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "a zbývající minuty (nad / velikost 1,5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "a zbývající minuty (nad / velikost 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "s procenty (nad)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "s procenty (nad/velikost 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "s procenty (nad/velikost 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "a zbývající minuty (pod)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "a zbývající minuty (pod /velikost 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "a zbývající minuty (pod /velikost 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "s procenty (pod)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "s procenty (pod/velikost 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "s procenty (pod/velikost 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "s aktuálním 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "s aktuálním 00:00 (Size 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "s aktuálním 00:00 (Size 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "s aktuálním 00:00 (nad)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "s aktuálním 00:00 (nad /velikost 1,5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "s aktuálním 00:00 (nad /velikost 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "s aktuálním 00:00 (pod)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "s aktuálním 00:00 (pod/velikost 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "s aktuálním 00:00 (pod/velikost 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "s procenty minut / Celkově (nad)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "s procenty minut / Celkově (nad/velikost 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "s procenty minut / Celkově (nad/velikost 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "s absolutním časem ukončení"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "s absolutním časem ukončení (velikost 1,2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "s absolutním časem ukončení (velikost 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "s minutami celkem / čas ukončení (nad)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "s minutami celkem / čas ukončení (nad/velikost1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "s minutami celkem / čas ukončení (nad/velikost 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Rychlý mód (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normální (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "abecedně"
-
-#: plugin.py:386
-msgid "random"
-msgstr "náhodně"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "better/slow"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "pomalu/rychle (jen obrázek)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "pomalu/rychle (vše)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + nastavení (vysoká kvalita, pomale)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + nastavení (nízká kvalita, rychle)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "bez cache + bez nastavování"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Zabudovaný tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Teď/Další"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normálně"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "redukované"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Neobnovit JavaScript"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Znovu načíst"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normalně"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - bok po boku"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "Otevřít mapu počasí"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternativní Mod kopírování-Mode/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "ano + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "ano, dlouhé"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "ano, krátké"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Hledat obal"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "vždy"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "Zapnuté+Media+Pohotovostní režim"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Pohotovostní režim"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "Zapnuté"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - barva"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - černobílá /barva"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x Tlačítko rychle vpřed"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x Tlačítko rychle vpřed Typ 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Dlouhé tlačítko rychle dopředu"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Dlouhé tlačítko rychle dopředu Typ 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Info tlačítko"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x ztlumit zvuk"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Dlouhé tlačítko info"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x Rychle zpět tlačítko"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x Rychle zpět tlačítkoTyp 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Dlouhé tlčítko rychle nazpět"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Dlouhé tlčítko rychle nazpět Typ 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "ao, rozšířené"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Běžná konzole"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Rozsáhlý log soubor"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Normální log soubor"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "zakázáno"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Rádio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Rádio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Rádio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (plný)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normální (plný)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "zdobené (černé)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "zdobené (průhledné)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "ZTLUM nebo definuj klíče"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "libovolné tlačítko"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Čas+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Čas+Trvání+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Čas+Délka+info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "polovina vlevo"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "polovina vpravo"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Rámeček x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Řádek"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "zádný bar"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "žádný rámeček"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Spád"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Hrany stínu"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normální"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Pozice pod"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Pozice vlevo"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Pozice vpravo"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Umístění"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Jméno"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Vypnuté"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Aktivní"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Aktivní+Neaktivní"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "jen použitý časovač"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "použít čas dodání"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "žádný celkový časovač"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "zobrazit celkový časovač"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "jeden řádek"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "dva řádky"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Dostupná paměť"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Volná paměť"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "na celou obrazovku"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "ano kromě nahrávek"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "V"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "VSV"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "VJV"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "SV"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "SSV"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "SSZ"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "SZ"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "J"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "JV"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "JJV"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "JJZ"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "JZ"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "Z"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "ZSZ"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "ZJZ"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Nahrej aktivní konfig. soubor"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Načíst výchozí hodnoty / prázdná konfigurace"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Ulož Config do souboru... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Nahrej soubor: %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Zmazat soubor?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "smazáno"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "aktuální nastavení: %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux Nastavení"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Režim"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Uložit"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Restart displejů"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Do nastavení >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Nečinný"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "žádný LCD1 obrazový soubor"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "žádný LCD2 obrazový soubor"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "žádný LCD3 obrazový soubor"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux povolený"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Typ"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 otočit"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 barva pozadí"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 obrázek pozadí [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 jas"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 noční mód"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 obnova"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Typ"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 otočit"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 barva pozadí"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 obrázek pozadí [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 jas"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 noční mód"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 obnova"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Typ"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 otočit"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 barva pozadí"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 obrázek pozadí [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 jas"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Noční mód"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 obnova"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD rozměry"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Offset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD barva"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD Povolit zapnutý mód"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD povolit media mód"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD povolit čekací mód"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [čas zobrazení]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- které LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Ukázat v módě"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Velikost OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Pozadí/Průhlednost"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Rychlý snímek nízké kvality"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Vyskakovací text"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Vymazat klíč"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Velikost písma"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Pozice"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Zarovnání"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Barva"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Barva pozadí"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Písmo"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Aktivní obrazovka"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Výběr přepínače obrazovky - obrazovka"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Výběr přepínače obrazovky - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Obrazovky používané ke změně"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Obrazovka 1 čas změny"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Čas změny obrazovky 2"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Čas změny obrazovky 3"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Čas změny obrazovky 4"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Čas změny obrazovky 5"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Čas změny obrazovky 6"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Čas změny obrazovky 7"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Čas změny obrazovky 8"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Čas změny obrazovky 9"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Obrázek čas změny"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Seřazení obrázků"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Obrázek rekurzivní složka"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Kvalita obrazu pro změnu velikosti"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Obrázek čas rychlé aktualizace [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Typ obrázku [jen obrázek]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Typ obrázku pozadí"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Počasí výběr poskytovatele"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Počasí API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Počasí API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Počasí Město"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Počasí Město 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Počasí- Ikona- Cesta [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Počasí- Ikona zvětšení"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Počasí barva nízké (-) teploty"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Počasí barva vysoké (+) teploty"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Počasí průhlednost"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Počasí jednotka rychlosti větru"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Počasí směr a rychlost větru"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Počasí možnost deště"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Zvětšení deště"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Barva deště"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Déšť používá barvu 2 z"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Barva deště 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Počasí linky"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Počasí sípky trendov"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Počasí rozšířené info"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra zvětšení"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Zobrazit teplotu ochlazení jeli rozdíl"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extra barva města"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extra barva ochlazení"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Min rozsah"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Max rozsah"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "URL počasí"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Měsíc - cesta k ikoně [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Obrázek záznamu [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Změna dvoj-stlačením tlačítka"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Klíč pro změnu obrazovky"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Tlačítko pro zapnutí/vypnutí obrazovky"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall acesta k obrázkům [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Počet řádků na vstupní údaj"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall počet položek seznamu"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall počet obrázků"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall orientace obrázku"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall průhlednost obrázku"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall vyhledávání obrazku"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall odstranit hovory po hodinách"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall čas vyskakovacího okna"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall vyskakovací LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall barva vyskakovacího okna"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall rámeček obrázku [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Kalendář - ics-cesta [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Kalendař - ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Kalendář - plánovač"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Kalendář - barva soboty"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Kalendář - barva neděle"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Kalendář - tloušťka čáry"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Kalendář - denní přehled"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Kalendář - oprava časové zóny"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Kalendář - průsvitnost"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Kalendář - čas obnovy"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Tuner Barva"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Tuner Barva aktivní"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Tuner Barva zapnuto"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Nejdřív prohledat kanál"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T korekce kvality signálu"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Druh písma celkově [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Druh písma 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Druh písma 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Druh písma 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Druh písma 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Druh písma 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 připojení"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Zobrazené jméno:]Uživatelské jméno"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 heslo"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 připojení"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Zobrazené jméno:]Uživatelské jméno"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 heslo"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 připojení"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Zobrazené jméno:]Uživatelské jméno"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 heslo"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 připojení"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Zobrazené jméno:]Uživatelské jméno"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 heslo"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 připojení"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Zobrazené jméno:]Uživatelské jméno"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 heslo"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Pošta obnovovací interval"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Pošta IMAP limit na posledné dny"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail Zobrazit prázdné schránky"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Pošta ukaž datum"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Pošta skrýt adresu"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Vzdálený Box 1 [Zobrazované jméno:]IP/Jméno"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Vzdálený Box 2 [Zobrazované jméno:]IP/Jméno"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Vzdálený Box 3 [Zobrazované jméno:]IP/Jméno"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Vzdálený Box 4 [Zobrazované jméno:]IP/Jméno"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Vzdálený Box 5 [Zobrazované jméno:]IP/Jméno"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "RVzdálený Box obnova v minutách"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Vzdálený Box 1 [Zobrazované jméno:]IP/Jméno"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Vzdálený Box obnova v minutách"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Konvertor časové obnovy"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "Použiť WWW konvertor"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey from cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey from convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF aktualizace [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF Typ aktualizace"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF Inicializace zpoždění"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP povol"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP zakaž"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF vzhled"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Uložit jako obrázek pro WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 povolit"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 Port"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 Virtuální jas"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 povolit"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 Port"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 Virtuální jas"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 povolit"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 Port"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 Virtuální jas"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG Cyklus"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Při chybě restartujte"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG Režim záhlaví"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos časový limit ping [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Přehrát šek"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Obnovit [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Časový limit ping [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "Kontrola přehrávání BlueSound"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Obnovit [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [volitelný]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Časový limit ping [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Kontrola přehrávání"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Obnovit [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Obal"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD volitelná šířka"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD volitelná výška"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD volitelná šířka 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD volitelná výška 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD Vypnuto při vypnutí"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Časování ! výpočet všech časů na Čas/5*2 v rychlém módě"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Zpoždění displeje [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Návrhy na LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Zobrazit Chybové hlášení"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Zobrazit 'žádné ....' Hlášení"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Úložná zařízení: Vynutit čtení"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Úložná zařízení: Barva zpět"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Úložná zařízení: Barevná lišta"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Úložná zařízení: Barva plná"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Kontrola sítě aktivní"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Přepnout FrameBuffer [pokud je to možné]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Záloha nastavení [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Obnova všeho nastavení"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Logování > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Podsvícení Off [Zakázat nastavení Off = On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Podsvícení zapnout"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Podsvícení víkend [Zakázat nastavení Off = On]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Podsvícení přes víkend zapnout"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD automatické vypnutí"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Pozadí"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Obrázek [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon Size"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Rozdělená obrazovka"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Celá obrazovka"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Velikost textu"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Průhlednost"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon cesta [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon cesta 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache cesta [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Hodiny"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Typ"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analogové Hodiny"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Vzdálenost"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Velikost"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Hrany stínu"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Hodiny 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Název kanálu"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- maximum řádků"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Délka"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Číslo kanálu"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Info o programu"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Typ"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Info o programu 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Info o dalším programu"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Rozšířený popis"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- prázdné použijte informace"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Ukazatel průběhu"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Barevný Text"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Okraj"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Stínované"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Jednotka min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informace"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Informace o tuneru"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Snímače"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informace 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Lišta kvality signálu"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Spád"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Rozsah sloupce kvality signálu na Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Rozsah sloupce kvality signálu na Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satelit"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Poskytovatel"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Použitý tuner"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- jen aktivní tuner"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Další časovač udalosti"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Hlasitost"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Ztlumit zvuk"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Stav sítě [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Zobrazit stav"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Časový limit [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Síťové jméno: Adresa"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Externí IP adresa"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- externí IP adresa"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Paměťové - zařízení"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- bez varování"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- další informace"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Jméno zařízení"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Počasí"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zvětšení"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Typ počasí"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Počasí 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteorologická stanice"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Stanice"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Modul"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Modul definovaný uživatelem"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Základ"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Jméno"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Barva 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Barva 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Barva 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Barva 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Barva 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Barva 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Indikátor"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Délka [Bar]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Konforktní indikátor"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Fáze měsíce"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Informační linky"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Šípky trendov"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Východ slunce"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Zobraz oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Soubor [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Zobraz ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Zobraz textový soubor"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Zobraz textový soubor 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Zobraz textový soubor 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Zobraz HTTP Text"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "Konvertor web. stránek"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP šířka"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP výška"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Vystřiženo z X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Vystřiženo z Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Zmenšit šířku [zakázat = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Výška střihu [deaktivovat = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Zobraz obrázek"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Soubor nebo cesta [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Maximální Výška"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Rychlá aktualizace"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Zobraz obrázek 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Zobraz obrázek 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Zobraz obrázek 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Pošta"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Řádky"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- e-mailové konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- maximální šířka"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Vzdálený Box"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Vzdálený Box"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Velikost obrázku"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Pozice obrázku"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Zarovnání obrázku"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Kalendář"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP povol"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Žádný a nebo nesprávný soubor, skus nejdříve správný soubor !"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Režim"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Zabezpečení IP není podporováno Boxem"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Chybový výpis"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Zobrazit"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Zmazat"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Název souboru"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Obnova Configu"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Záloha Configu"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Zmazání log souboru"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Stáhnout log soubor"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Ulož Config"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "zastav výměnu obrazovek"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Celkový"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "Zapnuté"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Nečinný"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "Je vyžadován restart GUI"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Nastavení"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "jiné"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "aktivuj nastavení"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "zkopírovat do aktivních"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "zkopírovat do Média"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "zkopírovat do pohotovostních"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Vykonat"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Zobraz venkovní"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Seznam úložných zařízení"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Nadřazený adresář"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Pá"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Po"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "So"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Ne"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Čt"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Út"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "St"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "černá"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "bílá"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "šedá"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "stříbrná"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "břidlicově šedá"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "aquamarine"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "zlatá"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "zelenožlutá"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "žlutá"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "tmavě ooranžová"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "tmavě červená"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indiánská červená"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "oranžová"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "oranžově červená"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "červená"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "rajčatová"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "tmavě zelená"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "zelená"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "zelený trávník"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "svetlejší zelená"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "limetka"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "modrá"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "modrofialová"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "kadetská modrá"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "chrpa modrá"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "tmavě modrá"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "světlejší modrá"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "světle modrá"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "tmavá orchidej"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "tmavě růžová"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "purpurová"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "fialová"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "hnědá"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "mokasín"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olivová"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "růžově hnědá"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "pískově hnědá"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Obrazovka 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Obrazovka 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Obrazovka 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Obrazovka 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Obrazovka 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Obrazovka 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Obrazovka 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Obrazovka 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Obrazovka 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Obrazovka 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Obrazovka 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Obrazovka 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Obrazovka 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Obrazovka 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Obrazovka 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Obrazovka 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Obrazovka 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Obrazovka 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Obrazovka 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Obrazovka 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Obrazovka 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Obrazovka 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Obrazovka 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Obrazovka 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Obrazovka 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Obrazovka 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Obrazovka 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Obrazovka 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Obrazovka 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "vypnuto"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Obrazovka 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Obrazovka 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Obrazovka 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "zapnuto"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (nebo kompaktibilní LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (nebo kompaktibilní LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (nebo kompaktibilní LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (nebo kompatibilní LCD) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Zabudovaný box-skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Zabudovaný TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "jen obrázek 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "jen obrázek 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "jen obrázek 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "jen obrázek 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "jen obrázek vlastní velikosti"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "jen obrázek vlastní velikosti 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Zabudovaný Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 dny 1 řádek"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 dny 2 řádky"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 dny 1 řádek"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 dny 2 řádky"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 dny svislý pohled"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 dnů 1 řádek"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 dnů 2 řádky"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 svislý pohled na dny"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Aktuální teplota (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Aktuální teplota (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Aktuální"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Aktuální teplota"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Vše"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Teplota"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Teplota+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Teplota+Co2+Tlak"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Teplota+Vlhkost"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Modul 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Modul 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Modul 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Modul 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Modul 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Modul 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Modul 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Modul 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Modul 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Modul 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Modul 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Modul 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Modul 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Module 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Modul 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Modul 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Module 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Module 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Modul 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Modul 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Modul 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Modul 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Modul 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "definováno uživatelem"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Sloupec"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Sloupec+hodnota"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Knoflík"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Knoflík+hodnota"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analogové"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analogové + datum"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analogové + datum + všední den"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analogové + datum + všední den 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Datum"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Datum+ čas"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Datum+čas+Všední den"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Datum prvních kapek"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Návrh kapek pro všední den"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Čas"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Čas+Všední den"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Všední den"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "vycentorovat"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "levý"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "v pravo"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Rozšířený"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Rozšířený (méně info.)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Krátký"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Krátký (rozšířený)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Krátký +rozšířený"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Měsíc"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Měsíc+hlavička"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Týden"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Týden+Hlavička"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "žádný kalendář"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Datumy 1 řádek"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Datumy 3 řádek"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Datumy 5 řádek"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Datumy 9 řádek"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Kompaktní datumy 2 řádky"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Kompaktní datumy 3 řádky"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "žádné termíny"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Podtrhnutí"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Podtrhnutí 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Rámeček"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Datumy"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Kompaktní datumy"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Kompaktní datumy bez ikon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Datumy bez ikony"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "žádná ikona"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "žádná ikona, s cílovým číslem"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "s ikonou"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "s ikonou & cílovým číslem"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + otáčky"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + otáčky/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "otáčky"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "otáčky/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "ne"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "zobrazit aktivní"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "zobrazit aktivní+čekající"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Vždy vše"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Vždy nové"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "jen nové"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Všechny informace"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "jen vzdálenost"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Vzdálenost + osvětlení"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Vzdálenost + fáze měsíce"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "jen osvětlení"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Osvětlení+Fáze měsíce"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "jen měsíční fáze"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Kanál"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Kanál + titulek"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+kanál"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+kanál+název"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "stejná barva"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "ano 25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "ano"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "svisle"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "vodorovně"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "vše"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Roh"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Roh + časový posun"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Časový posun"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "jen ukazatel průběhu"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "a zbývající minuty"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "a zbývající minuty (velikost 1,5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "a zbývající minuty (velikost 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "s procenty minut"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "s procenty (velikost 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "s procenty (velikost 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "a zbývající minuty (nad)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "a zbývající minuty (nad / velikost 1,5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "a zbývající minuty (nad / velikost 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "s procenty (nad)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "s procenty (nad/velikost 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "s procenty (nad/velikost 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "a zbývající minuty (pod)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "a zbývající minuty (pod /velikost 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "a zbývající minuty (pod /velikost 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "s procenty (pod)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "s procenty (pod/velikost 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "s procenty (pod/velikost 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "s aktuálním 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "s aktuálním 00:00 (Size 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "s aktuálním 00:00 (Size 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "s aktuálním 00:00 (nad)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "s aktuálním 00:00 (nad /velikost 1,5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "s aktuálním 00:00 (nad /velikost 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "s aktuálním 00:00 (pod)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "s aktuálním 00:00 (pod/velikost 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "s aktuálním 00:00 (pod/velikost 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "s procenty minut / Celkově (nad)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "s procenty minut / Celkově (nad/velikost 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "s procenty minut / Celkově (nad/velikost 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "s absolutním časem ukončení"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "s absolutním časem ukončení (velikost 1,2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "s absolutním časem ukončení (velikost 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "s minutami celkem / čas ukončení (nad)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "s minutami celkem / čas ukončení (nad/velikost1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "s minutami celkem / čas ukončení (nad/velikost 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Rychlý mód (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normální (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "abecedně"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "náhodně"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "better/slow"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "pomalu/rychle (jen obrázek)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "pomalu/rychle (vše)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + nastavení (vysoká kvalita, pomale)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + nastavení (nízká kvalita, rychle)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "bez cache + bez nastavování"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Zabudovaný tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Teď/Další"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normálně"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "redukované"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Neobnovit JavaScript"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Znovu načíst"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normalně"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - bok po boku"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "Otevřít mapu počasí"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternativní Mod kopírování-Mode/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "ano + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "ano, dlouhé"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "ano, krátké"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Hledat obal"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "vždy"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "Zapnuté+Media+Pohotovostní režim"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Pohotovostní režim"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - barva"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - černobílá /barva"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x Tlačítko rychle vpřed"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x Tlačítko rychle vpřed Typ 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Dlouhé tlačítko rychle dopředu"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Dlouhé tlačítko rychle dopředu Typ 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Info tlačítko"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x ztlumit zvuk"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Dlouhé tlačítko info"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x Rychle zpět tlačítko"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x Rychle zpět tlačítkoTyp 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Dlouhé tlčítko rychle nazpět"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Dlouhé tlčítko rychle nazpět Typ 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "ao, rozšířené"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Běžná konzole"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Rozsáhlý log soubor"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Normální log soubor"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "zakázáno"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Rádio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Rádio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Rádio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (plný)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normální (plný)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "zdobené (černé)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "zdobené (průhledné)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "ZTLUM nebo definuj klíče"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "libovolné tlačítko"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Čas+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Čas+Trvání+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Čas+Délka+info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "polovina vlevo"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "polovina vpravo"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Rámeček x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Řádek"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "zádný bar"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "žádný rámeček"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Spád"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Hrany stínu"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normální"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Pozice pod"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Pozice vlevo"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Pozice vpravo"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Umístění"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Jméno"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Vypnuté"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Aktivní"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Aktivní+Neaktivní"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "jen použitý časovač"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "použít čas dodání"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "žádný celkový časovač"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "zobrazit celkový časovač"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "jeden řádek"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "dva řádky"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Dostupná paměť"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Volná paměť"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "na celou obrazovku"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "ano kromě nahrávek"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "V"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "VSV"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "VJV"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "SV"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "SSV"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "SSZ"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "SZ"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "J"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "JV"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "JJV"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "JJZ"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "JZ"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "Z"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "ZSZ"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "ZJZ"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Nahrej aktivní konfig. soubor"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Načíst výchozí hodnoty / prázdná konfigurace"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Ulož Config do souboru... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Nahrej soubor: %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Zmazat soubor?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "smazáno"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "aktuální nastavení: %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux Nastavení"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Uložit"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Restart displejů"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Do nastavení >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "žádný LCD1 obrazový soubor"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "žádný LCD2 obrazový soubor"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "žádný LCD3 obrazový soubor"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux povolený"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Typ"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 otočit"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 barva pozadí"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 obrázek pozadí [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 jas"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 noční mód"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 obnova"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Typ"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 otočit"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 barva pozadí"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 obrázek pozadí [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 jas"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 noční mód"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 obnova"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Typ"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 otočit"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 barva pozadí"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 obrázek pozadí [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 jas"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Noční mód"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 obnova"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD rozměry"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Offset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD barva"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD Povolit zapnutý mód"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD povolit media mód"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD povolit čekací mód"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [čas zobrazení]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- které LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Ukázat v módě"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Velikost OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Pozadí/Průhlednost"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Rychlý snímek nízké kvality"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Vyskakovací text"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Vymazat klíč"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Velikost písma"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Pozice"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Zarovnání"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Barva"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Barva pozadí"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Písmo"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Aktivní obrazovka"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Výběr přepínače obrazovky - obrazovka"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Výběr přepínače obrazovky - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Obrazovky používané ke změně"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Obrazovka 1 čas změny"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Čas změny obrazovky 2"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Čas změny obrazovky 3"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Čas změny obrazovky 4"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Čas změny obrazovky 5"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Čas změny obrazovky 6"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Čas změny obrazovky 7"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Čas změny obrazovky 8"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Čas změny obrazovky 9"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Obrázek čas změny"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Seřazení obrázků"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Obrázek rekurzivní složka"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Kvalita obrazu pro změnu velikosti"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Obrázek čas rychlé aktualizace [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Typ obrázku [jen obrázek]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Typ obrázku pozadí"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Počasí výběr poskytovatele"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Počasí API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Počasí API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Počasí Město"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Počasí Město 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Počasí- Ikona- Cesta [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Počasí- Ikona zvětšení"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Počasí barva nízké (-) teploty"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Počasí barva vysoké (+) teploty"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Počasí průhlednost"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Počasí jednotka rychlosti větru"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Počasí směr a rychlost větru"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Počasí možnost deště"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Zvětšení deště"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Barva deště"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Déšť používá barvu 2 z"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Barva deště 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Počasí Vlhkost Barva"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Počasí linky"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Počasí sípky trendov"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Počasí rozšířené info"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra zvětšení"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Zobrazit teplotu ochlazení jeli rozdíl"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extra barva města"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extra barva ochlazení"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Min rozsah"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Max rozsah"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "URL počasí"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Měsíc - cesta k ikoně [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Obrázek záznamu [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Změna dvoj-stlačením tlačítka"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Klíč pro změnu obrazovky"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Tlačítko pro zapnutí/vypnutí obrazovky"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall acesta k obrázkům [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Počet řádků na vstupní údaj"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall počet položek seznamu"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall počet obrázků"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall orientace obrázku"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall průhlednost obrázku"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall vyhledávání obrazku"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall odstranit hovory po hodinách"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall čas vyskakovacího okna"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall vyskakovací LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall barva vyskakovacího okna"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall rámeček obrázku [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Kalendář - ics-cesta [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Kalendař - ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Kalendář - plánovač"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Kalendář - barva soboty"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Kalendář - barva neděle"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Kalendář - tloušťka čáry"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Kalendář - denní přehled"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Kalendář - oprava časové zóny"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Kalendář - průsvitnost"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Kalendář - čas obnovy"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Tuner Barva"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Tuner Barva aktivní"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Tuner Barva zapnuto"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Nejdřív prohledat kanál"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T korekce kvality signálu"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Druh písma celkově [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Druh písma 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Druh písma 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Druh písma 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Druh písma 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Druh písma 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 připojení"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Zobrazené jméno:]Uživatelské jméno"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 heslo"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 připojení"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Zobrazené jméno:]Uživatelské jméno"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 heslo"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 připojení"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Zobrazené jméno:]Uživatelské jméno"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 heslo"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 připojení"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Zobrazené jméno:]Uživatelské jméno"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 heslo"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 připojení"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Zobrazené jméno:]Uživatelské jméno"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 heslo"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Pošta obnovovací interval"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Pošta IMAP limit na posledné dny"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail Zobrazit prázdné schránky"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Pošta ukaž datum"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Pošta skrýt adresu"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Vzdálený Box 1 [Zobrazované jméno:]IP/Jméno"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Vzdálený Box 2 [Zobrazované jméno:]IP/Jméno"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Vzdálený Box 3 [Zobrazované jméno:]IP/Jméno"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Vzdálený Box 4 [Zobrazované jméno:]IP/Jméno"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Vzdálený Box 5 [Zobrazované jméno:]IP/Jméno"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "RVzdálený Box obnova v minutách"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Vzdálený Box 1 [Zobrazované jméno:]IP/Jméno"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Vzdálený Box obnova v minutách"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Konvertor časové obnovy"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "Použiť WWW konvertor"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey from cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey from convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF aktualizace [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF Typ aktualizace"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF Inicializace zpoždění"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP zakaž"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF vzhled"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Uložit jako obrázek pro WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 povolit"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 Port"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 Virtuální jas"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 povolit"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 Port"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 Virtuální jas"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 povolit"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 Port"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 Virtuální jas"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG Cyklus"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Při chybě restartujte"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG Režim záhlaví"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos časový limit ping [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Přehrát šek"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Obnovit [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Časový limit ping [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "Kontrola přehrávání BlueSound"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Obnovit [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [volitelný]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Časový limit ping [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Kontrola přehrávání"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Obnovit [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Obal"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD volitelná šířka"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD volitelná výška"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD volitelná šířka 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD volitelná výška 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD Vypnuto při vypnutí"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Časování ! výpočet všech časů na Čas/5*2 v rychlém módě"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Zpoždění displeje [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Návrhy na LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Zobrazit Chybové hlášení"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Zobrazit 'žádné ....' Hlášení"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Úložná zařízení: Vynutit čtení"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Úložná zařízení: Barva zpět"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Úložná zařízení: Barevná lišta"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Úložná zařízení: Barva plná"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Kontrola sítě aktivní"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Přepnout FrameBuffer [pokud je to možné]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Záloha nastavení [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Obnova všeho nastavení"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Logování > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Podsvícení Off [Zakázat nastavení Off = On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Podsvícení zapnout"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Podsvícení víkend [Zakázat nastavení Off = On]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Podsvícení přes víkend zapnout"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD automatické vypnutí"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Pozadí"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Obrázek [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon Size"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Rozdělená obrazovka"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Celá obrazovka"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Velikost textu"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Průhlednost"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon cesta [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon cesta 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache cesta [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Hodiny"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Typ"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analogové Hodiny"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Vzdálenost"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Velikost"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Hrany stínu"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Hodiny 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Název kanálu"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- maximum řádků"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Délka"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Číslo kanálu"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Info o programu"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Typ"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Info o programu 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Info o dalším programu"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Rozšířený popis"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- prázdné použijte informace"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Ukazatel průběhu"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Barevný Text"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Okraj"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Stínované"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Jednotka min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informace"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Informace o tuneru"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Snímače"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informace 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Lišta kvality signálu"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Spád"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Rozsah sloupce kvality signálu na Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Rozsah sloupce kvality signálu na Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satelit"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Poskytovatel"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Použitý tuner"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- jen aktivní tuner"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Další časovač udalosti"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Hlasitost"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Ztlumit zvuk"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Stav sítě [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Zobrazit stav"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Časový limit [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Síťové jméno: Adresa"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Externí IP adresa"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- externí IP adresa"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Paměťové - zařízení"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- bez varování"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- další informace"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Jméno zařízení"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zvětšení"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Typ počasí"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Počasí 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteorologická stanice"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Stanice"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Modul"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Modul definovaný uživatelem"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Základ"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Jméno"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Barva 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Barva 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Barva 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Barva 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Barva 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Barva 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Indikátor"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Délka [Bar]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Konforktní indikátor"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Fáze měsíce"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Informační linky"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Šípky trendov"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Východ slunce"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Zobraz oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Soubor [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Zobraz ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Zobraz textový soubor"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Zobraz textový soubor 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Zobraz textový soubor 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Zobraz HTTP Text"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "Konvertor web. stránek"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP šířka"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP výška"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Vystřiženo z X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Vystřiženo z Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Zmenšit šířku [zakázat = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Výška střihu [deaktivovat = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Zobraz obrázek"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Soubor nebo cesta [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Maximální Výška"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Rychlá aktualizace"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Zobraz obrázek 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Zobraz obrázek 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Zobraz obrázek 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Řádky"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- e-mailové konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- maximální šířka"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Vzdálený Box"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Velikost obrázku"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Pozice obrázku"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Zarovnání obrázku"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Rozložení"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Barva pozadí aktuálního dne"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Barva titulku"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Seznam datumů"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Panel ikon události"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Vyskakovací obrazovka"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Vyskakovací LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Zobraz text 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Text"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Zobraz text 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Obdélník 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Pozice x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Pozice y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Velikost x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Velikost y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Obdélník 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Záznam"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Zobraz - zrcadlení TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Obrazovky použíté na výměnu"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Titulek"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Informace"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Zobrazit obálku"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Hledaná cesta [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Najdi soubor obalu [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Výchozí obálka [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Nejdřív Picon"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Oříznuto"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Stáhnout obálku"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Typ stahování"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Displej"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Režim zobrazení - zapnutý"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Nastavit Media >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Přehrávač médií v zobrazovacím režimu"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Nastavit Idle >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Režim nečinnosti displeje"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Obecná nastavení >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Zvol složku"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Zvol soubor"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Zvol písmo"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Současná hodnota: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3843,95 +4076,95 @@ msgstr ""
 "Je pořeba restaru GUI, k aplikaci změn.\n"
 "Chcete nyní restartovat GUI?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Restartovar GUI teď?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Vnitřní"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Venkovní"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Déšť"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Vítr"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Nový měsíc"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "První čtvrtina"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Dorůstající srpek"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Dorůstající měsíc"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Úplněk"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Ubývající měsíc"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Ubývající srpek"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Poslední čtvrtina"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Obrázek není k dispozici"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "žádný časovač"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM neběží"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "žádné volání"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Správy  %d Nové  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "nenainstalovaný Netatmo-Plugin"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux povolen"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Přepínač obrazovky"
 
@@ -3949,111 +4182,3 @@ msgstr "LCD4linux Přepínač obrazovky"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Počasí Směr větru"
-
-#~ msgid "Backup Config"
-#~ msgstr "Záloha Configu"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Chybový výpis"
-
-#~ msgid "Delete"
-#~ msgstr "Zmazat"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Zmazání log souboru"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Stáhnout log soubor"
-
-#~ msgid "Element"
-#~ msgstr "Nastavení"
-
-#~ msgid "Exec"
-#~ msgstr "Vykonat"
-
-#~ msgid "Filename"
-#~ msgstr "Název souboru"
-
-#~ msgid "Font"
-#~ msgstr "Druh písma"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "Je vyžadován restart GUI"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Zabezpečení IP není podporováno Boxem"
-
-#~ msgid "Key"
-#~ msgstr "Klíč"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Seznam úložných zařízení"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Žádný a nebo nesprávný soubor, skus nejdříve správný soubor !"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Nadřazený adresář"
-
-#~ msgid "Picture"
-#~ msgstr "Obrázek"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Vyskakovací text"
-
-#~ msgid "Restore Config"
-#~ msgstr "Obnova Configu"
-
-#~ msgid "Save Config"
-#~ msgstr "Ulož Config"
-
-#~ msgid "Screen"
-#~ msgstr "Obrazovka"
-
-#~ msgid "Show"
-#~ msgstr "Zobrazit"
-
-#~ msgid "Show Externals"
-#~ msgstr "Zobraz venkovní"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Tuner"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW Konvertor"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "zkopírovat do pohotovostních"
-
-#~ msgid "copy to Media"
-#~ msgstr "zkopírovat do Média"
-
-#~ msgid "copy to On"
-#~ msgstr "zkopírovat do aktivních"
-
-#~ msgid "other"
-#~ msgstr "jiné"
-
-#~ msgid "set Settings"
-#~ msgstr "aktivuj nastavení"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "zastav výměnu obrazovek"

--- a/LCD4linux/po/de.po
+++ b/LCD4linux/po/de.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:01+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:10+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -13,3831 +13,4064 @@ msgstr ""
 "X-Poedit-KeywordsList: _;gettext;gettext_noop\n"
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Fr"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Mo"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Boxskin-LCD"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sa"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Zeichensatz"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "So"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Schlüssel"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Do"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Di"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Mi"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Bild"
 
-#: plugin.py:288
-msgid "black"
-msgstr "schwarz"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Popup-Text"
 
-#: plugin.py:288
-msgid "white"
-msgstr "weiss"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "grau"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Tuner"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "silber"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW Konverter"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "schiefergrau"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "aquamarine"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Schirm"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "gold"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "grüngelb"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "gelb"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "dunkelorange"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "dunkelrot"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indianrot"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "orange"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "orangerot"
-
-#: plugin.py:292
-msgid "red"
-msgstr "rot"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomate"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "dunkelgrün"
-
-#: plugin.py:293
-msgid "green"
-msgstr "grün"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "rasengrün"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "hellgrün"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "limone"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "blau"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "blauviolett"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "kadettblau"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "kornblumenblau"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "dunkelblau"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "hellblau"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "cyan"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "dunkelorchidee"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "dunkelrosa"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violett"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "braun"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "moccasin"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olive"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "rosigbraun"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "sandbraun"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Schirm 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Schirm 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Schirm 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Schirm 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Schirm 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Schirm 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Schirm 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Schirm 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Schirm 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Schirm 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Schirm 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Schirm 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Schirm 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Screen 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Schirm 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Schirm 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Schirm 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Schirm 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Schirm 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Schirm 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Schirm 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Schirm 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Schirm 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Schirm 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Schirm 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Schirm 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Schirm 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Schirm 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Schirm 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "aus"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Schirm 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Schirm 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Schirm 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "ein"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2 Std"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3 Std"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4 min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1 min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10 min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5 min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60 min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (oder kompatibles LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (oder kompatibles LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (oder kompatibles LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (oder kompatibles LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H alt 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H alt 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Internes TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Internes Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "nur Bild 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "nur Bild 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "nur Bild 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "nur Bild 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "nur Bild benutzerdefinierte Größe"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "nur Bild benutzerdefinierte Größe 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Internes Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 Tage 1 Zeile"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 Tage 2 Zeilen"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 Tage 1 Zeile"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 Tage 2 Zeilen"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 Tage vertikale Ansicht"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 Tage 1 Zeile"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 Tage 2 Zeilen"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 Tage vertikale Ansicht"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Aktuelle Temperatur (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Aktuelle Temperatur (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Aktuell"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Aktuelle Temperatur"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Alles"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperatur"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperatur+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperatur+Co2+Luftdruck"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperatur+Luftfeuchte"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Modul 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Modul 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Modul 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Modul 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Modul 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Modul 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Modul 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Modul 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Modul 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Module 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Modul 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Modul 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Modul 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Modul 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Module 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Modul 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Modul 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Module 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Modul 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Module 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Modul 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Module 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Modul 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "Benutzerdefiniert"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Balken"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Balken+Wert"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Knopf"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Knopf+Wert"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analog"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analog+Datum"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analog+Datum+Wochentag"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analog+Datum+Wochentag 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Datum"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Datum+Uhrzeit"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Datum+Uhrzeit+Wochentag"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Klappen Design Datum"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Klappen Design Wochentag"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Zeit"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Uhrzeit+Wochentag"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Wochentag"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "zentriert"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "links"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "rechts"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Erweitert"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Erweitert (Kurz)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Kurz"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Kurz (Erweitert)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Kurz+Erweitert"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Monat"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Monat+Kopf"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Woche"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Woche+Kopf"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "kein Kalender"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Termine 1 Zeile"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Termine 3 Zeilen"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Termine 5 Zeilen"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Termine 9 Zeilen"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Termine kompakt 2 Zeilen"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Termine kompakt 3 Zeilen"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "keine Termine"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Unterstrich"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Unterstrich 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Rahmen"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Termine"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Termine kompakt"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Termine kompakt kein Icon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Termine kein Icon"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "kein Icon"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "ohne Icon, mit Zielnummer"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "mit Icon"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "mit Icon & Zielnummer"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "nein"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "zeige aktiv"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "zeige aktiv+schlafend"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Immer Alle"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Immer Neue"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Nur Neue"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Alle Informationen"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "nur Abstand"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Abstand+Ausleuchtung"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Abstand+Mondphase"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "nur Ausleuchtung"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Ausleuchtung+Mondphase"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "nur Mondphase"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Kanal"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Kanal+Titel"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Kanal"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Kanal+Titel"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "gleiche Farbe"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "ja +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "ja"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "vertikal"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontal"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Global"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "Alles"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Ecke"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Ecke+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "nur Fortschrittsbalken"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "mit verbleibenden Minuten"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "mit verbleibenden Minuten (Größe 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "mit verbleibenden Minuten (Größe 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "mit Prozent"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "mit Prozent (Größe 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "mit Prozent (Größe 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "mit verbleibenden Minuten (oberhalb)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "mit verbleibenden Minuten (oberhalb/Größe 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "mit verbleibenden Minuten (oberhalb/Größe 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "mit Prozent (oberhalb)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "mit Prozent (oberhalb/Größe 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "mit Prozent (oberhalb/Größe 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "mit verbleibenden Minuten (unterhalb)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "mit verbleibenden Minuten (unterhalb/Größe 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "mit verbleibenden Minuten (unterhalb/Größe 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "mit Prozent (unterhalb)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "mit Prozent (unterhalb/Größe 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "mit Prozent (unterhalb/Größe 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "mit Aktuell 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "mit Aktuell 00:00 (Größe 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "mit Aktuell 00:00 (Größe 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "mit Aktuell 00:00 (oberhalb)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "mit Aktuell 00:00 (oberhalb/Größe 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "mit Aktuell 00:00 (oberhalb/Größe 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "mit Aktuell 00:00 (unterhalb)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "mit Aktuell 00:00 (unterhalb/Größe 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "mit Aktuell 00:00 (unterhalb/Größe 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "mit Prozent Minuten / Gesamt (oberhalb)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "mit Prozent Minuten / Gesamt (oberhalb/Größe 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "mit Prozent Minuten / Gesamt  (oberhalb/Größe 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "mit absoluter Endzeit"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "mit absoluter Endzeit (Größe 1,5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "mit absoluter Endzeit (Größe 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "mit Minuten Gesamt/Endzeit (oben)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "mit Minuten Gesamt/Endzeit (oben/Größe 1,5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "mit Minuten Gesamt/Endzeit (oben/Größe 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Fastmode (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alphabetisch"
-
-#: plugin.py:386
-msgid "random"
-msgstr "zufällig"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "besser/langsam"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "niedrig/schnell (nur Bild)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "niedrig/schnell (alles)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "Cache + Anpassung (hohe Qualität, langsam)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "Cache + Anpassung (niedrige Qualität, schnell)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "kein Cache + keine Anpassung"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Steck Tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Now/Next"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "reduziert"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Keine JavaScript Auffrischung"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Neu Laden"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - nebeneinander"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternativer Kopiermodus/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "ja + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "ja, lang"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "ja, kurz"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Coversuche"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "immer"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Medien+Standby"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Standby"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Medien"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "On"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32 Bit Farbtiefe"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8 Bit Graustufen/Farbe"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x Vorspultaste"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x Vorspultaste Typ 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Lang Vorspultaste"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Lang Vorspultaste Typ 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Infotaste"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Stumm"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Lang InfoTaste"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x Rückspultaste"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x Rückspultaste Typ 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Lang RückSpulTaste"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Lang RückSpulTaste Typ 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15 min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "ja, erweitert"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Konsole normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "LogDatei umfangreich"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "LogDatei normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "deaktiviert"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Medien"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Medien"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (voll)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normal (voll)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "getrimmt (schwarz)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "getrimmt (transparent)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "STUMM oder definierte Schlüssel"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "Jeder Key"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Zeit+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Zeit+Info+Dauerr"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Zeit+Länge+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "halb links"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "halb rechts"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Frame x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Linie"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "keine Bar"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "Kein Rahmen"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Verlauf"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Schattenkanten"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Position unterhalb"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Position links"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Position rechts"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Position"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Name"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Offline"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Online"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Online+Offline"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "verwende nur Timer"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "verwende Vorlaufzeit"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "keine Timeranzahl"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "zeige Timeranzahl"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "eine Zeile"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "zwei Zeilen"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Hauptspeicher verfügbar"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Hauptspeicher frei"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "Vollbild"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "ja außer Aufnahmen"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "O"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ONO"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "OSO"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NO"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNO"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNW"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NW"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SO"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSO"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSW"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SW"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "W"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "WNW"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "WSW"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Lade aktive Konfig-Datei"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Lade Standard/Leere Konfiguration"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Speichere Konfig in Datei... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Lade Datei : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Datei löschen?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "gelöscht"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "aktuell eingestellt : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux Einstellungen Global"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Modus"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Abbruch"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Speichern"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Neustart Displays"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Setze An >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Leerlauf"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "keine LCD1 Bild-Datei"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "keine LCD2 Bild-Datei"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "keine LCD3 Bild-Datei"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux aktiviert"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Typ"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 Drehung"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Hintergrundfarbe"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Hintergrundbild [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Helligkeit"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Nachtabsenkung"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 Aktualisierung"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Typ"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Drehung"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Hintergrundfarbe"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Hintergrundbild [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Helligkeit"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Nachtabsenkung"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 Aktualisierung"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Typ"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Drehung"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Hintergrundfarbe"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Hintergrundbild [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Helligkeit"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Nachtabsenkung"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 Aktualisierung"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Boxskin-LCD Größe"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Boxskin-LCD Offset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Boxskin-LCD Farbe"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Boxskin-LCD Aktiviere Modus An"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Boxskin-LCD Aktiviere Modus Medien"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Boxskin-LCD Aktiviere Modus Leerlauf"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [Anzeigezeit]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- welches LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Zeige im Modus"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- OSD-Größe"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Hintergrund/Transparenz"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- schneller Zugriff niedrige Qualität"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Popup Text"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Schlüssel löschen"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Schriftgröße"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Position"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Ausrichtung"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Farbe"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Hintergrundfarbe"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Schriftart"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Aktiver Schirm"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Schirm Schalter Auswahl - Schirm"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Schirm Schalter Auswahl - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Benutzte Schirme zum Wechsel"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Schirm 1 Wechselzeit"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Umschaltzeit Schirm 2"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Umschaltzeit Schirm 3"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Umschaltzeit Schirm 4"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Umschaltzeit Schirm 5"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Umschaltzeit Schirm 6"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Umschaltzeit Schirm 7"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Umschaltzeit Schirm 8"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Umschaltzeit Schirm 9"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Bild Wechselzeit"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Bild Sortierung"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Bild Verzeichnis Rekursiv"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Bild Qualität für Größenänderung"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Bild Quick Aktualisierung Zeit [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Bild Typ [nur Bild]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Hintergrundbild-Typ"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Wetter API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Wetter API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Wetter API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Wetter Stadt"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Wetter Stadt 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Wetter-Icon-Verz. [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Wetter-Icon Zoom"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Wetter Niedrige Temperatur Farbe"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Wetter Hohe Temperatur Farbe"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Wetter Transparenz"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Wetter Wind Einheit"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Wetter Wind Infozeilen"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Wetter Regen Wahrscheinlichkeit"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Regenzoom"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Regenfarbe"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Regen verwende Farbe 2 ab"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Regenfarbe 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Wetter Linien"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Wetter Trendpfeile"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Wetter Extra Infos"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra Zoom"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Zeige gefühlte Temperatur ab Differenz"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extrafarbe Stadt"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extrafarbe gefühlte Temperatur"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Min Bereich"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Max Bereich"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteo URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Mond-Icon-Verz. [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Aufnahme Bilddatei [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Doppel-Tasten Schalter"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Taste für Schirmwechsel"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Taste für Schirm Ein/Aus"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall Bilder Verz. [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Anzahl Zeilen je Eintrag"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall Anzahl Listeneinträge"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall Anzahl Bilder"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall Bilder Ausrichtung"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall Bilder Transparenz"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall Bilder Suche"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall entferne Anrufe nach Stunden"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Popup-Zeit"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall Popup LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Popup Farbe"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Rahmen Bild [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Kalender ics-Verzeichnis [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Kalender ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Kalender planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Kalender Samstag Farbe"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Kalender Sonntag Farbe"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Kalender Linienstärke"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Kalender Tage Ereignisvorschau"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Kalender Zeitzone Korrektur"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Kalender Transparenz"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Kalender Abruf Interval"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Tuner Farbe"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Tuner Farbe Aktiv"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Tuner Farbe Ein"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Service Suche zuerst"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Signal-Qualitäts-Korrektur"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Zeichensatz Global [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Zeichensatz 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Zeichensatz 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Zeichensatz 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Zeichensatz 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Zeichensatz 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 Connect"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 Server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Anzeigename:]Nutzername"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 Passwort"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 Connect"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 Server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Anzeigename:]Nutzername"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 Passwort"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 Connect"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Anzeigename:]Nutzername"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 Passwort"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 Connect"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 Server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Anzeigename:]Nutzername"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 Passwort"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 Connect"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 Server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Anzeigename:]Nutzername"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 Passwort"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Mail Abruf Interval"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Mail IMAP begrenze auf letze Tage"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail Zeige Leere Mailboxen"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Mail zeige Datum"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Mail verberge Mailadresse"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Remote Box 1 [Anzeigename:]IP/Name"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Remote Box 2 [Anzeigename:]IP/Name"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Remote Box 3 [Anzeigename:]IP/Name"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Remote Box 4 [Anzeigename:]IP/Name"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Remote Box 5 [Anzeigename:]IP/Name"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Remote Box Abruf alle Minuten"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Remote Box Timer [Displayname:]IP/Name"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Remote Box Timer anfrage Minuten"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Konverter Abruf Interval"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW Konverter Verwendung"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey von cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey von convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF Aktualisierung [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF Aktualisierungstyp"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF Init Verzögert"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP erlaubt"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP verweigert"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF Design"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Speichern als Bild für WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 aktiv"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 Port"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 virtuelle Helligkeit"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 aktiv"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 Port"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 virtuelle Helligkeit"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 aktiv"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 Port"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 virtuelle Helligkeit"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG Zyklus"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Neustart bei Fehler"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG Header Modus"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Timeout [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Play Check"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Refresh [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Ping Timeout [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound Play-Prüfung"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Refresh [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [optional]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Timeout [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Play Check"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Refresh [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Cover"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD benutzerdefinierte Breite"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD benutzerdefinierte Höhe"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD-Sonderbreite 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD-Sonderhöhe 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD aus, beim Abschalten"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Timing ! rechne alle Zeiten um Zeit/5*2 im Schnellmodus"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Verzögerung [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Threads pro LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Zeige Crash Ecke"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Zeige 'keine ....' Mitteilungen"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Speicher-Geräte: erzwinge Lesen"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Speicher-Geräte: Farbe zurück"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Speicher-Geräte: Farbbar"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Speicher-Geräte: Farbe voll"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Netzwerk Check Aktive"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "FramBuffer umschalten [wenn möglich]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Konfig Backup Verz. [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Alle Einstellungen wiederherstellen"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debug-Logging > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Hintergrundbeleuchtung aus [inaktiv bei Aus=Ein]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Hintergrundbeleuchtung Ein"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Hintergrundbeleuchtung am Wochenende aus [inaktiv bei Aus=Ein]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Hintergrundbeleuchtung am Wochenende Ein"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD-Auto-Aus"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Hintergrund"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Bild [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon Größe"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Geteilter Schirm"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Vollbild"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Zeichengröße"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparenz"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon Verzeichnis [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon Verzeichnis 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache Verz. [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Uhrzeit"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "- Typ"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analoguhr"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Abstand"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Größe"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Schattenkanten"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Uhrzeit 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Programm Name"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- maximale Zeilen"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Länge"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Programm Nummer"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Programm Info"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Typ"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Programm Info 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Nächste Programm Info"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Erweiterte Beschreibung"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- benutze Info wenn leer"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Fortschrittsbalken"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Textfarbe"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Umrandung"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Schattiert"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Einheit min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informationen"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Tunerinfo"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensoren"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- Prozessor"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informationen 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Signal Qualität Bar"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Verlauf"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Bar-Bereich Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Bar-Bereich Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satellit"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Provider"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Verwendete Tuner"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- nur aktive Tuner"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Nächste Aufnahme"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Lautstärke"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Stumm"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Online [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Zeige Status"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Timeout [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Online Name:Adresse"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Externe IP Adresse"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- externe IP-URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Speicher-Geräte"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- frei Warnung"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- Zusatzinfo"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Gerätename"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Wetter"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Wettertyp"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Wetter 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo-Wetter Station"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Station"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Modul"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Benutzerdefinierte Module"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Basis"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Name"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Farbe 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Farbe 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Farbe 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Farbe 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Farbe 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Farbe 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Indikator"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Länge [Balken]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Komfort Indikator"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Mondphase"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Infozeilen"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Trendpfeile"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Sonnenaufgang"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Zeige oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Datei [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Zeige ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Zeige Textdatei"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Zeige Textdatei 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Zeige Textdatei 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Zeige HTTP Text"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-Internet Konverter"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP-Breite"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP-Höhe"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Beschneiden ab X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Beschneiden ab Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Breite beschneiden [deaktiviert = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Höhe beschneiden [deaktiviert = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Zeige Bild"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Datei oder Verzeichnis [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Größe max. Höhe"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Schnellaktualisierung"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Zeige Bild 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Zeige Bild 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Zeige Bild 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Zeilen"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Mail-Konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- max Breite"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Remote Box"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Remote Box Timer"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Bildgröße"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Bildposition"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Bildausrichtung"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Kalender"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP erlaubt"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Keine oder eine falsche Datei ausgewählt, wähle zuerst eine richtige Datei !"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Modus"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "IP Sicherheit durch Box nicht unterstützt"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Crashlog"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Zeige"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Löschen"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Dateiname"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Wiederherstellung der Einstellungen"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Sicherung der Einstellungen"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Logdatei löschen"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Download Logdatei"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Speichern der Einstellungen"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "Schirmwechsel anhalten"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Global"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "On"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Medien"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Leerlauf"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "GUI Neustart ist notwendig"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Element"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "andere"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "setze Einstellungen"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "kopiere nach An"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "kopiere nach Medien"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "kopiere nach Leerlauf"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Ausführung"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Zeige Externe"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Liste der Speichergeräte"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Übergeordnetes Verzeichnis"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Fr"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Mo"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sa"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "So"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Do"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Di"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Mi"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "schwarz"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "weiss"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "grau"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "silber"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "schiefergrau"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "aquamarine"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "gold"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "grüngelb"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "gelb"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "dunkelorange"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "dunkelrot"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indianrot"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "orange"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "orangerot"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "rot"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomate"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "dunkelgrün"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "grün"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "rasengrün"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "hellgrün"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "limone"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "blau"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "blauviolett"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "kadettblau"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "kornblumenblau"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "dunkelblau"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "hellblau"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "cyan"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "dunkelorchidee"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "dunkelrosa"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violett"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "braun"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "moccasin"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olive"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "rosigbraun"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "sandbraun"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Schirm 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Schirm 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Schirm 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Schirm 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Schirm 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Schirm 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Schirm 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Schirm 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Schirm 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Schirm 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Schirm 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Schirm 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Schirm 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Screen 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Schirm 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Schirm 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Schirm 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Schirm 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Schirm 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Schirm 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Schirm 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Schirm 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Schirm 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Schirm 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Schirm 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Schirm 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Schirm 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Schirm 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Schirm 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "aus"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Schirm 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Schirm 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Schirm 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "ein"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2 Std"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3 Std"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4 min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1 min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10 min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5 min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60 min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (oder kompatibles LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (oder kompatibles LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (oder kompatibles LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (oder kompatibles LCD) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H alt 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H alt 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Internes Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Internes TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "nur Bild 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "nur Bild 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "nur Bild 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "nur Bild 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "nur Bild benutzerdefinierte Größe"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "nur Bild benutzerdefinierte Größe 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Internes Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 Tage 1 Zeile"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 Tage 2 Zeilen"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 Tage 1 Zeile"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 Tage 2 Zeilen"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 Tage vertikale Ansicht"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 Tage 1 Zeile"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 Tage 2 Zeilen"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 Tage vertikale Ansicht"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Aktuelle Temperatur (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Aktuelle Temperatur (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Aktuell"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Aktuelle Temperatur"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Alles"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperatur"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperatur+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperatur+Co2+Luftdruck"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperatur+Luftfeuchte"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Modul 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Modul 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Modul 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Modul 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Modul 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Modul 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Modul 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Modul 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Modul 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Module 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Modul 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Modul 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Modul 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Modul 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Module 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Modul 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Modul 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Module 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Modul 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Module 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Modul 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Module 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Modul 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "Benutzerdefiniert"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Balken"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Balken+Wert"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Knopf"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Knopf+Wert"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analog"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analog+Datum"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analog+Datum+Wochentag"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analog+Datum+Wochentag 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Datum"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Datum+Uhrzeit"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Datum+Uhrzeit+Wochentag"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Klappen Design Datum"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Klappen Design Wochentag"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Zeit"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Uhrzeit+Wochentag"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Wochentag"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "zentriert"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "links"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "rechts"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Erweitert"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Erweitert (Kurz)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Kurz"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Kurz (Erweitert)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Kurz+Erweitert"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Monat"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Monat+Kopf"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Woche"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Woche+Kopf"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "kein Kalender"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Termine 1 Zeile"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Termine 3 Zeilen"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Termine 5 Zeilen"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Termine 9 Zeilen"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Termine kompakt 2 Zeilen"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Termine kompakt 3 Zeilen"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "keine Termine"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Unterstrich"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Unterstrich 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Rahmen"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Termine"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Termine kompakt"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Termine kompakt kein Icon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Termine kein Icon"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "kein Icon"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "ohne Icon, mit Zielnummer"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "mit Icon"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "mit Icon & Zielnummer"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "nein"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "zeige aktiv"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "zeige aktiv+schlafend"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Immer Alle"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Immer Neue"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Nur Neue"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Alle Informationen"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "nur Abstand"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Abstand+Ausleuchtung"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Abstand+Mondphase"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "nur Ausleuchtung"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Ausleuchtung+Mondphase"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "nur Mondphase"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Kanal"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Kanal+Titel"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Kanal"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Kanal+Titel"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "gleiche Farbe"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "ja +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "ja"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "vertikal"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontal"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "Alles"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Ecke"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Ecke+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "nur Fortschrittsbalken"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "mit verbleibenden Minuten"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "mit verbleibenden Minuten (Größe 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "mit verbleibenden Minuten (Größe 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "mit Prozent"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "mit Prozent (Größe 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "mit Prozent (Größe 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "mit verbleibenden Minuten (oberhalb)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "mit verbleibenden Minuten (oberhalb/Größe 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "mit verbleibenden Minuten (oberhalb/Größe 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "mit Prozent (oberhalb)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "mit Prozent (oberhalb/Größe 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "mit Prozent (oberhalb/Größe 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "mit verbleibenden Minuten (unterhalb)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "mit verbleibenden Minuten (unterhalb/Größe 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "mit verbleibenden Minuten (unterhalb/Größe 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "mit Prozent (unterhalb)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "mit Prozent (unterhalb/Größe 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "mit Prozent (unterhalb/Größe 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "mit Aktuell 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "mit Aktuell 00:00 (Größe 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "mit Aktuell 00:00 (Größe 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "mit Aktuell 00:00 (oberhalb)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "mit Aktuell 00:00 (oberhalb/Größe 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "mit Aktuell 00:00 (oberhalb/Größe 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "mit Aktuell 00:00 (unterhalb)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "mit Aktuell 00:00 (unterhalb/Größe 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "mit Aktuell 00:00 (unterhalb/Größe 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "mit Prozent Minuten / Gesamt (oberhalb)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "mit Prozent Minuten / Gesamt (oberhalb/Größe 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "mit Prozent Minuten / Gesamt  (oberhalb/Größe 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "mit absoluter Endzeit"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "mit absoluter Endzeit (Größe 1,5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "mit absoluter Endzeit (Größe 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "mit Minuten Gesamt/Endzeit (oben)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "mit Minuten Gesamt/Endzeit (oben/Größe 1,5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "mit Minuten Gesamt/Endzeit (oben/Größe 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Fastmode (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alphabetisch"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "zufällig"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "besser/langsam"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "niedrig/schnell (nur Bild)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "niedrig/schnell (alles)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "Cache + Anpassung (hohe Qualität, langsam)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "Cache + Anpassung (niedrige Qualität, schnell)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "kein Cache + keine Anpassung"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Steck Tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Now/Next"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "reduziert"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Keine JavaScript Auffrischung"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Neu Laden"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - nebeneinander"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternativer Kopiermodus/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "ja + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "ja, lang"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "ja, kurz"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Coversuche"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "immer"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Medien+Standby"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Standby"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32 Bit Farbtiefe"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8 Bit Graustufen/Farbe"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x Vorspultaste"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x Vorspultaste Typ 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Lang Vorspultaste"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Lang Vorspultaste Typ 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Infotaste"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Stumm"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Lang InfoTaste"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x Rückspultaste"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x Rückspultaste Typ 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Lang RückSpulTaste"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Lang RückSpulTaste Typ 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15 min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "ja, erweitert"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Konsole normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "LogDatei umfangreich"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "LogDatei normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Medien"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Medien"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (voll)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normal (voll)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "getrimmt (schwarz)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "getrimmt (transparent)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "STUMM oder definierte Schlüssel"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "Jeder Key"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Zeit+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Zeit+Info+Dauerr"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Zeit+Länge+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "halb links"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "halb rechts"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Frame x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Linie"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "keine Bar"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "Kein Rahmen"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Verlauf"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Schattenkanten"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Position unterhalb"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Position links"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Position rechts"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Position"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Name"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Offline"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Online"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Online+Offline"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "verwende nur Timer"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "verwende Vorlaufzeit"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "keine Timeranzahl"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "zeige Timeranzahl"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "eine Zeile"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "zwei Zeilen"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Hauptspeicher verfügbar"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Hauptspeicher frei"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "Vollbild"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "ja außer Aufnahmen"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "O"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ONO"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "OSO"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NO"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNO"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNW"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NW"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SO"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSO"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSW"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SW"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "W"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "WNW"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "WSW"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Lade aktive Konfig-Datei"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Lade Standard/Leere Konfiguration"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Speichere Konfig in Datei... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Lade Datei : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Datei löschen?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "gelöscht"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "aktuell eingestellt : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux Einstellungen Global"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Abbruch"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Speichern"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Neustart Displays"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Setze An >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "keine LCD1 Bild-Datei"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "keine LCD2 Bild-Datei"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "keine LCD3 Bild-Datei"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux aktiviert"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Typ"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 Drehung"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Hintergrundfarbe"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Hintergrundbild [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Helligkeit"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Nachtabsenkung"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 Aktualisierung"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Typ"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Drehung"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Hintergrundfarbe"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Hintergrundbild [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Helligkeit"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Nachtabsenkung"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 Aktualisierung"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Typ"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Drehung"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Hintergrundfarbe"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Hintergrundbild [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Helligkeit"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Nachtabsenkung"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 Aktualisierung"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Boxskin-LCD Größe"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Boxskin-LCD Offset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Boxskin-LCD Farbe"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Boxskin-LCD Aktiviere Modus An"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Boxskin-LCD Aktiviere Modus Medien"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Boxskin-LCD Aktiviere Modus Leerlauf"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [Anzeigezeit]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- welches LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Zeige im Modus"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- OSD-Größe"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Hintergrund/Transparenz"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- schneller Zugriff niedrige Qualität"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Popup Text"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Schlüssel löschen"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Schriftgröße"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Position"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Ausrichtung"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Farbe"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Hintergrundfarbe"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Schriftart"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Aktiver Schirm"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Schirm Schalter Auswahl - Schirm"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Schirm Schalter Auswahl - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Benutzte Schirme zum Wechsel"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Schirm 1 Wechselzeit"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Umschaltzeit Schirm 2"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Umschaltzeit Schirm 3"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Umschaltzeit Schirm 4"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Umschaltzeit Schirm 5"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Umschaltzeit Schirm 6"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Umschaltzeit Schirm 7"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Umschaltzeit Schirm 8"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Umschaltzeit Schirm 9"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Bild Wechselzeit"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Bild Sortierung"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Bild Verzeichnis Rekursiv"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Bild Qualität für Größenänderung"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Bild Quick Aktualisierung Zeit [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Bild Typ [nur Bild]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Hintergrundbild-Typ"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Wetter API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Wetter API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Wetter API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Wetter Stadt"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Wetter Stadt 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Wetter-Icon-Verz. [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Wetter-Icon Zoom"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Wetter Niedrige Temperatur Farbe"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Wetter Hohe Temperatur Farbe"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Wetter Transparenz"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Wetter Wind Einheit"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Wetter Wind Infozeilen"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Wetter Regen Wahrscheinlichkeit"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Regenzoom"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Regenfarbe"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Regen verwende Farbe 2 ab"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Regenfarbe 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Wetter Luftfeuchtefarbe"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Wetter Linien"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Wetter Trendpfeile"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Wetter Extra Infos"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra Zoom"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Zeige gefühlte Temperatur ab Differenz"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extrafarbe Stadt"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extrafarbe gefühlte Temperatur"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Min Bereich"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Max Bereich"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteo URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Mond-Icon-Verz. [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Aufnahme Bilddatei [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Doppel-Tasten Schalter"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Taste für Schirmwechsel"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Taste für Schirm Ein/Aus"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall Bilder Verz. [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Anzahl Zeilen je Eintrag"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall Anzahl Listeneinträge"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall Anzahl Bilder"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall Bilder Ausrichtung"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall Bilder Transparenz"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall Bilder Suche"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall entferne Anrufe nach Stunden"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Popup-Zeit"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall Popup LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Popup Farbe"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Rahmen Bild [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Kalender ics-Verzeichnis [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Kalender ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Kalender planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Kalender Samstag Farbe"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Kalender Sonntag Farbe"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Kalender Linienstärke"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Kalender Tage Ereignisvorschau"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Kalender Zeitzone Korrektur"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Kalender Transparenz"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Kalender Abruf Interval"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Tuner Farbe"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Tuner Farbe Aktiv"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Tuner Farbe Ein"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Service Suche zuerst"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Signal-Qualitäts-Korrektur"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Zeichensatz Global [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Zeichensatz 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Zeichensatz 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Zeichensatz 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Zeichensatz 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Zeichensatz 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 Connect"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 Server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Anzeigename:]Nutzername"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 Passwort"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 Connect"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 Server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Anzeigename:]Nutzername"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 Passwort"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 Connect"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Anzeigename:]Nutzername"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 Passwort"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 Connect"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 Server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Anzeigename:]Nutzername"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 Passwort"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 Connect"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 Server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Anzeigename:]Nutzername"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 Passwort"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Mail Abruf Interval"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Mail IMAP begrenze auf letze Tage"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail Zeige Leere Mailboxen"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Mail zeige Datum"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Mail verberge Mailadresse"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Remote Box 1 [Anzeigename:]IP/Name"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Remote Box 2 [Anzeigename:]IP/Name"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Remote Box 3 [Anzeigename:]IP/Name"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Remote Box 4 [Anzeigename:]IP/Name"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Remote Box 5 [Anzeigename:]IP/Name"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Remote Box Abruf alle Minuten"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Remote Box Timer [Displayname:]IP/Name"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Remote Box Timer anfrage Minuten"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Konverter Abruf Interval"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW Konverter Verwendung"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey von cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey von convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF Aktualisierung [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF Aktualisierungstyp"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF Init Verzögert"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP verweigert"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF Design"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Speichern als Bild für WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 aktiv"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 Port"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 virtuelle Helligkeit"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 aktiv"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 Port"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 virtuelle Helligkeit"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 aktiv"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 Port"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 virtuelle Helligkeit"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG Zyklus"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Neustart bei Fehler"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG Header Modus"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Timeout [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Play Check"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Refresh [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Ping Timeout [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound Play-Prüfung"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Refresh [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [optional]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Timeout [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Play Check"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Refresh [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Cover"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD benutzerdefinierte Breite"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD benutzerdefinierte Höhe"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD-Sonderbreite 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD-Sonderhöhe 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD aus, beim Abschalten"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing ! rechne alle Zeiten um Zeit/5*2 im Schnellmodus"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Verzögerung [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Threads pro LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Zeige Crash Ecke"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Zeige 'keine ....' Mitteilungen"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Speicher-Geräte: erzwinge Lesen"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Speicher-Geräte: Farbe zurück"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Speicher-Geräte: Farbbar"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Speicher-Geräte: Farbe voll"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Netzwerk Check Aktive"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "FramBuffer umschalten [wenn möglich]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Konfig Backup Verz. [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Alle Einstellungen wiederherstellen"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debug-Logging > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Hintergrundbeleuchtung aus [inaktiv bei Aus=Ein]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Hintergrundbeleuchtung Ein"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Hintergrundbeleuchtung am Wochenende aus [inaktiv bei Aus=Ein]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Hintergrundbeleuchtung am Wochenende Ein"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD-Auto-Aus"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Hintergrund"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Bild [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon Größe"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Geteilter Schirm"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Vollbild"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Zeichengröße"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparenz"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon Verzeichnis [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon Verzeichnis 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache Verz. [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Uhrzeit"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "- Typ"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analoguhr"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Abstand"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Größe"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Schattenkanten"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Uhrzeit 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Programm Name"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- maximale Zeilen"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Länge"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Programm Nummer"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Programm Info"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Typ"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Programm Info 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Nächste Programm Info"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Erweiterte Beschreibung"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- benutze Info wenn leer"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Fortschrittsbalken"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Textfarbe"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Umrandung"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Schattiert"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Einheit min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informationen"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Tunerinfo"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensoren"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- Prozessor"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informationen 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Signal Qualität Bar"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Verlauf"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Bar-Bereich Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Bar-Bereich Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satellit"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Provider"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Verwendete Tuner"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- nur aktive Tuner"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Nächste Aufnahme"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Lautstärke"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Stumm"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Online [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Zeige Status"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Timeout [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Online Name:Adresse"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Externe IP Adresse"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- externe IP-URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Speicher-Geräte"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- frei Warnung"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- Zusatzinfo"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Gerätename"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Wettertyp"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Wetter 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo-Wetter Station"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Station"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Modul"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Benutzerdefinierte Module"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Basis"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Name"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Farbe 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Farbe 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Farbe 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Farbe 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Farbe 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Farbe 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Indikator"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Länge [Balken]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Komfort Indikator"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Mondphase"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Infozeilen"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Trendpfeile"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Sonnenaufgang"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Zeige oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Datei [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Zeige ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Zeige Textdatei"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Zeige Textdatei 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Zeige Textdatei 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Zeige HTTP Text"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-Internet Konverter"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP-Breite"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP-Höhe"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Beschneiden ab X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Beschneiden ab Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Breite beschneiden [deaktiviert = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Höhe beschneiden [deaktiviert = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Zeige Bild"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Datei oder Verzeichnis [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Größe max. Höhe"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Schnellaktualisierung"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Zeige Bild 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Zeige Bild 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Zeige Bild 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Zeilen"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Mail-Konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- max Breite"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Remote Box Timer"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Bildgröße"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Bildposition"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Bildausrichtung"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Layout"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Hintergrundfarbe für aktuellen Tag"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Beschriftungsfarbe"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Termine Liste"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Ereignis Icon Bar"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popup Schirm"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Text 1 anzeigen"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Text"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Text 2 anzeigen"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rechteck 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Position x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Position y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Größe x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Größe y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rechteck 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Aufnahme"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stotter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Benutzte Schirme zum Wechsel"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Titel"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Infos"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Zeige Cover"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Suche im Verzeichnis [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Finde Cover-Datei [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Standardcover [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon zuerst"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Getrimmt"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Cover herunterladen"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Downloadtyp"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google-API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Anzeige"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display Modus An"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Setze Medien >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Display Modus Medien Player"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Setze Leerlauf >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display Modus Leerlauf"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Setze Global >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Wähle Verzeichnis"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Wähle Verzeichnis"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Wähle Zeichensatz"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Aktueller Wert: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3845,95 +4078,95 @@ msgstr ""
 "GUI muss für das Aktiveren der Änderungen neu gestartet werden.\n"
 "Soll die GUI jetzt neu gestartet werden?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Neustart GUI jetzt?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Indoor"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Outdoor"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Regen"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Wind"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Neumond"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Erstes Viertel"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Zunehmender Halbmond"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Zunehmender Mond"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Vollmond"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Abnehmender Mond"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Abnehmender Halbmond"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Letztes Viertel"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Bild nicht verfügbar"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "kein Timer"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM läuft nicht"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "keine Anrufe"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d Neu  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "kein Netatmo-Plugin installiert"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Schirm Schalter"
 
@@ -3951,111 +4184,3 @@ msgstr "LCD4linux Schirm Schalter"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Wetter Wind Richtung"
-
-#~ msgid "Backup Config"
-#~ msgstr "Sicherung der Einstellungen"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Boxskin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Crashlog"
-
-#~ msgid "Delete"
-#~ msgstr "Löschen"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Logdatei löschen"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Download Logdatei"
-
-#~ msgid "Element"
-#~ msgstr "Element"
-
-#~ msgid "Exec"
-#~ msgstr "Ausführung"
-
-#~ msgid "Filename"
-#~ msgstr "Dateiname"
-
-#~ msgid "Font"
-#~ msgstr "Zeichensatz"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "GUI Neustart ist notwendig"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "IP Sicherheit durch Box nicht unterstützt"
-
-#~ msgid "Key"
-#~ msgstr "Schlüssel"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Liste der Speichergeräte"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Keine oder eine falsche Datei ausgewählt, wähle zuerst eine richtige Datei !"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Übergeordnetes Verzeichnis"
-
-#~ msgid "Picture"
-#~ msgstr "Bild"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Popup-Text"
-
-#~ msgid "Restore Config"
-#~ msgstr "Wiederherstellung der Einstellungen"
-
-#~ msgid "Save Config"
-#~ msgstr "Speichern der Einstellungen"
-
-#~ msgid "Screen"
-#~ msgstr "Schirm"
-
-#~ msgid "Show"
-#~ msgstr "Zeige"
-
-#~ msgid "Show Externals"
-#~ msgstr "Zeige Externe"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Tuner"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW Konverter"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "kopiere nach Leerlauf"
-
-#~ msgid "copy to Media"
-#~ msgstr "kopiere nach Medien"
-
-#~ msgid "copy to On"
-#~ msgstr "kopiere nach An"
-
-#~ msgid "other"
-#~ msgstr "andere"
-
-#~ msgid "set Settings"
-#~ msgstr "setze Einstellungen"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "Schirmwechsel anhalten"

--- a/LCD4linux/po/en.po
+++ b/LCD4linux/po/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD 4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:04+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:12+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: none\n"
 "Language: en\n"
@@ -16,3831 +16,4064 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Fri"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Mon"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sat"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Font"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Sun"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Key"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Thur"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Tue"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Wed"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Picture"
 
-#: plugin.py:288
-msgid "black"
-msgstr "black"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Popup-Text"
 
-#: plugin.py:288
-msgid "white"
-msgstr "white"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "gray"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Tuner"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "silver"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW Converter"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "slategray"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "aquamarine"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Screen"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "gold"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "greenyellow"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "yellow"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "darkorange"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "darkred"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indianred"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "orange"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "orangered"
-
-#: plugin.py:292
-msgid "red"
-msgstr "red"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomato"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "darkgreen"
-
-#: plugin.py:293
-msgid "green"
-msgstr "green"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "lawngreen"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "lightgreen"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "lime"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "blue"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "blueviolet"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "cadetblue"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "cornflowerblue"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "darkblue"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "lightblue"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "cyan"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "darkorchid"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "deeppink"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violet"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "brown"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "moccasin"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olive"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "rosybrown"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "sandybrown"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Screen 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Screen 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Screen 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Screen 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Screen 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Screen 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Screen 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Screen 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Screen 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Screen 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Screen 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Screen 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Screen 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Screen 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Screen 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Screen 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Screen 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Screen 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Screen 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Screen 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Screen 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Screen 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Screen 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Screen 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Screen 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Screen 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Screen 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Screen 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Screen 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "off"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Screen 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Screen 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Screen 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "on"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (or compatible LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (or compatible LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (or compatible LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (or compatible LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Internal TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Internal Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "only Picture 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "only Picture 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "only Picture 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "only Picture 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "only Picture Custom Size"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "only Picture Custom Size 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Internal Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 Days 1 Line"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 Days 2 Line"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 Days 1 Line"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 Days 2 Lines"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 Days Vertical View"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 Days 1 Line"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 Days 2 Lines"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 Days Vertical View"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Current Temperature (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Current Temperature (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Current"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Current Temperature"
-
-#: plugin.py:317
-msgid "All"
-msgstr "All"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperature"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperature+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperature+Co2+Pressure"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperature+Humidity"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Module 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Module 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Module 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Module 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Module 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Module 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Module 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Module 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Module 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Module 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Module 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Module 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Module 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Module 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Module 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Module 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Module 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Module 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Module 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Module 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Module 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Module 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Module 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "userdefined"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Bar"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Bar+Value"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Knob"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Knob+Value"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analog"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analog+Date"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analog+Date+Weekday"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analog+Date+Weekday 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Date"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Date+Time"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Date+Time+Weekday"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Flaps Design Date"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Flaps Design Weekday"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Time"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Time+Weekday"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Weekday"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "center"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "left"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "right"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Extended"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Extended (Short)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Short"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Short (Extended)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Short+Extended"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Month"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Month+Header"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Week"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Week+Header"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "no Calendar"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Dates 1 Line"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Dates 3 Lines"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Dates 5 Lines"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Dates 9 Lines"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Dates compact 2 Lines"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Dates compact 3 Lines"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "no Dates"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Underline"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Underline 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Frame"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Dates"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Dates compact"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Dates compact no Icon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Dates no Icon"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "no Calls"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "no Icon, with Targetnumber"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "with Icon"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "with Icon & Targetnumber"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "no"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "show run"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "show run+sleep"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Always All"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Always New"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Only New"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "All Informations"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Distance only"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Distance+Illumination"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Distance+Moonphase"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Illumination only"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Illumination+Moonphase"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Moonphase only"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Channel"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Channel+Title"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Channel"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Channel+Title"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "same color"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "yes +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "yes"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "vertically"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontally"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Global"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "all"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Corner"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Corner+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "only Progress Bar"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "with Remaining Minutes"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "with Remaining Minutes (Size 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "with Remaining Minutes (Size 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "with Percent"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "with Percent (Size 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "with Percent (Size 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "with Remaining Minutes (above)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "with Remaining Minutes (above/Size 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "with Remaining Minutes (above/Size 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "with Percent (above)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "with Percent (above/Size 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "with Percent (above/Size 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "with Remaining Minutes (below)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "with Remaining Minutes (below/Size 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "with Remaining Minutes (below/Size 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "with Percent (below)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "with Percent (below/Size 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "with Percent (below/Size 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "with Current 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "with Current 00:00 (Size 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "with Current 00:00 (Size 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "with Current 00:00 (above)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "with Current 00:00 (above/Size 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "with Current 00:00 (above/Size 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "with Current 00:00 (below)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "with Current 00:00 (below/Size 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "with Current 00:00 (below/Size 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "with Percent Minutes / Total (above)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "with Percent Minutes / Total (above/Size 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "with Percent Minutes / Total (above/Size 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "with absolute Endtime"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "with absolute Endtime (Size 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "with absolute Endtime (Size 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "with Minutes Total / Endtime (above)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "with Minutes Total / Endtime (above/Size 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "with Minutes Total / Endtime (above/Size 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Fastmode (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alphabetic"
-
-#: plugin.py:386
-msgid "random"
-msgstr "random"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "better/slow"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "low/fast (Picture only)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "low/fast (all)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + adjustment (high quality, slow)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + adjustment (low quality, fast)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "no cache + no adjustment"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Plug Tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Now/Next"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "reduced"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript no Refresh"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Reload"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - side by side"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternative Copy-Mode/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "yes + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "yes, long"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "yes, short"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Coversearch"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "always"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Media+Standby"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Standby"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "On"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - color"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - grayscale/color"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x FastForwardKey"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x FastForwardKey Type 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Long FastForwardKey"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Long FastForwardKey Type 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x InfoKey"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Mute"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Long InfoKey"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x FastBackwardKey"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x FastBackwardKey Type 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Long FastBackwardKey"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Long FastBackwardKey Type 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "yes, extended"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Console normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Logfile extensive"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Logfile normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "disabled"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (full)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normal (full)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "trimmed (black)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "trimmed (transparent)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE or defined Keys"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "all"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Time+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Time+Duration+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Time+Length+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "half left"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "half right"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Frame x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Line"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "no Bar"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "no Frame"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradient"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Shadow Edges"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Position below"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Position left"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Position right"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Position"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Name"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Offline"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Online"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Online+Offline"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "only use Timer"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "use lead-time"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "no total Timer"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "show total Timer"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "one line"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "two lines"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Memory available"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Memory free"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "full Screen"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "yes except records"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ENE"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "ESE"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "Mute"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NE"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNE"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNW"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NW"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SE"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSE"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSW"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SW"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "W"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "WNW"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "WSW"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Load Active Config-File"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Load Defaults / Empty Config"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Save Config to File... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Load File : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Delete File?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "deleted"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "currently set : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux Settings"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Mode"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Cancel"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Save"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Restart Displays"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Set On >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Idle"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "no LCD1 Picture-File"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "no LCD2 Picture-File"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "no LCD3 Picture-File"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux enabled"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Type"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 Rotate"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Background Color"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Background-Picture [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Brightness"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Night Reduction"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 Refresh"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Type"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Rotate"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Background Color"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Background-Picture [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Brightness"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Night Reduction"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 Refresh"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Type"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Rotate"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Background Color"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Background-Picture [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Brightness"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Night Reduction"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 Refresh"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD Dimension"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Offset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD Color"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD Enable On-Mode"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD Enable Media-Mode"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD Enable Idle-Mode"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [display time]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- which LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Show in Mode"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- OSD Size"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Background/Transparency"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Fast Grab lower quality"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Popup Text"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Clear Key"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Font Size"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Position"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Alignment"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Color"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Background Color"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Font"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Active Screen"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Screen Switch Select - Screen"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Screen Switch Select - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Screens used for Changing"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Screen 1 Changing Time"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Screen 2 Changing Time"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Screen 3 Changing Time"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Screen 4 Changing Time"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Screen 5 Changing Time"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Screen 6 Changing Time"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Screen 7 Changing Time"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Screen 8 Changing Time"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Screen 9 Changing Time"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Picture Changing Time"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Picture Sort"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Picture Directory Recursive"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Picture Quality for Resizing"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Picture Quick Update Time [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Picture Type [only Picture]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Background-Picture Type"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Weather API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Weather API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Weather City"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Weather City 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Weather-Icon-Path [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Weather-Icon Zoom"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Weather Low Temperature Color"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Weather High Temperature Color"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Weather Transparency"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Weather Wind speed unit"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Weather Wind Info Lines"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Weather Rain Chance"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Rain Zoom"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Rain Color"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Rain use Color 2 from"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Rain Color 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Weather Lines"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Weather Trendarrows"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Weather Extra Infos"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra Zoom"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Show chill temperature from difference"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extra Color City"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extra Color Chill"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Min Range"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Max Range"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteo URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Moon-Icon-Path [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Recording Picture [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Double-button switches"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Key for Screen Change"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Key for Screen On/Off"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall Picture Path [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Number of Lines per Entry"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall Number of List Entries"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall Number of Pictures"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall Picture Orientation"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall Picture Transparency"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall Pictures Search"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall remove Calls after hours"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Popup-Time"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall Popup LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Popup Color"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Frame Picture [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Calendar ics-Path [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Calendar ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Calendar planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Calendar Saturday Color"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Calendar Sunday Color"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Calendar Line Thickness"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Calendar Day Event Preview"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Calendar Timezone Correction"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Calendar Transparency"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Calendar Poll Interval"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Tuner Color"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Tuner Color Active"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Tuner Color On"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Service search first"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Signal-Quality Correction"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Font global [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Font 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Font 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Font 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Font 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Font 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 Connect"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 Server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Displayname:]Username"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 Password"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 Connect"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 Server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Displayname:]Username"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 Password"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 Connect"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Displayname:]Username"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 Password"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 Connect"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 Server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Displayname:]Username"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 Password"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 Connect"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 Server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Displayname:]Username"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 Password"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Mail Poll Interval"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Mail IMAP limit to last days"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail Show Empty Mailboxes"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Mail Show Date"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Mail Hide Mailadress"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Remote Box 1 [Displayname:]IP/Name"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Remote Box 2 [Displayname:]IP/Name"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Remote Box 3 [Displayname:]IP/Name"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Remote Box 4 [Displayname:]IP/Name"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Remote Box 5 [Displayname:]IP/Name"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Remote Box Poll every Minutes"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Remote Box Timer [Displayname:]IP/Name"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Remote Box Timer Poll every Minutes"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Converter Poll Interval"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW Converter Usage"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey from cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey from convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF Refresh [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF Refresh Type"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF Init Delay"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP Allow"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP Deny"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF Design"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Save as Picture for WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 enable"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 Port"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 Virtual Brightness"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 enable"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 Port"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 Virtual Brightness"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 enable"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 Port"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 Virtual Brightness"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG Cycle"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Restart on Error"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG Header Mode"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Timeout [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Play Check"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Refresh [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Ping Timeout [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound Play Check"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Refresh [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [optional]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Timeout [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Play Check"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Refresh [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Cover"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD Custom Width"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD Custom Height"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD Custom Width 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD Custom Height 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD Off when shutdown"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Display Delay [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Threads per LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Show Crash Corner"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Show 'no ....' Messages"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Storage-Devices: Force Read"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Storage-Devices: Color Back"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Storage-Devices: Color Bar"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Storage-Devices: Color Full"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Network Check active"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Switch FrameBuffer [if possible]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Config Backup Path [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Config Restore All Settings"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debug-Logging > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Backlight Off [disable set Off=On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Backlight On"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Backlight Weekend Off [disable set Off=On]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Backlight Weekend On"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Auto-OFF"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Background"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Picture [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon Size"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Split Screen"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Full Screen"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Text Size"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparency"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon Path [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon Path 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache Path [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Clock"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Type"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analog Clock"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Spacing"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Size"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Shadow Edges"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Clock 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Program Name"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- maximum Lines"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Length"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Program Number"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Program Info"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Type"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Program Info 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Next Program Info"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Extended Description"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- use Info when empty"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Progress Bar"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Color Text"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Border"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Shaded"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Unit min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informations"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Tunerinfo"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensors"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informations 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Signal Quality Bar"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradient"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Bar Range Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Bar Range Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satellite"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Provider"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Used Tuner"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- only active Tuner"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Next Timer Event"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volume"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Mute"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Online [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Show State"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Timeout [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Online Name:Address"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "External IP Address"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- external IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Storage-Devices"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- free Warning"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- extra Info"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Device Name"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Weather"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Weather Type"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Weather 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo-Weather Station"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Station"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Module"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Module userdefined"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Base"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Name"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Color 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Color 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Color 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Color 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Color 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Color 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Indicator"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Length [Bar]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Comfort Indicator"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Moonphase"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Infolines"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Trendarrows"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Sunrise"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Show oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- File [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Show ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Show Textfile"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Show Textfile 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Show Textfile 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Show HTTP Text"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-Internet Converter"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP Width"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP Height"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Cut from X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Cut from Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Cut Width [disable = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Cut Height [disable = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Show Picture"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- File or Path [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Size max Height"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Quick Update"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Show Picture 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Show Picture 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Show Picture 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Lines"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Mail Konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- max Width"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Remote Box"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Remote Box Timer"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Picture Size"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Picture Position"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Picture Alignment"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Calendar"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP Allow"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "No or wrong File selected, try a correct File first !"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Mode"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "IP security not supported by Box"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Crashlog"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Show"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Delete"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Filename"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Restore Config"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Backup Config"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Delete Logfile"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Download Logfile"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Save Config"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "show total Timer"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Global"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "On"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Idle"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "GUI Restart is required"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Element"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "other"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "set Settings"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "copy to On"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "copy to Media"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "copy to Idle"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Exec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Show Externals"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "List of Storage Devices"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Parent Directory"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Fri"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Mon"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sat"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Sun"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Thur"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Tue"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Wed"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "black"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "white"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "gray"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "silver"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "slategray"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "aquamarine"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "gold"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "greenyellow"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "yellow"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "darkorange"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "darkred"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indianred"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "orange"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "orangered"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "red"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomato"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "darkgreen"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "green"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "lawngreen"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "lightgreen"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "lime"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "blue"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "blueviolet"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "cadetblue"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "cornflowerblue"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "darkblue"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "lightblue"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "cyan"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "darkorchid"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "deeppink"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violet"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "brown"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "moccasin"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olive"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "rosybrown"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "sandybrown"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Screen 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Screen 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Screen 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Screen 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Screen 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Screen 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Screen 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Screen 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Screen 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Screen 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Screen 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Screen 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Screen 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Screen 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Screen 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Screen 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Screen 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Screen 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Screen 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Screen 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Screen 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Screen 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Screen 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Screen 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Screen 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Screen 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Screen 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Screen 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Screen 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "off"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Screen 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Screen 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Screen 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "on"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (or compatible LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (or compatible LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (or compatible LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (or compatible LCD) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Internal Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Internal TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "only Picture 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "only Picture 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "only Picture 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "only Picture 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "only Picture Custom Size"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "only Picture Custom Size 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Internal Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 Days 2 Line"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 Days 2 Lines"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 Days Vertical View"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 Days 2 Lines"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 Days Vertical View"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Current Temperature (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Current Temperature (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Current"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Current Temperature"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "All"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperature"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperature+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperature+Co2+Pressure"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperature+Humidity"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Module 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Module 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Module 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Module 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Module 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Module 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Module 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Module 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Module 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Module 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Module 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Module 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Module 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Module 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Module 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Module 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Module 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Module 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Module 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Module 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Module 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Module 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Module 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "userdefined"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Bar"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Bar+Value"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Knob"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Knob+Value"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analog"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analog+Date"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analog+Date+Weekday"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analog+Date+Weekday 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Date"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Date+Time"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Date+Time+Weekday"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Flaps Design Date"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Flaps Design Weekday"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Time"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Time+Weekday"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Weekday"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "center"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "left"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "right"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Extended"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Extended (Short)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Short"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Short (Extended)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Short+Extended"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Month"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Month+Header"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Week"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Week+Header"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "no Calendar"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Dates 1 Line"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Dates 3 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Dates 5 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Dates 9 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Dates compact 2 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Dates compact 3 Lines"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "no Dates"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Underline"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Underline 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Frame"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Dates"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Dates compact"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Dates compact no Icon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Dates no Icon"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "no Calls"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "no Icon, with Targetnumber"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "with Icon"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "with Icon & Targetnumber"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "no"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "show run"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "show run+sleep"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Always All"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Always New"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Only New"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "All Informations"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Distance only"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Distance+Illumination"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Distance+Moonphase"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Illumination only"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Illumination+Moonphase"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Moonphase only"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Channel"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Channel+Title"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Channel"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Channel+Title"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "same color"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "yes +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "yes"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "vertically"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontally"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "all"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Corner"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Corner+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "only Progress Bar"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "with Remaining Minutes"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "with Remaining Minutes (Size 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "with Remaining Minutes (Size 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "with Percent"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "with Percent (Size 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "with Percent (Size 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "with Remaining Minutes (above)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "with Remaining Minutes (above/Size 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "with Remaining Minutes (above/Size 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "with Percent (above)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "with Percent (above/Size 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "with Percent (above/Size 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "with Remaining Minutes (below)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "with Remaining Minutes (below/Size 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "with Remaining Minutes (below/Size 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "with Percent (below)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "with Percent (below/Size 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "with Percent (below/Size 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "with Current 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "with Current 00:00 (Size 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "with Current 00:00 (Size 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "with Current 00:00 (above)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "with Current 00:00 (above/Size 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "with Current 00:00 (above/Size 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "with Current 00:00 (below)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "with Current 00:00 (below/Size 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "with Current 00:00 (below/Size 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "with Percent Minutes / Total (above)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "with Percent Minutes / Total (above/Size 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "with Percent Minutes / Total (above/Size 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "with absolute Endtime"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "with absolute Endtime (Size 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "with absolute Endtime (Size 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "with Minutes Total / Endtime (above)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "with Minutes Total / Endtime (above/Size 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "with Minutes Total / Endtime (above/Size 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Fastmode (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alphabetic"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "random"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "better/slow"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "low/fast (Picture only)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "low/fast (all)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + adjustment (high quality, slow)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + adjustment (low quality, fast)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "no cache + no adjustment"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Plug Tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Now/Next"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "reduced"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript no Refresh"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Reload"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - side by side"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternative Copy-Mode/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "yes + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "yes, long"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "yes, short"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Coversearch"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "always"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Media+Standby"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Standby"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - color"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - grayscale/color"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x FastForwardKey"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x FastForwardKey Type 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Long FastForwardKey"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Long FastForwardKey Type 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x InfoKey"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Mute"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Long InfoKey"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x FastBackwardKey"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x FastBackwardKey Type 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Long FastBackwardKey"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Long FastBackwardKey Type 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "yes, extended"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Console normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Logfile extensive"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Logfile normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "disabled"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (full)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normal (full)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "trimmed (black)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "trimmed (transparent)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "MUTE or defined Keys"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "all"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Time+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Time+Duration+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Time+Length+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "half left"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "half right"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Frame x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Line"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "no Bar"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "no Frame"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradient"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Shadow Edges"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Position below"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Position left"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Position right"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Position"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Name"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Offline"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Online"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Online+Offline"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "only use Timer"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "use lead-time"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "no total Timer"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "show total Timer"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "one line"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "two lines"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Memory available"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Memory free"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "full Screen"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "yes except records"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ENE"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "ESE"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "Mute"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NE"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNE"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNW"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NW"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SE"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSE"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSW"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SW"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "W"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "WNW"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "WSW"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Load Active Config-File"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Load Defaults / Empty Config"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Save Config to File... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Load File : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Delete File?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "deleted"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "currently set : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux Settings"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Save"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Restart Displays"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Set On >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "no LCD1 Picture-File"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "no LCD2 Picture-File"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "no LCD3 Picture-File"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux enabled"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Type"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 Rotate"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Background Color"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Background-Picture [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Brightness"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Night Reduction"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 Refresh"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Type"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Rotate"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Background Color"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Background-Picture [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Brightness"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Night Reduction"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 Refresh"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Type"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Rotate"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Background Color"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Background-Picture [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Brightness"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Night Reduction"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 Refresh"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD Dimension"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Offset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD Color"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD Enable On-Mode"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD Enable Media-Mode"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD Enable Idle-Mode"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [display time]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- which LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Show in Mode"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- OSD Size"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Background/Transparency"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Fast Grab lower quality"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Popup Text"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Clear Key"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Font Size"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Position"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Alignment"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Color"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Background Color"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Font"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Active Screen"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Screen Switch Select - Screen"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Screen Switch Select - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Screens used for Changing"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Screen 1 Changing Time"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Screen 2 Changing Time"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Screen 3 Changing Time"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Screen 4 Changing Time"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Screen 5 Changing Time"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Screen 6 Changing Time"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Screen 7 Changing Time"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Screen 8 Changing Time"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Screen 9 Changing Time"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Picture Changing Time"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Picture Sort"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Picture Directory Recursive"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Picture Quality for Resizing"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Picture Quick Update Time [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Picture Type [only Picture]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Background-Picture Type"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Weather API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Weather API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Weather City"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Weather City 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Weather-Icon-Path [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Weather-Icon Zoom"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Weather Low Temperature Color"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Weather High Temperature Color"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Weather Transparency"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Weather Wind speed unit"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Weather Wind Info Lines"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Weather Rain Chance"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Rain Zoom"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Rain Color"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Rain use Color 2 from"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Rain Color 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Weather Humidity Color"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Weather Lines"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Weather Trendarrows"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Weather Extra Infos"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra Zoom"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Show chill temperature from difference"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extra Color City"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extra Color Chill"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Min Range"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Max Range"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteo URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Moon-Icon-Path [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Recording Picture [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Double-button switches"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Key for Screen Change"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Key for Screen On/Off"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall Picture Path [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Number of Lines per Entry"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall Number of List Entries"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall Number of Pictures"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall Picture Orientation"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall Picture Transparency"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall Pictures Search"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall remove Calls after hours"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Popup-Time"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall Popup LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Popup Color"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Frame Picture [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Calendar ics-Path [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Calendar ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Calendar planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Calendar Saturday Color"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Calendar Sunday Color"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Calendar Line Thickness"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Calendar Day Event Preview"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Calendar Timezone Correction"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Calendar Transparency"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Calendar Poll Interval"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Tuner Color"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Tuner Color Active"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Tuner Color On"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Service search first"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Signal-Quality Correction"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Font global [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Font 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Font 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Font 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Font 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Font 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 Connect"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 Server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Displayname:]Username"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 Password"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 Connect"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 Server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Displayname:]Username"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 Password"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 Connect"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Displayname:]Username"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 Password"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 Connect"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 Server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Displayname:]Username"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 Password"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 Connect"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 Server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Displayname:]Username"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 Password"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Mail Poll Interval"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Mail IMAP limit to last days"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail Show Empty Mailboxes"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Mail Show Date"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Mail Hide Mailadress"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Remote Box 1 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Remote Box 2 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Remote Box 3 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Remote Box 4 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Remote Box 5 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Remote Box Poll every Minutes"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Remote Box Timer [Displayname:]IP/Name"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Remote Box Timer Poll every Minutes"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Converter Poll Interval"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW Converter Usage"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey from cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey from convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF Refresh [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF Refresh Type"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF Init Delay"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP Deny"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF Design"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Save as Picture for WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 enable"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 Port"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 Virtual Brightness"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 enable"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 Port"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 Virtual Brightness"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 enable"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 Port"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 Virtual Brightness"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG Cycle"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Restart on Error"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG Header Mode"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Timeout [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Play Check"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Refresh [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Ping Timeout [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound Play Check"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Refresh [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [optional]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Timeout [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Play Check"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Refresh [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Cover"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD Custom Width"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD Custom Height"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD Custom Width 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD Custom Height 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD Off when shutdown"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Display Delay [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Threads per LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Show Crash Corner"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Show 'no ....' Messages"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Storage-Devices: Force Read"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Storage-Devices: Color Back"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Storage-Devices: Color Bar"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Storage-Devices: Color Full"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Network Check active"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Switch FrameBuffer [if possible]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Config Backup Path [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Config Restore All Settings"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debug-Logging > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Backlight Off [disable set Off=On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Backlight On"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Backlight Weekend Off [disable set Off=On]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Backlight Weekend On"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Auto-OFF"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Background"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Picture [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon Size"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Split Screen"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Full Screen"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Text Size"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparency"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon Path [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon Path 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache Path [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Clock"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Type"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analog Clock"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Spacing"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Size"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Shadow Edges"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Clock 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Program Name"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- maximum Lines"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Length"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Program Number"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Program Info"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Type"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Program Info 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Next Program Info"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Extended Description"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- use Info when empty"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Progress Bar"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Color Text"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Border"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Shaded"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Unit min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informations"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Tunerinfo"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensors"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informations 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Signal Quality Bar"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradient"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Bar Range Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Bar Range Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satellite"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Provider"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Used Tuner"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- only active Tuner"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Next Timer Event"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volume"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Mute"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Online [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Show State"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Timeout [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Online Name:Address"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "External IP Address"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- external IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Storage-Devices"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- free Warning"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- extra Info"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Device Name"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Weather Type"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Weather 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo-Weather Station"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Station"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Module"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Module userdefined"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Name"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Color 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Color 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Color 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Color 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Color 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Color 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Indicator"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Length [Bar]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Comfort Indicator"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Moonphase"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Infolines"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Trendarrows"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Sunrise"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Show oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- File [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Show ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Show Textfile"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Show Textfile 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Show Textfile 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Show HTTP Text"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-Internet Converter"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP Width"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP Height"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Cut from X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Cut from Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Cut Width [disable = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Cut Height [disable = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Show Picture"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- File or Path [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Size max Height"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Quick Update"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Show Picture 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Show Picture 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Show Picture 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Lines"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Mail Konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- max Width"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Remote Box Timer"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Picture Size"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Picture Position"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Picture Alignment"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Layout"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Current Day Background Color"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Caption Color"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Dates List"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Event Icon Bar"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popup Screen"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Show Text 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Text"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Show Text 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Position x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Position y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Size x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Size y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Recording"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Screens used for Changing"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Title"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Infos"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Show Cover"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Search Path [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Find Cover File [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Default Cover [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon First"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Trimmed"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Download Cover"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Download Type"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Display"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display-Mode On"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Set Media >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Display-Mode MediaPlayer"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Set Idle >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display-Mode Idle"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Set Global >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Choose dir"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Choose file"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Choose font"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Current value: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3848,95 +4081,95 @@ msgstr ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Restart GUI now?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Indoor"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Outdoor"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Rain"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Wind"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "New Moon"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "First Quarter"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Waxing Moon"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Full Moon"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Waning Moon"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Last Quarter"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Picture not available"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "no Timer"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM not running"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "no Calls"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d New  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "no Netatmo-Plugin installed"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Screen Switch"
 
@@ -3954,111 +4187,3 @@ msgstr "LCD4linux Screen Switch"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Weather Wind direction"
-
-#~ msgid "Backup Config"
-#~ msgstr "Backup Config"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Crashlog"
-
-#~ msgid "Delete"
-#~ msgstr "Delete"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Delete Logfile"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Download Logfile"
-
-#~ msgid "Element"
-#~ msgstr "Element"
-
-#~ msgid "Exec"
-#~ msgstr "Exec"
-
-#~ msgid "Filename"
-#~ msgstr "Filename"
-
-#~ msgid "Font"
-#~ msgstr "Font"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "GUI Restart is required"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "IP security not supported by Box"
-
-#~ msgid "Key"
-#~ msgstr "Key"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "List of Storage Devices"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "No or wrong File selected, try a correct File first !"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Parent Directory"
-
-#~ msgid "Picture"
-#~ msgstr "Picture"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Popup-Text"
-
-#~ msgid "Restore Config"
-#~ msgstr "Restore Config"
-
-#~ msgid "Save Config"
-#~ msgstr "Save Config"
-
-#~ msgid "Screen"
-#~ msgstr "Screen"
-
-#~ msgid "Show"
-#~ msgstr "Show"
-
-#~ msgid "Show Externals"
-#~ msgstr "Show Externals"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Tuner"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW Converter"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "copy to Idle"
-
-#~ msgid "copy to Media"
-#~ msgstr "copy to Media"
-
-#~ msgid "copy to On"
-#~ msgstr "copy to On"
-
-#~ msgid "other"
-#~ msgstr "other"
-
-#~ msgid "set Settings"
-#~ msgstr "set Settings"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "show total Timer"

--- a/LCD4linux/po/en_GB.po
+++ b/LCD4linux/po/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD 4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:05+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:12+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: none\n"
 "Language: en_GB\n"
@@ -16,3831 +16,4064 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Fri"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Mon"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sat"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Font"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Sun"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Key"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Thur"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Tue"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Wed"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Picture"
 
-#: plugin.py:288
-msgid "black"
-msgstr "black"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Popup-Text"
 
-#: plugin.py:288
-msgid "white"
-msgstr "white"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "gray"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Tuner"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "silver"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW Converter"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "slategray"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "aquamarine"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Screen"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "gold"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "greenyellow"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "yellow"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "darkorange"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "darkred"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indianred"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "orange"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "orangered"
-
-#: plugin.py:292
-msgid "red"
-msgstr "red"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomato"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "darkgreen"
-
-#: plugin.py:293
-msgid "green"
-msgstr "green"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "lawngreen"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "lightgreen"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "lime"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "blue"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "blueviolet"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "cadetblue"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "cornflowerblue"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "darkblue"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "lightblue"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "cyan"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "darkorchid"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "deeppink"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violet"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "brown"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "moccasin"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olive"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "rosybrown"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "sandybrown"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Screen 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Screen 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Screen 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Screen 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Screen 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Screen 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Screen 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Screen 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Screen 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Screen 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Screen 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Screen 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Screen 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Screen 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Screen 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Screen 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Screen 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Screen 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Screen 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Screen 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Screen 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Screen 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Screen 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Screen 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Screen 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Screen 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Screen 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Screen 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Screen 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "off"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Screen 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Screen 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Screen 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "on"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (or compatible LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (or compatible LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (or compatible LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (or compatible LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Internal TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Internal Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "only Picture 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "only Picture 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "only Picture 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "only Picture 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "only Picture Custom Size"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "only Picture Custom Size 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Internal Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 Days 1 Line"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 Days 2 Line"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 Days 1 Line"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 Days 2 Lines"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 Days Vertical View"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 Days 1 Line"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 Days 2 Lines"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 Days Vertical View"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Current Temperature (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Current Temperature (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Current"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Current Temperature"
-
-#: plugin.py:317
-msgid "All"
-msgstr "All"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperature"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperature+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperature+Co2+Pressure"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperature+Humidity"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Module 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Module 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Module 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Module 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Module 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Module 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Module 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Module 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Module 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Module 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Module 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Module 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Module 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Module 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Module 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Module 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Module 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Module 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Module 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Module 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Module 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Module 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Module 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "userdefined"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Bar"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Bar+Value"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Knob"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Knob+Value"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analog"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analog+Date"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analog+Date+Weekday"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analog+Date+Weekday 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Date"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Date+Time"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Date+Time+Weekday"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Flaps Design Date"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Flaps Design Weekday"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Time"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Time+Weekday"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Weekday"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "center"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "left"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "right"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Extended"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Extended (Short)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Short"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Short (Extended)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Short+Extended"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Month"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Month+Header"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Week"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Week+Header"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "no Calendar"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Dates 1 Line"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Dates 3 Lines"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Dates 5 Lines"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Dates 9 Lines"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Dates compact 2 Lines"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Dates compact 3 Lines"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "no Dates"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Underline"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Underline 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Frame"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Dates"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Dates compact"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Dates compact no Icon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Dates no Icon"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "no Calls"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "no Icon, with Targetnumber"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "with Icon"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "with Icon & Targetnumber"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "no"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "show run"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "show run+sleep"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Always All"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Always New"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Only New"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "All Informations"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Distance only"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Distance+Illumination"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Distance+Moonphase"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Illumination only"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Illumination+Moonphase"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Moonphase only"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Channel"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Channel+Title"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Channel"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Channel+Title"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "same color"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "yes +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "yes"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "vertically"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontally"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Global"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "all"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Corner"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Corner+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "only Progress Bar"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "with Remaining Minutes"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "with Remaining Minutes (Size 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "with Remaining Minutes (Size 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "with Percent"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "with Percent (Size 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "with Percent (Size 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "with Remaining Minutes (above)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "with Remaining Minutes (above/Size 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "with Remaining Minutes (above/Size 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "with Percent (above)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "with Percent (above/Size 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "with Percent (above/Size 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "with Remaining Minutes (below)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "with Remaining Minutes (below/Size 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "with Remaining Minutes (below/Size 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "with Percent (below)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "with Percent (below/Size 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "with Percent (below/Size 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "with Current 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "with Current 00:00 (Size 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "with Current 00:00 (Size 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "with Current 00:00 (above)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "with Current 00:00 (above/Size 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "with Current 00:00 (above/Size 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "with Current 00:00 (below)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "with Current 00:00 (below/Size 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "with Current 00:00 (below/Size 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "with Percent Minutes / Total (above)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "with Percent Minutes / Total (above/Size 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "with Percent Minutes / Total (above/Size 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "with absolute Endtime"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "with absolute Endtime (Size 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "with absolute Endtime (Size 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "with Minutes Total / Endtime (above)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "with Minutes Total / Endtime (above/Size 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "with Minutes Total / Endtime (above/Size 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Fastmode (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alphabetic"
-
-#: plugin.py:386
-msgid "random"
-msgstr "random"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "better/slow"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "low/fast (Picture only)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "low/fast (all)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + adjustment (high quality, slow)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + adjustment (low quality, fast)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "no cache + no adjustment"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Plug Tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Now/Next"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "reduced"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript no Refresh"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Reload"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - side by side"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternative Copy-Mode/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "yes + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "yes, long"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "yes, short"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Coversearch"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "always"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Media+Standby"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Standby"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "On"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - color"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - grayscale/color"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x FastForwardKey"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x FastForwardKey Type 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Long FastForwardKey"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Long FastForwardKey Type 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x InfoKey"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Mute"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Long InfoKey"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x FastBackwardKey"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x FastBackwardKey Type 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Long FastBackwardKey"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Long FastBackwardKey Type 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "yes, extended"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Console normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Logfile extensive"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Logfile normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "disabled"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (full)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normal (full)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "trimmed (black)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "trimmed (transparent)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE or defined Keys"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "all"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Time+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Time+Duration+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Time+Length+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "half left"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "half right"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Frame x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Line"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "no Bar"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "no Frame"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradient"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Shadow Edges"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Position below"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Position left"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Position right"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Position"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Name"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Offline"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Online"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Online+Offline"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "only use Timer"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "use lead-time"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "no total Timer"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "show total Timer"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "one line"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "two lines"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Memory available"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Memory free"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "full Screen"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "yes except records"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ENE"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "ESE"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "Mute"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NE"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNE"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNW"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NW"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SE"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSE"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSW"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SW"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "W"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "WNW"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "WSW"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Load Active Config-File"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Load Defaults / Empty Config"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Save Config to File... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Load File : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Delete File?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "deleted"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "currently set : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux Settings"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Mode"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Cancel"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Save"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Restart Displays"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Set On >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Idle"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "no LCD1 Picture-File"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "no LCD2 Picture-File"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "no LCD3 Picture-File"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux enabled"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Type"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 Rotate"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Background Color"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Background-Picture [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Brightness"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Night Reduction"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 Refresh"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Type"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Rotate"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Background Color"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Background-Picture [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Brightness"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Night Reduction"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 Refresh"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Type"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Rotate"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Background Color"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Background-Picture [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Brightness"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Night Reduction"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 Refresh"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD Dimension"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Offset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD Color"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD Enable On-Mode"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD Enable Media-Mode"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD Enable Idle-Mode"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [display time]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- which LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Show in Mode"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- OSD Size"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Background/Transparency"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Fast Grab lower quality"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Popup Text"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Clear Key"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Font Size"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Position"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Alignment"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Color"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Background Color"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Font"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Active Screen"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Screen Switch Select - Screen"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Screen Switch Select - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Screens used for Changing"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Screen 1 Changing Time"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Screen 2 Changing Time"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Screen 3 Changing Time"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Screen 4 Changing Time"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Screen 5 Changing Time"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Screen 6 Changing Time"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Screen 7 Changing Time"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Screen 8 Changing Time"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Screen 9 Changing Time"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Picture Changing Time"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Picture Sort"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Picture Directory Recursive"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Picture Quality for Resizing"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Picture Quick Update Time [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Picture Type [only Picture]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Background-Picture Type"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Weather API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Weather API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Weather City"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Weather City 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Weather-Icon-Path [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Weather-Icon Zoom"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Weather Low Temperature Color"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Weather High Temperature Color"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Weather Transparency"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Weather Wind speed unit"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Weather Wind Info Lines"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Weather Rain Chance"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Rain Zoom"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Rain Color"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Rain use Color 2 from"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Rain Color 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Weather Lines"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Weather Trendarrows"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Weather Extra Infos"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra Zoom"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Show chill temperature from difference"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extra Color City"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extra Color Chill"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Min Range"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Max Range"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteo URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Moon-Icon-Path [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Recording Picture [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Double-button switches"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Key for Screen Change"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Key for Screen On/Off"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall Picture Path [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Number of Lines per Entry"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall Number of List Entries"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall Number of Pictures"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall Picture Orientation"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall Picture Transparency"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall Pictures Search"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall remove Calls after hours"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Popup-Time"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall Popup LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Popup Color"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Frame Picture [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Calendar ics-Path [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Calendar ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Calendar planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Calendar Saturday Color"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Calendar Sunday Color"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Calendar Line Thickness"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Calendar Day Event Preview"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Calendar Timezone Correction"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Calendar Transparency"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Calendar Poll Interval"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Tuner Color"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Tuner Color Active"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Tuner Color On"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Service search first"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Signal-Quality Correction"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Font global [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Font 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Font 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Font 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Font 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Font 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 Connect"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 Server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Displayname:]Username"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 Password"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 Connect"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 Server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Displayname:]Username"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 Password"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 Connect"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Displayname:]Username"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 Password"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 Connect"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 Server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Displayname:]Username"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 Password"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 Connect"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 Server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Displayname:]Username"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 Password"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Mail Poll Interval"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Mail IMAP limit to last days"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail Show Empty Mailboxes"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Mail Show Date"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Mail Hide Mailadress"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Remote Box 1 [Displayname:]IP/Name"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Remote Box 2 [Displayname:]IP/Name"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Remote Box 3 [Displayname:]IP/Name"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Remote Box 4 [Displayname:]IP/Name"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Remote Box 5 [Displayname:]IP/Name"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Remote Box Poll every Minutes"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Remote Box Timer [Displayname:]IP/Name"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Remote Box Timer Poll every Minutes"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Converter Poll Interval"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW Converter Usage"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey from cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey from convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF Refresh [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF Refresh Type"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF Init Delay"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP Allow"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP Deny"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF Design"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Save as Picture for WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 enable"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 Port"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 Virtual Brightness"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 enable"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 Port"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 Virtual Brightness"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 enable"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 Port"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 Virtual Brightness"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG Cycle"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Restart on Error"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG Header Mode"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Timeout [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Play Check"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Refresh [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Ping Timeout [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound Play Check"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Refresh [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [optional]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Timeout [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Play Check"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Refresh [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Cover"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD Custom Width"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD Custom Height"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD Custom Width 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD Custom Height 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD Off when shutdown"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Display Delay [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Threads per LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Show Crash Corner"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Show 'no ....' Messages"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Storage-Devices: Force Read"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Storage-Devices: Color Back"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Storage-Devices: Color Bar"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Storage-Devices: Color Full"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Network Check active"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Switch FrameBuffer [if possible]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Config Backup Path [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Config Restore All Settings"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debug-Logging > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Backlight Off [disable set Off=On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Backlight On"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Backlight Weekend Off [disable set Off=On]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Backlight Weekend On"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Auto-OFF"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Background"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Picture [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon Size"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Split Screen"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Full Screen"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Text Size"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparency"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon Path [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon Path 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache Path [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Clock"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Type"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analog Clock"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Spacing"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Size"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Shadow Edges"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Clock 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Program Name"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- maximum Lines"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Length"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Program Number"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Program Info"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Type"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Program Info 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Next Program Info"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Extended Description"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- use Info when empty"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Progress Bar"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Color Text"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Border"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Shaded"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Unit min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informations"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Tunerinfo"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensors"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informations 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Signal Quality Bar"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradient"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Bar Range Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Bar Range Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satellite"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Provider"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Used Tuner"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- only active Tuner"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Next Timer Event"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volume"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Mute"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Online [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Show State"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Timeout [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Online Name:Address"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "External IP Address"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- external IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Storage-Devices"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- free Warning"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- extra Info"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Device Name"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Weather"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Weather Type"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Weather 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo-Weather Station"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Station"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Module"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Module userdefined"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Base"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Name"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Color 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Color 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Color 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Color 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Color 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Color 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Indicator"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Length [Bar]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Comfort Indicator"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Moonphase"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Infolines"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Trendarrows"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Sunrise"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Show oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- File [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Show ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Show Textfile"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Show Textfile 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Show Textfile 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Show HTTP Text"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-Internet Converter"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP Width"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP Height"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Cut from X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Cut from Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Cut Width [disable = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Cut Height [disable = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Show Picture"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- File or Path [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Size max Height"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Quick Update"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Show Picture 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Show Picture 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Show Picture 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Lines"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Mail Konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- max Width"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Remote Box"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Remote Box Timer"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Picture Size"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Picture Position"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Picture Alignment"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Calendar"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP Allow"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "No or wrong File selected, try a correct File first !"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Mode"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "IP security not supported by Box"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Crashlog"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Show"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Delete"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Filename"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Restore Config"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Backup Config"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Delete Logfile"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Download Logfile"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Save Config"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "show total Timer"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Global"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "On"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Idle"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "GUI Restart is required"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Element"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "other"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "set Settings"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "copy to On"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "copy to Media"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "copy to Idle"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Exec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Show Externals"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "List of Storage Devices"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Parent Directory"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Fri"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Mon"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sat"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Sun"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Thur"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Tue"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Wed"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "black"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "white"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "gray"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "silver"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "slategray"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "aquamarine"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "gold"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "greenyellow"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "yellow"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "darkorange"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "darkred"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indianred"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "orange"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "orangered"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "red"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomato"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "darkgreen"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "green"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "lawngreen"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "lightgreen"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "lime"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "blue"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "blueviolet"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "cadetblue"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "cornflowerblue"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "darkblue"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "lightblue"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "cyan"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "darkorchid"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "deeppink"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violet"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "brown"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "moccasin"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olive"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "rosybrown"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "sandybrown"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Screen 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Screen 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Screen 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Screen 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Screen 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Screen 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Screen 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Screen 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Screen 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Screen 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Screen 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Screen 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Screen 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Screen 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Screen 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Screen 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Screen 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Screen 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Screen 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Screen 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Screen 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Screen 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Screen 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Screen 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Screen 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Screen 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Screen 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Screen 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Screen 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "off"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Screen 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Screen 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Screen 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "on"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (or compatible LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (or compatible LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (or compatible LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (or compatible LCD) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Internal Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Internal TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "only Picture 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "only Picture 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "only Picture 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "only Picture 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "only Picture Custom Size"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "only Picture Custom Size 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Internal Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 Days 2 Line"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 Days 2 Lines"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 Days Vertical View"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 Days 2 Lines"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 Days Vertical View"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Current Temperature (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Current Temperature (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Current"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Current Temperature"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "All"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperature"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperature+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperature+Co2+Pressure"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperature+Humidity"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Module 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Module 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Module 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Module 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Module 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Module 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Module 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Module 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Module 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Module 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Module 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Module 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Module 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Module 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Module 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Module 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Module 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Module 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Module 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Module 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Module 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Module 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Module 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "userdefined"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Bar"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Bar+Value"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Knob"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Knob+Value"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analog"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analog+Date"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analog+Date+Weekday"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analog+Date+Weekday 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Date"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Date+Time"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Date+Time+Weekday"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Flaps Design Date"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Flaps Design Weekday"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Time"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Time+Weekday"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Weekday"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "center"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "left"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "right"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Extended"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Extended (Short)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Short"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Short (Extended)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Short+Extended"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Month"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Month+Header"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Week"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Week+Header"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "no Calendar"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Dates 1 Line"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Dates 3 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Dates 5 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Dates 9 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Dates compact 2 Lines"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Dates compact 3 Lines"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "no Dates"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Underline"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Underline 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Frame"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Dates"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Dates compact"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Dates compact no Icon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Dates no Icon"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "no Calls"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "no Icon, with Targetnumber"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "with Icon"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "with Icon & Targetnumber"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "no"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "show run"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "show run+sleep"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Always All"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Always New"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Only New"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "All Informations"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Distance only"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Distance+Illumination"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Distance+Moonphase"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Illumination only"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Illumination+Moonphase"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Moonphase only"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Channel"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Channel+Title"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Channel"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Channel+Title"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "same color"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "yes +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "yes"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "vertically"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontally"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "all"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Corner"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Corner+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "only Progress Bar"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "with Remaining Minutes"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "with Remaining Minutes (Size 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "with Remaining Minutes (Size 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "with Percent"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "with Percent (Size 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "with Percent (Size 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "with Remaining Minutes (above)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "with Remaining Minutes (above/Size 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "with Remaining Minutes (above/Size 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "with Percent (above)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "with Percent (above/Size 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "with Percent (above/Size 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "with Remaining Minutes (below)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "with Remaining Minutes (below/Size 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "with Remaining Minutes (below/Size 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "with Percent (below)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "with Percent (below/Size 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "with Percent (below/Size 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "with Current 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "with Current 00:00 (Size 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "with Current 00:00 (Size 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "with Current 00:00 (above)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "with Current 00:00 (above/Size 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "with Current 00:00 (above/Size 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "with Current 00:00 (below)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "with Current 00:00 (below/Size 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "with Current 00:00 (below/Size 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "with Percent Minutes / Total (above)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "with Percent Minutes / Total (above/Size 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "with Percent Minutes / Total (above/Size 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "with absolute Endtime"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "with absolute Endtime (Size 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "with absolute Endtime (Size 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "with Minutes Total / Endtime (above)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "with Minutes Total / Endtime (above/Size 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "with Minutes Total / Endtime (above/Size 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Fastmode (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alphabetic"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "random"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "better/slow"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "low/fast (Picture only)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "low/fast (all)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + adjustment (high quality, slow)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + adjustment (low quality, fast)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "no cache + no adjustment"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Plug Tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Now/Next"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "reduced"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript no Refresh"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Reload"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - side by side"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternative Copy-Mode/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "yes + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "yes, long"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "yes, short"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Coversearch"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "always"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Media+Standby"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Standby"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - color"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - grayscale/color"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x FastForwardKey"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x FastForwardKey Type 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Long FastForwardKey"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Long FastForwardKey Type 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x InfoKey"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Mute"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Long InfoKey"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x FastBackwardKey"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x FastBackwardKey Type 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Long FastBackwardKey"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Long FastBackwardKey Type 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "yes, extended"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Console normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Logfile extensive"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Logfile normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "disabled"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (full)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normal (full)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "trimmed (black)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "trimmed (transparent)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "MUTE or defined Keys"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "all"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Time+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Time+Duration+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Time+Length+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "half left"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "half right"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Frame x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Line"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "no Bar"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "no Frame"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradient"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Shadow Edges"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Position below"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Position left"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Position right"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Position"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Name"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Offline"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Online"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Online+Offline"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "only use Timer"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "use lead-time"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "no total Timer"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "show total Timer"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "one line"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "two lines"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Memory available"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Memory free"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "full Screen"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "yes except records"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ENE"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "ESE"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "Mute"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NE"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNE"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNW"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NW"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SE"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSE"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSW"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SW"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "W"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "WNW"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "WSW"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Load Active Config-File"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Load Defaults / Empty Config"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Save Config to File... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Load File : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Delete File?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "deleted"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "currently set : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux Settings"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Save"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Restart Displays"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Set On >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "no LCD1 Picture-File"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "no LCD2 Picture-File"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "no LCD3 Picture-File"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux enabled"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Type"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 Rotate"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Background Color"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Background-Picture [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Brightness"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Night Reduction"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 Refresh"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Type"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Rotate"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Background Color"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Background-Picture [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Brightness"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Night Reduction"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 Refresh"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Type"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Rotate"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Background Color"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Background-Picture [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Brightness"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Night Reduction"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 Refresh"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD Dimension"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Offset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD Color"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD Enable On-Mode"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD Enable Media-Mode"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD Enable Idle-Mode"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [display time]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- which LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Show in Mode"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- OSD Size"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Background/Transparency"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Fast Grab lower quality"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Popup Text"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Clear Key"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Font Size"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Position"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Alignment"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Color"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Background Color"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Font"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Active Screen"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Screen Switch Select - Screen"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Screen Switch Select - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Screens used for Changing"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Screen 1 Changing Time"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Screen 2 Changing Time"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Screen 3 Changing Time"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Screen 4 Changing Time"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Screen 5 Changing Time"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Screen 6 Changing Time"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Screen 7 Changing Time"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Screen 8 Changing Time"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Screen 9 Changing Time"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Picture Changing Time"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Picture Sort"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Picture Directory Recursive"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Picture Quality for Resizing"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Picture Quick Update Time [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Picture Type [only Picture]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Background-Picture Type"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Weather API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Weather API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Weather City"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Weather City 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Weather-Icon-Path [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Weather-Icon Zoom"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Weather Low Temperature Color"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Weather High Temperature Color"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Weather Transparency"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Weather Wind speed unit"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Weather Wind Info Lines"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Weather Rain Chance"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Rain Zoom"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Rain Color"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Rain use Color 2 from"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Rain Color 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Weather Humidity Color"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Weather Lines"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Weather Trendarrows"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Weather Extra Infos"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra Zoom"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Show chill temperature from difference"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extra Color City"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extra Color Chill"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Min Range"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Max Range"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteo URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Moon-Icon-Path [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Recording Picture [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Double-button switches"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Key for Screen Change"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Key for Screen On/Off"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall Picture Path [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Number of Lines per Entry"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall Number of List Entries"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall Number of Pictures"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall Picture Orientation"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall Picture Transparency"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall Pictures Search"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall remove Calls after hours"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Popup-Time"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall Popup LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Popup Color"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Frame Picture [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Calendar ics-Path [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Calendar ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Calendar planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Calendar Saturday Color"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Calendar Sunday Color"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Calendar Line Thickness"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Calendar Day Event Preview"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Calendar Timezone Correction"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Calendar Transparency"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Calendar Poll Interval"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Tuner Color"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Tuner Color Active"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Tuner Color On"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Service search first"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Signal-Quality Correction"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Font global [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Font 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Font 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Font 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Font 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Font 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 Connect"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 Server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Displayname:]Username"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 Password"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 Connect"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 Server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Displayname:]Username"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 Password"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 Connect"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Displayname:]Username"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 Password"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 Connect"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 Server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Displayname:]Username"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 Password"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 Connect"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 Server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Displayname:]Username"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 Password"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Mail Poll Interval"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Mail IMAP limit to last days"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail Show Empty Mailboxes"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Mail Show Date"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Mail Hide Mailadress"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Remote Box 1 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Remote Box 2 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Remote Box 3 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Remote Box 4 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Remote Box 5 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Remote Box Poll every Minutes"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Remote Box Timer [Displayname:]IP/Name"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Remote Box Timer Poll every Minutes"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Converter Poll Interval"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW Converter Usage"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey from cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey from convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF Refresh [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF Refresh Type"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF Init Delay"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP Deny"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF Design"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Save as Picture for WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 enable"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 Port"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 Virtual Brightness"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 enable"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 Port"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 Virtual Brightness"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 enable"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 Port"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 Virtual Brightness"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG Cycle"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Restart on Error"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG Header Mode"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Timeout [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Play Check"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Refresh [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Ping Timeout [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound Play Check"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Refresh [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [optional]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Timeout [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Play Check"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Refresh [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Cover"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD Custom Width"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD Custom Height"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD Custom Width 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD Custom Height 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD Off when shutdown"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Display Delay [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Threads per LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Show Crash Corner"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Show 'no ....' Messages"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Storage-Devices: Force Read"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Storage-Devices: Color Back"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Storage-Devices: Color Bar"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Storage-Devices: Color Full"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Network Check active"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Switch FrameBuffer [if possible]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Config Backup Path [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Config Restore All Settings"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debug-Logging > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Backlight Off [disable set Off=On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Backlight On"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Backlight Weekend Off [disable set Off=On]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Backlight Weekend On"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Auto-OFF"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Background"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Picture [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon Size"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Split Screen"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Full Screen"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Text Size"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparency"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon Path [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon Path 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache Path [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Clock"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Type"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analog Clock"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Spacing"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Size"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Shadow Edges"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Clock 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Program Name"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- maximum Lines"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Length"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Program Number"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Program Info"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Type"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Program Info 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Next Program Info"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Extended Description"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- use Info when empty"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Progress Bar"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Color Text"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Border"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Shaded"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Unit min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informations"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Tunerinfo"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensors"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informations 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Signal Quality Bar"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradient"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Bar Range Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Bar Range Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satellite"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Provider"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Used Tuner"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- only active Tuner"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Next Timer Event"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volume"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Mute"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Online [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Show State"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Timeout [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Online Name:Address"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "External IP Address"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- external IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Storage-Devices"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- free Warning"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- extra Info"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Device Name"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Weather Type"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Weather 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo-Weather Station"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Station"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Module"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Module userdefined"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Name"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Color 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Color 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Color 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Color 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Color 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Color 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Indicator"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Length [Bar]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Comfort Indicator"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Moonphase"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Infolines"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Trendarrows"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Sunrise"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Show oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- File [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Show ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Show Textfile"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Show Textfile 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Show Textfile 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Show HTTP Text"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-Internet Converter"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP Width"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP Height"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Cut from X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Cut from Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Cut Width [disable = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Cut Height [disable = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Show Picture"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- File or Path [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Size max Height"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Quick Update"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Show Picture 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Show Picture 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Show Picture 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Lines"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Mail Konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- max Width"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Remote Box Timer"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Picture Size"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Picture Position"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Picture Alignment"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Layout"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Current Day Background Color"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Caption Color"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Dates List"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Event Icon Bar"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popup Screen"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Show Text 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Text"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Show Text 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Position x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Position y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Size x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Size y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Recording"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Screens used for Changing"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Title"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Infos"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Show Cover"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Search Path [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Find Cover File [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Default Cover [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon First"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Trimmed"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Download Cover"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Download Type"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Display"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display-Mode On"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Set Media >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Display-Mode MediaPlayer"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Set Idle >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display-Mode Idle"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Set Global >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Choose dir"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Choose file"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Choose font"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Current value: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3848,95 +4081,95 @@ msgstr ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Restart GUI now?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Indoor"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Outdoor"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Rain"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Wind"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "New Moon"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "First Quarter"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Waxing Moon"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Full Moon"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Waning Moon"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Last Quarter"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Picture not available"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "no Timer"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM not running"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "no Calls"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d New  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "no Netatmo-Plugin installed"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Screen Switch"
 
@@ -3954,111 +4187,3 @@ msgstr "LCD4linux Screen Switch"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Weather Wind direction"
-
-#~ msgid "Backup Config"
-#~ msgstr "Backup Config"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Crashlog"
-
-#~ msgid "Delete"
-#~ msgstr "Delete"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Delete Logfile"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Download Logfile"
-
-#~ msgid "Element"
-#~ msgstr "Element"
-
-#~ msgid "Exec"
-#~ msgstr "Exec"
-
-#~ msgid "Filename"
-#~ msgstr "Filename"
-
-#~ msgid "Font"
-#~ msgstr "Font"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "GUI Restart is required"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "IP security not supported by Box"
-
-#~ msgid "Key"
-#~ msgstr "Key"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "List of Storage Devices"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "No or wrong File selected, try a correct File first !"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Parent Directory"
-
-#~ msgid "Picture"
-#~ msgstr "Picture"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Popup-Text"
-
-#~ msgid "Restore Config"
-#~ msgstr "Restore Config"
-
-#~ msgid "Save Config"
-#~ msgstr "Save Config"
-
-#~ msgid "Screen"
-#~ msgstr "Screen"
-
-#~ msgid "Show"
-#~ msgstr "Show"
-
-#~ msgid "Show Externals"
-#~ msgstr "Show Externals"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Tuner"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW Converter"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "copy to Idle"
-
-#~ msgid "copy to Media"
-#~ msgstr "copy to Media"
-
-#~ msgid "copy to On"
-#~ msgstr "copy to On"
-
-#~ msgid "other"
-#~ msgstr "other"
-
-#~ msgid "set Settings"
-#~ msgstr "set Settings"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "show total Timer"

--- a/LCD4linux/po/es.po
+++ b/LCD4linux/po/es.po
@@ -2,3839 +2,4072 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:06+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:13+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: OpenPlus\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Vie"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Lun"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "LCD Box-Skin"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sáb"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Fuente"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Dom"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Tecla"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Jue"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Mar"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Mié"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Imagen"
 
-#: plugin.py:288
-msgid "black"
-msgstr "negro"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Texto Emergente"
 
-#: plugin.py:288
-msgid "white"
-msgstr "blanco"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "gris"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Sintonizador"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "plateado"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "Convertidor WWW"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "grispizarra"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "aguamarina"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Pantalla"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "dorado"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "verdeamarillo"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "amarillo"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "naranjaoscuro"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "rojooscuro"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "pielroja"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "naranja"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "rojoanaranjado"
-
-#: plugin.py:292
-msgid "red"
-msgstr "rojo"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomate"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "verdeoscuro"
-
-#: plugin.py:293
-msgid "green"
-msgstr "verde"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "verdecésped"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "verdeclaro"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "lima"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "azul"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "azulvioleta"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "azul cadete"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "azul aciano"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "azul oscuro"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "azul índigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "celeste"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "cián"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "orquídea oscuro"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "rosa oscuro"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violeta"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "marrón"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "mocasín"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "verde oliva"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "marrón rosado"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "marrón arena"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Pantallas 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Pantallas 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Pantallas 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Pantallas 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Pantallas 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Pantallas 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Pantallas 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Pantallas 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Pantallas 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Pantallas 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Pantallas 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Pantallas 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Pantallas 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Pantallas 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Pantallas 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Pantallas 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Pantallas 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Pantallas 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Pantallas 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Pantallas 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Pantalla 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Pantalla 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Pantalla 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Pantalla 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Pantalla 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Pantalla 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Pantalla 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Pantalla 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Pantalla 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "off"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Pantallas 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Pantallas 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Pantallas 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "on"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (o LCD compatible) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (o LCD compatible) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (o LCD compatible) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (o LCD compatible) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "TFT-LCD interno 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "LCD Box-Skin interno"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "sólo Imágenes 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "sólo Imágenes 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "sólo Imágenes 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "sólo Imágenes 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "sólo Imágenes de tamaño configurable"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "sólo Imágenes de tamaño configurable"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "LCD interno Vu+ Duo2 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 Dias 1 Linea"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 Dias 2 Lineas"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 Dias 1 Linea"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 Dias 2 Lineas"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 días vista vertical"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 Dias 1 Linea"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 Dias 2 Lineas"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 días vista vertical"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Temperatura actual (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Temperatura actual (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Ahora"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Temperatura actual"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Todo"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperatura"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperatura+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperatura+Co2+Presión"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperatura+Humedad"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Módulo 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Módulos 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Módulos 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Módulos 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Módulos 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Módulos 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Módulos 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Módulos 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Módulos 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Módulos 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Módulo 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Módulos 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Módulos 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Módulos 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Módulo 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Módulo 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Módulos 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Módulo 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Módulo 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Módulo 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Módulo 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Módulo 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Módulo 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "definido por el usuario"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Pre"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Pre+Valor"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Knob"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Knob+Valor"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analógico"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analógico+Fecha"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analógico+Fecha+Día de la Semana"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analógico+Fecha+Día de la Semana 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Fecha"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Fecha+Hora"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Fecha+Hora+Día de la Semana"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Diseño Etiqueta Fecha"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Diseño Etiqueta Dia de la Semana"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Hora"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Hora+Día de la Semana"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Día de la Semana"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "centro"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "izquierda"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "derecha"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Extendido"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Extendido (Corto)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Corto"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Corto (Extendido)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Corto+Extendido"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Mes"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Mes+Cabecera"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Semana"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Semana+Cabecera"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "sin Calendario"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Fechas 1 Línea"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Fechas 3 Líneas"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Fechas 5 Líneas"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Fechas 9 Líneas"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Fechas compactas en 2 Líneas"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Fechas compactas en 3 Líneas"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "sin Fechas"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Debajo de Línea"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Debajo de Línea 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Marco"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Fechas"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Fechas compactas"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Fechas compactas sin icono"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Fechas sin icono"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "sin Icono"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "sin Icono, con Número de Destino"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "con Icono"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "con Icono & Número de Destino"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "no"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "mostrar carrera"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "mostrar carrera+sueño"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Siempre Todo"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Siempre lo Nuevo"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Sólo lo Nuevo"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Todas las Informaciones"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "solo distancia"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Distancia+Iluminación"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Distancia+Fase lunar"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "solo Iluminación"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Iluminación+Fase lunar"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "solo Fase lunar"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Canal"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Canal+Título"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Canal"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Canal+Título"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "el mismo color"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "sí+25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "sí"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "verticalmente"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontalmente"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Global"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "todo"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Esquina"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Esquina+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "sólo Barra de Progreso"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "con Minutos Restantes"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "con Minutos Restantes (Tamaño 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "con Minutos Restantes (Tamaño 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "con Porcentaje"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "con Porcentaje (Tamaño 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "con Porcentaje (Tamaño 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "con Minutos Restantes (arriba)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "con Minutos Restantes (arriba/Tamaño 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "con Minutos Restantes (arriba/Tamaño 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "con Porcentaje (arriba)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "con Porcentaje (arriba/Tamaño 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "con Porcentaje (arriba/Tamaño 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "con Minutos Restantes (debajo)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "con Minutos Restantes (debajo/Tamaño 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "con Minutos Restantes (debajo/Tamaño 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "con Porcentaje (debajo)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "con Porcentaje (debajo/Tamaño 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "con Porcentaje (debajo/Tamaño 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "con el Actual 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "con el Actual 00:00 (Tamaño 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "con el Actual 00:00 (Tamaño 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "con el Actual 00:00 (arriba)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "con el Actual 00:00 (arriba/Tamaño 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "con el Actual 00:00 (arriba/Tamaño 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "con el Actual 00:00 (debajo)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "con el Actual 00:00 (debajo/Tamaño 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "con el Actual 00:00 (debajo/Tamaño 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "con Porcentaje de Minutos / Total (arriba)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "con Porcentaje de Minutos / Total (arriba/Tamaño 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "con Porcentaje de Minutos / Total (arriba/Tamaño 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "con el tiempo del fin absoluto"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "con el tiempo del fin absoluto (Tamaño 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "con el tiempo del fin absoluto (Tamaño 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "con Minutos Totales / Hora de finalización (arriba)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "con Minutos Totales / Hora de finalización (arriba/Tamaño 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "con Minutos Totales / Hora de finalización (arriba/Tamaño 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Modo Rápido (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alfabético"
-
-#: plugin.py:386
-msgid "random"
-msgstr "aleatorio"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "mejor/lento"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "bajo/rápido (solo Fotos)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "bajo/rápido (todo)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + ajuste (alta calidad, lento)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + ajuste (baja calidad, rápido)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "sin cache + sin ajuste"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Sintonizador integrado"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "Sintonizador USB"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Ahora/Después"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "reducido"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript sin actualización"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Recarga"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - cara a cara"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "modo Copia alternativo/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "sí + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "sí, largo"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "sí, corto"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Búsqueda Cubrir"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "siempre"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Media+Reposo"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Reposo"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "On"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - color"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - gris/color"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x Tecla Avance Rápido"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x Tecla Avance Rápido Tipo 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Tecla Avance Rápido Prolongada"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Tecla Avance Rápido Prolongada Tipo 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Tecla Info"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Silencio"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Tecla Info Prolongada"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x Tecla Retroceso Rápido"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x Tecla Retroceso Rápido Tipo 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Tecla Retroceso Rápido Prolongada"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Tecla Retroceso Rápido largo Tipo 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "sí, extendido"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Consola normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Archivo de log extenso"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Archivo de log normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "deshabilitado"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (completo)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normal (completo)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "ajustado (negro)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "ajustado (transparente)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "Silencio o teclas definidas"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "cualquier Tecla"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Hora+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Hora+Duración+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Hora+Duración+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "mitad izquierda"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "mitad derecha"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Marco x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Línea"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "sin Barra"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "sin Marco"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradiente"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Bordes de Sombra"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Posición debajo"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Posición izquierda"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Posición derecha"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Posición"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Nombre"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Desconectado"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Conectado"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Conectado+Desconectado"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "usar sólo Temporizador"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "usar hora principal"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "sin Temporizador completo"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "mostrar Temporizador completo"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "una línea"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "dos líneas"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Memoria disponible"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Memoria libre"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "a toda pantalla"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "sí, excepto grabaciones"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ENE"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "ESE"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NE"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNE"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNO"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NO"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SE"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSE"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSO"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SO"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "O"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "ONO"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "OSO"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Cargar Archivo de Configuración Activo"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Cargar por defecto / Configuración vacía"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Salvar Configuración al Archivo...(%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Cargar Archivo : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Borrar Archivo?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "borrado"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "ajuste actual : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "Ajustes de LCD4linux"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Modo"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Salvar"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Reiniciar Pantallas"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Ir a On >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "En Reposo"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "no hay Archivo de Imagen de LCD1"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "no hay Archivo de Imagen de LCD2"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "no hay Archivo de Imagen de LCD3"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux activado"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "Tipo LCD 1"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- Rotar LCD 1"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- Color de Fondo LCD 1"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- Fondo-Imagen LCD 1 [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- Brillo LCD 1"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- Reducción Nocturna LCD 1"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- Refrescar LCD 1"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "Tipo LCD 2"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- Rotar LCD 2"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- Color de Fondo LCD 2"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- Fondo-Imagen LCD 2 [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- Brillo LCD 2"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- Reducción Nocturna LCD 2"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- Refrescar LCD 2"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "Tipo LCD 3"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- Rotar LCD 3"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- Color de Fondo LCD 3"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- Fondo-Imagen LCD 3 [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- Brillo LCD 3"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- Reducción Nocturna LCD 3"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- Refrescar LCD 3"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Tamaño LCD Box-Skin"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Offset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Color LCD Box-Skin"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Activar Modo On LCD Box-Skin"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Activar Modo Media LCD Box-Skin"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Activar Modo Apagado LCD Box-Skin"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [hora en pantalla]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- qué LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Mostrar en Modo"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Tamaño OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Fondo/Transparencia"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Grabador Rápido baja calidad"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Texto Emergente"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Clave clara"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Tamaño de Fuente"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Posición"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Alineamiento"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Color"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Color de Fondo"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Fuente"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Pantalla Activa"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Seleccionar pantalla a Cambiar - Pantalla"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Seleccionar pantalla a Cambiar - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Pantallas usadas para los cambios"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Tiempo de cambio Pantalla 1"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 2"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 3"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 4"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 5"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 6"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 7"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 8"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Tiempo de cambio Pantalla 9"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Tiempo de cambio Imagen"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Imágenes aleatorias"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Directorio Recursivo de Imágenes"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Calidad de Imagen para Redimensionar"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Tiempo de Actualización Rápida de Imagen [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Tipo de Imagen [solo Imagen]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Tipo de Fondel de Imagen"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "El Tiempo API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Clave del Tiempo API OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Ciudad para el Tiempo"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Ciudad para el Tiempo 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Ruta de Iconos del Tiempo [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Zoom de Iconos del Tiempo"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Color de Baja Temperatura del Tiempo"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Color de Alta Temperatura del Tiempo"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Transparencias del Tiempo"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Unidad de velocidad del viento meteorológico"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Líneas de información de viento meteorológico"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Posibilidad de Lluvia en el Tiempo"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Zoom de Lluvia"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Color de Lluvia"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- La Lluvia usa color 2 desde"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Color de Lluvia 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Líneas del Tiempo"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Tiempo Flechas de Tendencia"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Informaciones Extras del Tiempo"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Zoom Extra"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Mostrar temperaturas más frías desde la diferencia"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Color Extra de Ciudad"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Color Extra del Frío"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Rango Mínimo"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Rango Máximo"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "URL Meteo"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Ruta Iconos Lunares [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Imagen de Grabación [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Cambios Doble Botón"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Tecla para Cambiar pantalla"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Tecla para Apagar/Encender Pantalla"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall Ruta Imagen [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Número de Líneas por Entrada"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall Número de Entradas Listadas"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall Número de Imágenes"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall Imagen de Orientación"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "Transparencia Imagen FritzCall"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall Búsqueda de Imágenes"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall Borrar Llamadas después de horas"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Hora Emergente"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall LCD Emergente"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Color Emergente"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Imagen de Marco [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Ruta Calendario ics [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "URL Calendario ics"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Calendario planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Calendario Color Sábado"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Calendario Color Domingo"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Calendario Líneas Finas"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Calendario Prevista Eventos Diarios"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Calendario Corrección Zona Horaria"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Calendario Transparencia"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Calendario Intervalo"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Color Sintonizador"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Color Sintonizador Activo"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Color Sintonizador Funcionando"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Primero Búsqueda de Canales"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "Corrección de Calidad de Señal DVB-T"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Fuente Global [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Fuente 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Fuente 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Fuente 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Fuente 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Fuente 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Conectar Correo 1"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Servidor Correo 1"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Correo 1 [NombrePantalla:]Usuario"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Contraseña Correo 1"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Conectar Correo 2"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Servidor Correo 2"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Correo 2 [NombrePantalla:]Usuario"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Contraseña Correo 2"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Conectar Correo 3"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Servidor Correo 3"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Correo 3 [NombrePantalla:]Usuario"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Contraseña Correo 3"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Conectar Correo 4"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Servidor Correo 4"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Correo 4 [NombrePantalla:]Usuario"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Contraseña Correo 4"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Conectar Correo 5"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Servidor Correo 5"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Correo 5 [NombrePantalla:]Usuario"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Contraseña Correo 5"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Intervalo Correo"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Correo IMAP limitado hasta los últimos días"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mostrar Carpetas Vacías del Correo"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Fecha de Muestra del Correo"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "El Correo Esconde la Dirección de Correo"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 1 [Nombrepantalla:]IP/Nombre"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 2 [Nombrepantalla:]IP/Nombre"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 3 [Nombrepantalla:]IP/Nombre"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 4 [Nombrepantalla:]IP/Nombre"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 5 [Nombrepantalla:]IP/Nombre"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Dispositivo Remoto Encuesta cada Minuto"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto Temporizador [Nombrepantalla:]IP/Nombre"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Dispositivo Remoto Temporizador Encuesta cada Minuto"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "Intervalo Convertidor WWW"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "Uso del Convertidor WWW"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "Llave Api WWW de cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "Llave Api WWW de convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "Refresco WebIF [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "Tipo de Refresco WebIF"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "Retraso de Inicio WebIF"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "IP Permitida WebIF"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "IP Prohibida WebIF"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "Diseño WebIF"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Guardar como Imagen para WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Arroyo LCD 1 permitir"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Arroyo LCD 1 Puerto"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Arroyo LCD 1 Brillo virtual"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Arroyo LCD 2 permitir"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Arroyo LCD 2 Puerto"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Arroyo LCD 2 Brillo virtual"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Arroyo LCD 3 permitir"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Arroyo LCD 3 Puerto"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Arroyo LCD 3 Brillo virtual"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG Ciclo"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Reiniciar en caso de error"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "Modo de Cabecera MJPEG"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Descanso [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Tocar Cheque"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Refresco [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Descanso [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound Tocar Cheque"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Refresco [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [optional]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Descanso [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Tocar Cheque"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Refresco [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Cover"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "Anchura Personalizada del LCD"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "Altura Personalizada del LCD"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "Anchura Personalizada 2 del LCD"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "Altura Personalizada 2 del LCD"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD apagado cuando se apaga"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Hora ! calcular todas las veces a hora/5*2 en Modo Rápido"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Retraso Pantalla [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Hilos por LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Mostrar Esquina Rota"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Mostrar Mensajes 'no...'"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Dispositivos de Almacenamiento: Forzar lectura"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Dispositivos de Almacenamiento: Color Fondo"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Dispositivos de Almacenamiento: Color Bar"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Dispositivos de Almacenamiento: Color Completo"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Comprobación de Red activa"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Poner contador de planos (si es posible)"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Ruta para Guardar Configuraciones [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Restaurar Configuración de Todos los Ajustes"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Registro de Depuración > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Luz de Fondo Desconectada [deshabilita ajuste Off=On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Luz de Fondo Conectada"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Luz de Fondo Fin de Semana desconectada [deshabilita ajuste Off=On]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Luz de Fondo Fin de Semana Conectada"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Apagado automático"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Fondo"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Imagen [ok]"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Tamaño de Picon"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Pantalla Dividida"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- A Toda Pantalla"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Tamaño de Texto"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparencia"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Ruta de Picon [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Ruta de Picon 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Ruta Caché Picon [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Reloj"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "- Tipo"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Reloj Analógico"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Espaciado"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Tamaño"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Bordes de Sombra"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Reloj 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Nombre de Programa"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- máximo de Líneas"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Duracción"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Número de Programa"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Información de Programa"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Tipo"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Información Programa 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Información Próximo Programa"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Descripción Extendida"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- Usa la información cuando está vacío"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Barra de Progreso"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Color Texto"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Margen"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Sombreado"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Unidad min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informaciones"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Información Sintonizador"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensores"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informaciones 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Barra de Calidad de Señal"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradiente"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Barra rango Mínimo"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Barra Rango Máximo"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satélite"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Proveedor"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Sintonizador Usado"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- solo Sintonizador activo"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Próximo Evento Programado"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volumen"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Silencio"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "En Linea [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Mostrar Estado"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Descanso [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Nombre En Linea:Dirección"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Dirección IP Extendida"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- externo IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Dispositivos de Almacenamiento"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- Advertencia"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- información extra"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Nombre de Dispositivo"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "El Tiempo"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Tipo de Tiempo"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "El Tiempo 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Estación Metereológica del Tiempo"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Estación"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Módulo"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Módulo definido por el usuario"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Base"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Nombre"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Color 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Color 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Color 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Color 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Color 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Color 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo Indicador de CO2"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Longitud [Barra]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Indicador de Comodidad"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Fases Lunares"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Líneas de información"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Flechas de Tendencia"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Amanecer"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Mostrar oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Archivo [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Mostrar ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Mostrar Archivo de Texto"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Mostrar Archivo de Texto 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Mostrar Archivo de Texto 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Mostrar Texto HTTP"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "Convertidor WWW-Internet"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- Ancho HTTP"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- Alto HTTP"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Cortar desde X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Cortar desde Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Cortar Ancho [deshabilitar = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Cortar Altura [deshabilitar = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Mostrar Imagen"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Archivo o Ruta [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Tamaño Altura Máxima"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Actualización Rápida"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Mostrar Imagen 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Mostrar Imagen 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Mostrar Imagen 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Correo"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Líneas"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Correo Konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- Anchura máxima"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Dispositivo Remoto"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Dispositivo Remoto Temporizador"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Tamaño Imagen"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Posición Imagen"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Alineamiento Imagen"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Calendario"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "IP Permitida WebIF"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "No hay archivo seleccionado o es equivocado, trata de corregir esto primero!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Modo"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Seguridad de IP no soprtada por el dispositivo"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Registro de Bloqueo"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Mostrar"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Borrar"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Archivo"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Restaurar Configuración"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Guardar Configuración"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Borrar Archivo de Depuración"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Descargar Archivo de Depuración"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Salvar Configuración"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "parar Ciclo de Pantalla"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Global"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "On"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "En Reposo"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "GUI Reinicia si es necesario"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Elemento"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "otro"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "ajustar"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "copiar a Encendido"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "copiar a Reproductor"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "copiar a Espera"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Ejec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Mostrar externas"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Lista de dispositivos de almacenamiento"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Directorio de padres"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Vie"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Lun"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sáb"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Dom"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Jue"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Mar"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Mié"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "negro"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "blanco"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "gris"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "plateado"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "grispizarra"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "aguamarina"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "dorado"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "verdeamarillo"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "amarillo"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "naranjaoscuro"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "rojooscuro"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "pielroja"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "naranja"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "rojoanaranjado"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "rojo"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomate"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "verdeoscuro"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "verde"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "verdecésped"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "verdeclaro"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "lima"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "azul"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "azulvioleta"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "azul cadete"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "azul aciano"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "azul oscuro"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "azul índigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "celeste"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "cián"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "orquídea oscuro"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "rosa oscuro"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violeta"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "marrón"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "mocasín"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "verde oliva"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "marrón rosado"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "marrón arena"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Pantallas 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Pantallas 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Pantallas 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Pantallas 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Pantallas 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Pantallas 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Pantallas 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Pantallas 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Pantallas 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Pantallas 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Pantallas 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Pantallas 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Pantallas 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Pantallas 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Pantallas 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Pantallas 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Pantallas 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Pantallas 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Pantallas 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Pantallas 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Pantalla 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Pantalla 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Pantalla 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Pantalla 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Pantalla 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Pantalla 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Pantalla 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Pantalla 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Pantalla 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "off"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Pantallas 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Pantallas 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Pantallas 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "on"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (o LCD compatible) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (o LCD compatible) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (o LCD compatible) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (o LCD compatible) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "LCD Box-Skin interno"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "TFT-LCD interno 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "sólo Imágenes 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "sólo Imágenes 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "sólo Imágenes 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "sólo Imágenes 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "sólo Imágenes de tamaño configurable"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "sólo Imágenes de tamaño configurable"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "LCD interno Vu+ Duo2 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 Dias 1 Linea"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 Dias 2 Lineas"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 Dias 1 Linea"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 Dias 2 Lineas"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 días vista vertical"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 Dias 1 Linea"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 Dias 2 Lineas"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 días vista vertical"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Temperatura actual (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Temperatura actual (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Ahora"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Temperatura actual"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Todo"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperatura+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperatura+Co2+Presión"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperatura+Humedad"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Módulo 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Módulos 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Módulos 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Módulos 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Módulos 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Módulos 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Módulos 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Módulos 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Módulos 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Módulos 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Módulo 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Módulos 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Módulos 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Módulos 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Módulo 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Módulo 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Módulos 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Módulo 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Módulo 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Módulo 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Módulo 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Módulo 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Módulo 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "definido por el usuario"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Pre"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Pre+Valor"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Knob"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Knob+Valor"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analógico"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analógico+Fecha"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analógico+Fecha+Día de la Semana"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analógico+Fecha+Día de la Semana 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Fecha"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Fecha+Hora"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Fecha+Hora+Día de la Semana"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Diseño Etiqueta Fecha"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Diseño Etiqueta Dia de la Semana"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Hora"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Hora+Día de la Semana"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Día de la Semana"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "centro"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "izquierda"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "derecha"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Extendido"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Extendido (Corto)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Corto"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Corto (Extendido)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Corto+Extendido"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Mes"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Mes+Cabecera"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Semana"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Semana+Cabecera"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "sin Calendario"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Fechas 1 Línea"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Fechas 3 Líneas"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Fechas 5 Líneas"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Fechas 9 Líneas"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Fechas compactas en 2 Líneas"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Fechas compactas en 3 Líneas"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "sin Fechas"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Debajo de Línea"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Debajo de Línea 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Marco"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Fechas"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Fechas compactas"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Fechas compactas sin icono"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Fechas sin icono"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "sin Icono"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "sin Icono, con Número de Destino"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "con Icono"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "con Icono & Número de Destino"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "no"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "mostrar carrera"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "mostrar carrera+sueño"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Siempre Todo"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Siempre lo Nuevo"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Sólo lo Nuevo"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Todas las Informaciones"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "solo distancia"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Distancia+Iluminación"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Distancia+Fase lunar"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "solo Iluminación"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Iluminación+Fase lunar"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "solo Fase lunar"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Canal"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Canal+Título"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Canal"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Canal+Título"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "el mismo color"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "sí+25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "sí"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "verticalmente"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontalmente"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "todo"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Esquina"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Esquina+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "sólo Barra de Progreso"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "con Minutos Restantes"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "con Minutos Restantes (Tamaño 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "con Minutos Restantes (Tamaño 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "con Porcentaje"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "con Porcentaje (Tamaño 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "con Porcentaje (Tamaño 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "con Minutos Restantes (arriba)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "con Minutos Restantes (arriba/Tamaño 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "con Minutos Restantes (arriba/Tamaño 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "con Porcentaje (arriba)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "con Porcentaje (arriba/Tamaño 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "con Porcentaje (arriba/Tamaño 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "con Minutos Restantes (debajo)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "con Minutos Restantes (debajo/Tamaño 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "con Minutos Restantes (debajo/Tamaño 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "con Porcentaje (debajo)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "con Porcentaje (debajo/Tamaño 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "con Porcentaje (debajo/Tamaño 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "con el Actual 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "con el Actual 00:00 (Tamaño 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "con el Actual 00:00 (Tamaño 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "con el Actual 00:00 (arriba)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "con el Actual 00:00 (arriba/Tamaño 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "con el Actual 00:00 (arriba/Tamaño 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "con el Actual 00:00 (debajo)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "con el Actual 00:00 (debajo/Tamaño 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "con el Actual 00:00 (debajo/Tamaño 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "con Porcentaje de Minutos / Total (arriba)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "con Porcentaje de Minutos / Total (arriba/Tamaño 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "con Porcentaje de Minutos / Total (arriba/Tamaño 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "con el tiempo del fin absoluto"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "con el tiempo del fin absoluto (Tamaño 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "con el tiempo del fin absoluto (Tamaño 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "con Minutos Totales / Hora de finalización (arriba)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "con Minutos Totales / Hora de finalización (arriba/Tamaño 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "con Minutos Totales / Hora de finalización (arriba/Tamaño 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Modo Rápido (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alfabético"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "aleatorio"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "mejor/lento"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "bajo/rápido (solo Fotos)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "bajo/rápido (todo)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + ajuste (alta calidad, lento)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + ajuste (baja calidad, rápido)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "sin cache + sin ajuste"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Sintonizador integrado"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "Sintonizador USB"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Ahora/Después"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "reducido"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript sin actualización"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Recarga"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - cara a cara"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "modo Copia alternativo/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "sí + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "sí, largo"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "sí, corto"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Búsqueda Cubrir"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "siempre"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Media+Reposo"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Reposo"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - color"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - gris/color"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x Tecla Avance Rápido"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x Tecla Avance Rápido Tipo 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Tecla Avance Rápido Prolongada"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Tecla Avance Rápido Prolongada Tipo 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Tecla Info"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Silencio"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Tecla Info Prolongada"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x Tecla Retroceso Rápido"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x Tecla Retroceso Rápido Tipo 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Tecla Retroceso Rápido Prolongada"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Tecla Retroceso Rápido largo Tipo 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "sí, extendido"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Consola normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Archivo de log extenso"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Archivo de log normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "deshabilitado"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (completo)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normal (completo)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "ajustado (negro)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "ajustado (transparente)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "Silencio o teclas definidas"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "cualquier Tecla"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Hora+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Hora+Duración+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Hora+Duración+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "mitad izquierda"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "mitad derecha"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Marco x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Línea"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "sin Barra"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "sin Marco"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradiente"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Bordes de Sombra"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Posición debajo"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Posición izquierda"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Posición derecha"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Posición"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Nombre"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Desconectado"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Conectado"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Conectado+Desconectado"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "usar sólo Temporizador"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "usar hora principal"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "sin Temporizador completo"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "mostrar Temporizador completo"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "una línea"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "dos líneas"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Memoria disponible"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Memoria libre"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "a toda pantalla"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "sí, excepto grabaciones"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ENE"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "ESE"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NE"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNE"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNO"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NO"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SE"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSE"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSO"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SO"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "O"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "ONO"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "OSO"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Cargar Archivo de Configuración Activo"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Cargar por defecto / Configuración vacía"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Salvar Configuración al Archivo...(%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Cargar Archivo : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Borrar Archivo?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "borrado"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "ajuste actual : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "Ajustes de LCD4linux"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Salvar"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Reiniciar Pantallas"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Ir a On >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "no hay Archivo de Imagen de LCD1"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "no hay Archivo de Imagen de LCD2"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "no hay Archivo de Imagen de LCD3"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux activado"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "Tipo LCD 1"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- Rotar LCD 1"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- Color de Fondo LCD 1"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- Fondo-Imagen LCD 1 [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- Brillo LCD 1"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- Reducción Nocturna LCD 1"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- Refrescar LCD 1"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "Tipo LCD 2"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- Rotar LCD 2"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- Color de Fondo LCD 2"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- Fondo-Imagen LCD 2 [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- Brillo LCD 2"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- Reducción Nocturna LCD 2"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- Refrescar LCD 2"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "Tipo LCD 3"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- Rotar LCD 3"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- Color de Fondo LCD 3"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- Fondo-Imagen LCD 3 [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- Brillo LCD 3"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- Reducción Nocturna LCD 3"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- Refrescar LCD 3"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Tamaño LCD Box-Skin"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Offset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Color LCD Box-Skin"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Activar Modo On LCD Box-Skin"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Activar Modo Media LCD Box-Skin"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Activar Modo Apagado LCD Box-Skin"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [hora en pantalla]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- qué LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Mostrar en Modo"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Tamaño OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Fondo/Transparencia"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Grabador Rápido baja calidad"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Texto Emergente"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Clave clara"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Tamaño de Fuente"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Posición"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Alineamiento"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Color"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Color de Fondo"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Fuente"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Pantalla Activa"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Seleccionar pantalla a Cambiar - Pantalla"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Seleccionar pantalla a Cambiar - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Pantallas usadas para los cambios"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Tiempo de cambio Pantalla 1"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 2"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 3"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 4"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 5"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 6"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 7"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 8"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Tiempo de cambio Pantalla 9"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Tiempo de cambio Imagen"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Imágenes aleatorias"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Directorio Recursivo de Imágenes"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Calidad de Imagen para Redimensionar"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Tiempo de Actualización Rápida de Imagen [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Tipo de Imagen [solo Imagen]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Tipo de Fondel de Imagen"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "El Tiempo API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Clave del Tiempo API OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Ciudad para el Tiempo"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Ciudad para el Tiempo 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Ruta de Iconos del Tiempo [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Zoom de Iconos del Tiempo"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Color de Baja Temperatura del Tiempo"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Color de Alta Temperatura del Tiempo"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Transparencias del Tiempo"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Unidad de velocidad del viento meteorológico"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Líneas de información de viento meteorológico"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Posibilidad de Lluvia en el Tiempo"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Zoom de Lluvia"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Color de Lluvia"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- La Lluvia usa color 2 desde"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Color de Lluvia 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Tiempo Humedad Color"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Líneas del Tiempo"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Tiempo Flechas de Tendencia"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Informaciones Extras del Tiempo"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Zoom Extra"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Mostrar temperaturas más frías desde la diferencia"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Color Extra de Ciudad"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Color Extra del Frío"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Rango Mínimo"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Rango Máximo"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "URL Meteo"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Ruta Iconos Lunares [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Imagen de Grabación [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Cambios Doble Botón"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Tecla para Cambiar pantalla"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Tecla para Apagar/Encender Pantalla"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall Ruta Imagen [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Número de Líneas por Entrada"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall Número de Entradas Listadas"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall Número de Imágenes"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall Imagen de Orientación"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "Transparencia Imagen FritzCall"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall Búsqueda de Imágenes"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall Borrar Llamadas después de horas"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Hora Emergente"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall LCD Emergente"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Color Emergente"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Imagen de Marco [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Ruta Calendario ics [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "URL Calendario ics"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Calendario planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Calendario Color Sábado"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Calendario Color Domingo"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Calendario Líneas Finas"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Calendario Prevista Eventos Diarios"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Calendario Corrección Zona Horaria"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Calendario Transparencia"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Calendario Intervalo"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Color Sintonizador"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Color Sintonizador Activo"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Color Sintonizador Funcionando"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Primero Búsqueda de Canales"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "Corrección de Calidad de Señal DVB-T"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Fuente Global [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Fuente 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Fuente 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Fuente 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Fuente 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Fuente 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Conectar Correo 1"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Servidor Correo 1"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Correo 1 [NombrePantalla:]Usuario"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Contraseña Correo 1"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Conectar Correo 2"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Servidor Correo 2"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Correo 2 [NombrePantalla:]Usuario"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Contraseña Correo 2"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Conectar Correo 3"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Servidor Correo 3"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Correo 3 [NombrePantalla:]Usuario"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Contraseña Correo 3"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Conectar Correo 4"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Servidor Correo 4"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Correo 4 [NombrePantalla:]Usuario"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Contraseña Correo 4"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Conectar Correo 5"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Servidor Correo 5"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Correo 5 [NombrePantalla:]Usuario"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Contraseña Correo 5"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Intervalo Correo"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Correo IMAP limitado hasta los últimos días"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mostrar Carpetas Vacías del Correo"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Fecha de Muestra del Correo"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "El Correo Esconde la Dirección de Correo"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 1 [Nombrepantalla:]IP/Nombre"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 2 [Nombrepantalla:]IP/Nombre"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 3 [Nombrepantalla:]IP/Nombre"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 4 [Nombrepantalla:]IP/Nombre"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 5 [Nombrepantalla:]IP/Nombre"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Dispositivo Remoto Encuesta cada Minuto"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto Temporizador [Nombrepantalla:]IP/Nombre"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Dispositivo Remoto Temporizador Encuesta cada Minuto"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "Intervalo Convertidor WWW"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "Uso del Convertidor WWW"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "Llave Api WWW de cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "Llave Api WWW de convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "Refresco WebIF [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "Tipo de Refresco WebIF"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "Retraso de Inicio WebIF"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "IP Prohibida WebIF"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "Diseño WebIF"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Guardar como Imagen para WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Arroyo LCD 1 permitir"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Arroyo LCD 1 Puerto"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Arroyo LCD 1 Brillo virtual"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Arroyo LCD 2 permitir"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Arroyo LCD 2 Puerto"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Arroyo LCD 2 Brillo virtual"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Arroyo LCD 3 permitir"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Arroyo LCD 3 Puerto"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Arroyo LCD 3 Brillo virtual"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG Ciclo"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Reiniciar en caso de error"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "Modo de Cabecera MJPEG"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Descanso [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Tocar Cheque"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Refresco [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Descanso [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound Tocar Cheque"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Refresco [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [optional]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Descanso [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Tocar Cheque"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Refresco [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Cover"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "Anchura Personalizada del LCD"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "Altura Personalizada del LCD"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "Anchura Personalizada 2 del LCD"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "Altura Personalizada 2 del LCD"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD apagado cuando se apaga"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Hora ! calcular todas las veces a hora/5*2 en Modo Rápido"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Retraso Pantalla [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Hilos por LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Mostrar Esquina Rota"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Mostrar Mensajes 'no...'"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Dispositivos de Almacenamiento: Forzar lectura"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Dispositivos de Almacenamiento: Color Fondo"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Dispositivos de Almacenamiento: Color Bar"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Dispositivos de Almacenamiento: Color Completo"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Comprobación de Red activa"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Poner contador de planos (si es posible)"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Ruta para Guardar Configuraciones [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Restaurar Configuración de Todos los Ajustes"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Registro de Depuración > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Luz de Fondo Desconectada [deshabilita ajuste Off=On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Luz de Fondo Conectada"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Luz de Fondo Fin de Semana desconectada [deshabilita ajuste Off=On]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Luz de Fondo Fin de Semana Conectada"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Apagado automático"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Fondo"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Imagen [ok]"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Tamaño de Picon"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Pantalla Dividida"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- A Toda Pantalla"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Tamaño de Texto"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparencia"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Ruta de Picon [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Ruta de Picon 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Ruta Caché Picon [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Reloj"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "- Tipo"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Reloj Analógico"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Espaciado"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Tamaño"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Bordes de Sombra"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Reloj 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Nombre de Programa"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- máximo de Líneas"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Duracción"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Número de Programa"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Información de Programa"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Tipo"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Información Programa 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Información Próximo Programa"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Descripción Extendida"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- Usa la información cuando está vacío"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Barra de Progreso"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Color Texto"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Margen"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Sombreado"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Unidad min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informaciones"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Información Sintonizador"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensores"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informaciones 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Barra de Calidad de Señal"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradiente"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Barra rango Mínimo"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Barra Rango Máximo"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satélite"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Proveedor"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Sintonizador Usado"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- solo Sintonizador activo"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Próximo Evento Programado"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volumen"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Silencio"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "En Linea [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Mostrar Estado"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Descanso [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Nombre En Linea:Dirección"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Dirección IP Extendida"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- externo IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Dispositivos de Almacenamiento"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- Advertencia"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- información extra"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Nombre de Dispositivo"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Tipo de Tiempo"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "El Tiempo 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Estación Metereológica del Tiempo"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Estación"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Módulo"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Módulo definido por el usuario"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Nombre"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Color 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Color 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Color 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Color 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Color 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Color 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo Indicador de CO2"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Longitud [Barra]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Indicador de Comodidad"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Fases Lunares"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Líneas de información"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Flechas de Tendencia"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Amanecer"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Mostrar oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Archivo [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Mostrar ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Mostrar Archivo de Texto"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Mostrar Archivo de Texto 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Mostrar Archivo de Texto 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Mostrar Texto HTTP"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "Convertidor WWW-Internet"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- Ancho HTTP"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- Alto HTTP"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Cortar desde X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Cortar desde Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Cortar Ancho [deshabilitar = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Cortar Altura [deshabilitar = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Mostrar Imagen"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Archivo o Ruta [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Tamaño Altura Máxima"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Actualización Rápida"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Mostrar Imagen 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Mostrar Imagen 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Mostrar Imagen 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Líneas"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Correo Konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- Anchura máxima"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Dispositivo Remoto Temporizador"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Tamaño Imagen"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Posición Imagen"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Alineamiento Imagen"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Disposición"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Color de Fondo Día Actual"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Leyenda Color"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Lista de fechas"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Barra de icono de Evento"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Pantalla Aparición"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- LCD Aparición"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Mostrar Texto 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Texto"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Mostrar Texto 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rectángulo 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Posición x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Posición y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Tamaño x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Tamaño y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rectángulo 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Grabando"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Pantallas usadas para Cambios"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Título"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Informaciones"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Mostrar Cubierta"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Buscar Ruta [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- - Buscar archivo de portada [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Cubierta por Defecto [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon Primero"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- recortado"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Descargar Cubierta"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Descargar Archivo de Depuración"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "Pantalla LCD"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "Modo de la Pantalla LCD4linux Encendido"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Ir a Reproductor >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "Modo de la Pantalla LCD4linux en Reproductor"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Ir a Espera >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "Modo de la Pantalla LCD4linux en Espera"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Ir a Global >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Elige Directorio"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Elige Archivo"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Elige Fuente"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Valor Actual: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3842,95 +4075,95 @@ msgstr ""
 "GUI necesita reiniciar para aplicar los cambios.\n"
 "¿Realmente quiere reiniciar el GUI ahora?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "¿Reiniciar el GUI ahora?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Interior"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Exterior"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Lluvia"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Viento"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Luna Nueva"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Cuarto Creciente"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Luna Creciente"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Luna Creciente"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Luna Llena"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Luna Menguante"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Creciente Menguante"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Cuarto Menguante"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Imagen no disponible"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "sin Temporizador"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM no está funcionando"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "sin Llamadas"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Correos %d Nuevo %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "no hay Plugin Netatmo instalado"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "Cambiar a Pantalla LCD4linux"
 
@@ -3948,111 +4181,3 @@ msgstr "Cambiar a Pantalla LCD4linux"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Tiempo Dirección del viento"
-
-#~ msgid "Backup Config"
-#~ msgstr "Guardar Configuración"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "LCD Box-Skin"
-
-#~ msgid "Crashlog"
-#~ msgstr "Registro de Bloqueo"
-
-#~ msgid "Delete"
-#~ msgstr "Borrar"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Borrar Archivo de Depuración"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Descargar Archivo de Depuración"
-
-#~ msgid "Element"
-#~ msgstr "Elemento"
-
-#~ msgid "Exec"
-#~ msgstr "Ejec"
-
-#~ msgid "Filename"
-#~ msgstr "Archivo"
-
-#~ msgid "Font"
-#~ msgstr "Fuente"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "GUI Reinicia si es necesario"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Seguridad de IP no soprtada por el dispositivo"
-
-#~ msgid "Key"
-#~ msgstr "Tecla"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Lista de dispositivos de almacenamiento"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "No hay archivo seleccionado o es equivocado, trata de corregir esto primero!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Directorio de padres"
-
-#~ msgid "Picture"
-#~ msgstr "Imagen"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Texto Emergente"
-
-#~ msgid "Restore Config"
-#~ msgstr "Restaurar Configuración"
-
-#~ msgid "Save Config"
-#~ msgstr "Salvar Configuración"
-
-#~ msgid "Screen"
-#~ msgstr "Pantalla"
-
-#~ msgid "Show"
-#~ msgstr "Mostrar"
-
-#~ msgid "Show Externals"
-#~ msgstr "Mostrar externas"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Sintonizador"
-
-#~ msgid "WWW Converter"
-#~ msgstr "Convertidor WWW"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "copiar a Espera"
-
-#~ msgid "copy to Media"
-#~ msgstr "copiar a Reproductor"
-
-#~ msgid "copy to On"
-#~ msgstr "copiar a Encendido"
-
-#~ msgid "other"
-#~ msgstr "otro"
-
-#~ msgid "set Settings"
-#~ msgstr "ajustar"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "parar Ciclo de Pantalla"

--- a/LCD4linux/po/fi.po
+++ b/LCD4linux/po/fi.po
@@ -7,3936 +7,4169 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-04-03 13:16+0300\n"
-"Last-Translator: Orlandox\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:15+0100\n"
+"Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Kojo/Orlandox\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Pe"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Ma"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "VDF-näyttö"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "La"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Fontti"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Aurinko"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Painikkeet"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "To"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG: Syöte"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Ti"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Ke"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Kuva"
 
-#: plugin.py:288
-msgid "black"
-msgstr "musta"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Popup-Teksti"
 
-#: plugin.py:288
-msgid "white"
-msgstr "valkoinen"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "harmaa"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Viritin"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "hopea"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW-muunnin"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "liuskeenharmaa"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "akvamariini"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Näyttö"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "kulta"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "vihreäkeltainen"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "keltainen"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "tummanoranssi"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "tummanpunainen"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "intianpuna"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "oranssi"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "oranssinpunainen"
-
-#: plugin.py:292
-msgid "red"
-msgstr "punainen"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomaatti"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "tummanvihreä"
-
-#: plugin.py:293
-msgid "green"
-msgstr "vihreä"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "nurmikonvihreä"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "vaaleanvihreä"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "limetti"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "sininen"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "sinivioletti"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "kadetinsininen"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "ruiskaunokinsininen"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "tummansininen"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigonsininen"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "vaaleansininen"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "syaani"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "tumma orkidea"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "syväpinkki"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violetti"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "ruskea"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "mokkasiini"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "oliivi"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "ruusunruskea"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "hiekanruskea"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Näytöt 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Näytöt 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Näytöt 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Näytöt 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Näytöt 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Näytöt 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Näytöt 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Näytöt 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Näytöt 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Näytöt 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Näytöt 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Näytöt 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Näytöt 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Näytöt 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Näytöt 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Näytöt 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Näytöt 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Näytöt 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Näytöt 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Näytöt 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Näyttö 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Näyttö 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Näyttö 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Näyttö 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Näyttö 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Näyttö 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Näyttö 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Näyttö 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Näyttö 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "pois päältä"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Näytöt 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Näytöt 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Näytöt 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "päällä"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (tai yhteensopiva LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (tai yhteensopiva LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (tai yhteensopiva LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (tai yhteensopiva LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Sisäinen TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Sisäinen LCD-näyttö"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "vain 1024x600 -kuva"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "vain 320x240 -kuva"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "vain 800x480 -kuva"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "vain 800x600 -kuva"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "vain muokatun koon kuva"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "vain muokatun koon kuva 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Sisäinen Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 päivää, 1 rivi"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 päivää, 2 riviä"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 päivää, 1 rivi"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 päivää, 2 riviä"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 päivää, vertikaalinen näkymä"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 päivää, 1 rivi"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 päivää, 2 riviä"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 päivää, vertikaalinen näkymä"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Nykyinen lämpötila (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Nykyinen lämpötila (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Nykyinen"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Nykyinen lämpötila"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Kaikki"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Lämpötila"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Lämpötila+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Lämpötila+Co2+Ilmanpaine"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Lämpötila+Kosteus"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Moduuli 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Moduulit 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Moduulit 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Moduulit 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Moduulit 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Moduulit 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Moduulit 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Moduulit 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Moduulit 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Moduulit 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Moduuli 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Moduulit 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Moduulit 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Moduulit 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Moduulit 2+6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Moduuli 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Moduulit 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Moduulit 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Moduuli 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Moduulit 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Moduuli 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Moduulit 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Moduuli 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "käyttäjän määrittelemä"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Palkki"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Palkki+Arvo"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Nuppi"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Nuppi+Arvo"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analoginen"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analoginen+Päivämäärä"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analoginen+Päivämäärä+Viikonpäivä"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analoginen+Päivämäärä+Viikonpäivä 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Päivämäärä"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Päivämäärä+Aika"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Päivämäärä+Aika+Viikonpäivä"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Läppä-mallinen päivämäärä"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Läppä-mallinen viikonpäivä"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Aika"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Aika+Viikonpäivä"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Viikonpäivä"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "keskellä"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "vasen"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "oikea"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Laajennettu"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Laajennettu (lyhyt)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Lyhyt"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Lyhyt (laajennettu)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Lyhyt+Laajennettu"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Kuukausi"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Kuukausi+Otsikko"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Viikko"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Viikko+Otsikko"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "ei Kalenteria"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Päivämäärät: 1 rivi"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Päivämäärät: 3 riviä"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Päivämäärät: 5 riviä"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Päivämäärät: 9 riviä"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Päivämäärät: kompakti, 2 riviä"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Päivämäärät: kompakti, 3 riviä"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "ei Päivämääriä"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Alleviivaus"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Alleviivaus 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Kehys"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Päivämäärät"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Päivämäärät: kompakti"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Päivämäärät: kompakti, ei ikonia"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Päivämäärät: ei ikonia"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "ei Ikonia"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "ei ikonia, kohdenumeron kanssa"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "ikonin kanssa"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "ikonin ja kohdenumeron kanssa"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "ei"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Kuorma@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Kuorma@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Kuorma@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Kuorma@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "näytä käynnissä"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "näytä käynnissä+lepotilassa"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Aina kaikki"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Aina uusin"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Vain uusin"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Kaikki tiedot"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Vain etäisyys"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Etäisyys+valaistu %"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Etäisyys+kuuvaihe"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Vain valaistu %"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Valaistu %+kuuvaihe"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Vain kuuvaihe"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Kanava"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Kanava+Otsikko"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Piconi+Kanava"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Piconi+Kanava+Otsikko"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Piconi"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "sama väri"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "kyllä +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "kyllä"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "pystysuorasti"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "vaakasuorasti"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Globaali"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "kaikki"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Kulma"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Kulma+Ajansiirto"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Piconi+Ajansiirto"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "vain etenemispalkki"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "jäljellä olevien minuuttien kanssa"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "jäljellä olevien minuuttien kanssa (Koko 1,5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "jäljellä olevien minuuttien kanssa (Koko 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "prosentteina"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "prosentteina (Koko 1,5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "prosentteina (Koko 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "jäljellä oleva aika minuutteina (yläpuolella)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "jäljellä olevien minuuttien kanssa (yläpuolella/Koko 1,5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "jäljellä olevien minuuttien kanssa (yläpuolella/Koko 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "prosentteina (yläpuolella)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "prosentteina (yläpuolella/Koko 1,5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "prosentteina (yläpuolella/Koko 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "jäljellä olevien minuuttien kanssa (alapuolella)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "jäljellä olevien minuuttien kanssa (alapuolella/Koko 1,5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "jäljellä olevien minuuttien kanssa (alapuolella/Koko 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "prosentteina (alapuolella)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "prosentteina (alapuolella/Koko 1,5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "prosentteina (alapuolella/Koko 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "nykyinen 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "nykyinen 00:00 (Koko 1,5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "nykyinen 00:00 (Koko 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "nykyinen 00:00 (yläpuolella)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "nykyinen 00:00 (yläpuolella/koko 1,5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "nykyinen 00:00 (yläpuolella/koko 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "nykyinen 00:00 (alapuolella)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "nykyinen 00:00 (alapuolella/koko 1,5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "nykyinen 00:00 (alapuolella/koko 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella/koko 1,5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella/koko 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "absoluuttinen loppuaika"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "absoluuttinen loppuaika (Koko 1,5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "absoluuttinen loppuaika (Koko 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella/koko 1,5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella/koko 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Nopea (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normaali (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "aakkosellinen"
-
-#: plugin.py:386
-msgid "random"
-msgstr "satunnainen"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "parempi/hidas"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "huonompi/nopea (vain kuva)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "huonompi/nopea (kaikki)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + sovitus (korkea laatu, hidas)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + sovitus (huonompi laatu, nopea)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "ei cachea + ei sovitusta"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Sisäinen viritin"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB-viritin"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Nyt/Seuraava"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normaali"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "pelkistetty"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript, ei virkistystä"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Uudelleenlataus"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normaali"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - vierekkäin"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "vaihtoehtoinen Kopio-tila/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "kyllä + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "kyllä, pitkä"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "kyllä, lyhyt"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Kansihaku"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "aina"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "Päällä+Media+Valmiustila"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Valmiustila"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "Päällä"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - väri"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - harmaasävy/väri"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x eteenpäinkelaus-näppäin"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x eteenpäinkelaus-näppäin, tyyppi 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Pitkä eteenpäinkelaus-näppäin"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Pitkä eteenpäinkelaus-näppäin tyyppi 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Info-näppäin"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Mykistys"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Pitkä Info-näppäin"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x taaksepäinkelaus-näppäin"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x taaksepäinkelaus-näppäin, tyyppi 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Pitkä taaksepäinkelaus-näppäin"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Pitkä taaksepäinkelaus-näppäin tyyppi 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "kyllä, laajennettu"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Normaali konsoli"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Laajennettu lokitiedosto"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Normaali lokitiedosto"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "pois päältä"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (täysi)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normaali (täysi)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "säädetty (musta)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "säädetty (läpinäkyvä)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE tai määritellyt näppäimet"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "mikä tahansa näppäin"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Aika+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Aika+Kesto+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Aika+Pituus+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "puolet vasen"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "puolet oikea"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Kehys x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Rivi"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "ei Palkkia"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "ei Reunusta"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Liukuväri"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Varjostetut reunat"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normaali"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Piconi+Sijainti alla"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Piconi+Sijainti vasemmalla"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Piconi+Sijainti oikealla"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Sijainti"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Nimi"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Ei yhteyttä"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Verkkoyhteys"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Päällä ja pois päältä"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "vain ajastimen käyttö"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "käytä aloitusaikaa"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "ei koko ajastusta"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "näytä koko ajastus"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "yksi rivi"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "kaksi riviä"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Muistia saatavilla"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Muistia vapaana"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "kokonäyttö"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "kyllä, paitsi tiedot"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "Itä"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "Itäkoillinen"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "Itäkaakko"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "Pohjoinen"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "Koillinen"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "Pohjoiskoillinen"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "Pohjoisluode"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "Luode"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "Etelä"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "Kaakko"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "Eteläkaakko"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "Etelälounas"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "Lounas"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "Länsi"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "Länsiluode"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "Länsiluode"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Lataa aktiivinen asetustiedosto"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Lataa oletukset / Tyhjennä konfiguraatio"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Tallenna tiedostoon... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Lataa tiedosto : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Poista tiedosto?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "poistettu"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "nyt asetettu : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux Asetukset"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Tila"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Peruuta"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Tallenna"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Käynnistä näytöt uudelleen"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Aseta Päällä >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Valmiustila"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "ei LCD1 -kuvatiedostoa"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "ei LCD2 -kuvatiedostoa"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "ei LCD3 -kuvatiedostoa"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux päällä"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Tyyppi"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 Kierto"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Taustaväri"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Taustakuva [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Kirkkaus"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Yövalaistus"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 Virkistys"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Tyyppi"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Kierto"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Taustaväri"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Taustakuva [ok]"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Kirkkaus"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Yövalaistus"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 Virkistys"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Tyyppi"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Kierto"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Taustaväri"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Taustakuva [ok]"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Kirkkaus"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Yövalaistus"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 Virkistys"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "VFD-näytön mitat"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "VFD-näyttön poikkeama"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "VFD-näytön väri"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "VFD-näyttö, aktivoi Käynnissä-tilassa"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "VFD-näyttö, aktivoi Media-tilassa"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "VFD-näyttö, aktivoi Valmiustilassa"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [näytettävä aika]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- mikä LCD-näyttö"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Näytä Tilassa"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- OSD:n koko"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Tausta/Läpinäkyvyys"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Fast Grab huonompi laatu"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Popup-Teksti"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Poistu-näppäin"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Fontin koko"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Sijainti"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Kohdistus"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Tekstin väri"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Taustaväri"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Fontti"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Aktiivinen näyttö"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Valitse vaihdettava näyttö - Näyttö"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Valitse vaihdettava näyttö - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Valitse kierrätettävät näytöt"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Näytön 1 vaihtumisaika"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Näyttö 2 vaihtumisaika"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Näyttö 3 vaihtumisaika"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Näyttö 4 vaihtumisaika"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Näyttö 5 vaihtumisaika"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Näyttö 6 vaihtumisaika"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Näyttö 7 vaihtumisaika"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Näyttö 8 vaihtumisaika"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Näyttö 9 vaihtumisaika"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Kuvan vaihtumisaika"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Kuvien järjestys"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Rekursiivinen kuvahakemisto"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Kuvakoon muokkauksen kuvanlaatu"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Kuvan nopea päivitysaika [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Kuvan formaatti [vain kuva]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Taustakuvan tyyppi"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Sää-API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Sää: API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Sää: API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Sää: Kaupunki"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Sää: Kaupunki 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Sää-ikonin polku [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Sää-ikoni zoom"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Sää: Alhaisen lämpötilan väri"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Sää: Korkean lämpötilan väri"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Sää: Läpiväkyvyys"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Sää: Tuulen nopeusyksikkö"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Sää: Tuuli tietorivit"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Sää: Sateen mahdollisuus"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Sade Zoom"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Sateen väri"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Sade: Käytä väriä 2 paikasta"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Sateen väri 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Sää: Erotin"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Sään: Trendinuolet"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Sää: Lisätiedot"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra Zoom"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Näytä jäähdytyslämpötila erosta"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Kaupungin lisäväri"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Jäähtymislämpötilan lisäväri"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Pienin arvo"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Suurin arvo"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteo URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Kuu-ikonin polku [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Tallennuskuva [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Kaksoispainallus vaihtaa näyttöä"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Näppäin näytön vaihtamiseen"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Näppäin, näyttö päälle/pois"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall: Kuvien polku"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall: Rivien määrä"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall: Listojen määrä"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall: Kuvien määrä"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall: Kuvan asettelu"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall: Kuvan läpinäkyvyys"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall: Kuvahaku"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall: Tuntimäärä, jonka jälkeen puhelut poistetaan"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall: Popup-aika"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall: Popup-LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall: Popup-väri"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall: Kuva [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Kalenteri: ics-polku [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Kalenteri: ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Kalenteri: planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Kalenteri: Lauantain väri"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Kalenteri: Sunnuntain väri"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Kalenteri: Reunojen paksuus"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Kalenteri: Päivän tapahtumien esikatselu"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Kalenteri: Aikavyöhykkeen korjaus"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Kalenteri: Läpinäkyvyys"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Kalenteri: Kyselyiden aikaväli"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Viritin: Väri"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Viritin: Väri aktiivisena"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Viritin: Väri, kun laite päällä"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Kanavanhaku ensin"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Signaalitason korjaus"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Globaali Fontti [ok]"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Fontti 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Fontti 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Fontti 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Fontti 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Fontti 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Posti 1 Yhteystapa"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Posti 1 Palvelin"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Posti 1 [Näyttönimi:] Käyttäjätunnus"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Posti 1 Salasana"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Posti 2 Yhteystapa"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Posti 2 Palvelin"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Posti 2 [Näyttönimi:] Käyttäjätunnus"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Posti 2 Salasana"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Posti 3 Yhteystapa"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Posti 3 Palvelin"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Posti 3 [Näyttönimi:] Käyttäjätunnus"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Posti 3 Salasana"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Posti 4 Yhteystapa"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Posti 4 Palvelin"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Posti 4 [Näyttönimi:] Käyttäjätunnus"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Posti 4 Salasana"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Posti 5 Yhteystapa"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Posti 5 Palvelin"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Posti 5 [Näyttönimi:] Käyttäjätunnus"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Posti 5 Salasana"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Posti: Kyselyväli"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Posti: IMAP-rajan kesto päivissä"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Posti: Näytä 'Tyhjennä postilaatikot'"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Posti: Näytä paivämäärä"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Posti: Piilota s-postiosoite"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Etälaite 1 [Näyttönimi:]IP/Nimi"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Etälaite 2 [Näyttönimi:]IP/Nimi"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Etälaite 3 [Näyttönimi:]IP/Nimi"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Etälaite 4 [Näyttönimi:]IP/Nimi"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Etälaite 5 [Näyttönimi:]IP/Nimi"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Etälaitteen pollaus joka minuutti"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Etälaitteen ajastus [Näyttönimi:]IP/Nimi"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Etälaitteen ajastuksen pollaus joka minuutti"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW-muuntimen kyselyväli"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW-muuntimen osoite"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "Cloudconvert.org WWW ApiKey"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "Convertapi.com WWW ApiKey"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF: Virkistä [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF: Virkistystyyppi"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF: Viive"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF: Sallitut IP:t"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF: Estä IP:(t)"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF: Ulkoasu"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Tallenna kuva WebIF:lle"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG: Syöte LCD 1 Päälle"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG: Syöte LCD 1 Portti"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG: Syöte LCD 1 Virtuaalinen kirkkaus"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG: Syöte LCD 2 Päälle"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG: Syöte LCD 2 Portti"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG: Syöte LCD 2 Virtuaalinen kirkkaus"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG: Syöte LCD 3 Päälle"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG: Syöte LCD 3 Portti"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG: Syöte LCD 3 Virtuaalinen kirkkaus"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG: Kierto"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG: Virheen sattuessa, uudelleenkäynnistys"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG: Otsikkotila"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos: IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos: Ping Aikakatkaisu [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos: Play-tarkistus"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos: Virkistä [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound: Ping Aikakatkaisu [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound: Toisto-tarkistus"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound: Virkistä [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast: IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast: Palvelimen IP [valinnainen]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast: Ping-aikakatkaisu [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast: Play-tarkistus"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast: Virkistä [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast: Kansikuva"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD: Mukautettu leveys"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD: Mukautettu korkeus"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD: Mukautettu leveys 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD: Mukautettu korkeus 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD: pois päältä kun sammutettuna"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Ajoitus! laske kaikki ajat aikaan/5*2 Nopea-tilassa"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Näytön viive [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Ketjut per LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Näytä kaatumiskulma"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Näytä 'ei ....' Viestejä"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Tallennusväline: Pakota luku"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Tallennusväline: Taustaväri"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Tallennusväline: Palkin väri"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Tallennusväline: Väri, kun tilaa on vähän jäljellä"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Verkkotarkistus aktiivinen"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Vaihda ruutubufferia [jos mahdollista]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Asetukset: Varmuuskopion polku [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Asetukset: Palauta kaikki asetukset"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debug-Lokitus > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Ei taustavaloa [pois käytöstä asetettu Off=Päällä]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Taustavalo päällä"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Ei taustavaloa viikonloppuisin [pois käytöstä asetettu Off=Päällä]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Taustavalo Viikkonloppuisin päällä"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Automaattisesti pois päältä"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Tausta"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Kuva [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Piconin koko"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Jaettu näyttö"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Kokonäyttö"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Tekstin koko"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Läpinäkyvyys"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Piconien polku [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Piconien polku 2[ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Piconien cachen polku [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Piconi 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Kello"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "- Tyyppi"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analoginen kello"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Kellon ja pvm väli"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Koko"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Varjoreunat"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Kello 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Kanavan nimi"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- suurin määrä rivejä"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Pituus"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Kanavan numero"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Ohjelmainfo"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Tyyppi"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Ohjelmainfo 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Seuraavan ohjelman info"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Laajennettu kuvaus"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- näytä Info kun tämä on tyhjä"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Etenemispalkki"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Tekstin väri"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Reunat"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Varjostettu"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Yksikkö min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Laitteen tekniset tiedot"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Viritininfo"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensorit"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Laitteen tekniset tiedot 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Signaalitason palkki"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Liukuväri"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Palkin pienin vaihteluväli"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Palkin suurin vaihteluväli"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satelliitti"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Tarjoaja"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Käytetty viritin"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- vain aktiivinen Viritin"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Seuraava ajastus"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Äänenvoimakkuus"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Mykistä"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bittinopeus"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Verkkoyhteys [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Näytä tila"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Aikakatkaisu [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Verkkonimi:Osoite"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Ulkoinen IP-osoite"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- ulkoinen IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Tallennusvälineet"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- Vapaan tilan varoitus"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- Lisätietoa"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Tallennusväline"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "Kiintolevy"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Sää"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Miten sää-tiedot näytetään"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Sää 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo-Sääasema"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo-sääasema"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Asema"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Moduuli"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Käyttäjän asettama moduuli"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Perus"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Nimi"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Väri 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Väri 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Väri 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Väri 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Väri 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Väri 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo-sääasema 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Indikaattori"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Palkin pituus"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo 'Tuntuu kuin'"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Kuuvaihe"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Tietorivit"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Trendinuolet"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Auringonnousu"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Näytä oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Tiedosto [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Näytä ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Näytä Tekstitiedosto"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Näytä Tekstitiedosto 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Näytä Tekstitiedosto 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Näytä HTTP-teksti"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW Internet-muunnin"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP Leveys"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP Korkeus"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Leikkaa kohdasta X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Leikkaa kohdasta Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Leikkaa leveyttä [0=pois päältä]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Leikkaa korkeutta [0=pois päältä]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Näytä kuva"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Tiedosto tai polku [ok]"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Suurin korkeus"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Nopea päivitys"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Näytä kuva 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Näytä kuva 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Näytä kuva 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "S-posti"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Rajat"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- S-postitilit"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- Suurin leveys"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Etälaite"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Etälaitteen ajastin"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Kuvakoko"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Kuvan positio"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Kuvan kohdistus"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Kalenteri"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF: Sallitut IP:t"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Ei lainkaan, tai väärä tiedosto valittu. Yritä uudelleen!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Tila"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Laite ei tue IP-turvallisuutta"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Kaatumisloki"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Näytä"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Poista"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Tiedostonimi"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Palauta asetukset"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Varmuuskopioi asetukset"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Poista lokitiedosto"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Lataa lokitiedosto"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Tallenna asetukset"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "pysäytä Screencycle"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Globaali"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "Päällä"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Valmiustila"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "Käyttöliittymän uudelleenkäynnistys tarvitaan"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Elementti"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "muut"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "aseta Asetukset"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "kopioi Päällä-tilaan"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "kopioi Media-tilaan"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "kopioi Valmiustilaan"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Exec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Näytä ulkoiset"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Lista tallennusvälineistä"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Kotihakemisto"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Pe"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Maa"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sat"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Aurinko"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "To"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Tii"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Kes"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "musta"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "valkoinen"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "harmaa"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "hopea"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "slategray"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "vedensininen"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "kulta"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "viherkeltainen"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "keltainen"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "tumma oranssi"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "tummanpunainen"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "intianpunainen"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "oranssi"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "oranssinpunainen"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "punainen"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomaatti"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "tummanvihreä"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "vihreä"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "ruohonvihreä"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "vaaleanvihreä"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "lime"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "sininen"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "sinivioletti"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "cadetblue"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "cornflowerblue"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "tummansininen"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigonsininen"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "vaaleansininen"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "sinivihreä"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "darkorchid"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "tumma vaaleanpunainen"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violetti"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "ruskea"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "ruskeahko"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "oliivi"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "punaruskea"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "hiekanruskea"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Näytöt 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Näytöt 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Näytöt 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Näytöt 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Näytöt 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Näytöt 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Näytöt 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Näytöt 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Näyttö 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Näyttö 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Näyttö 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Näyttö 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Näyttö 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Näyttö 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Näyttö 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Näyttö 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Näyttö 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Näyttö 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Näyttö 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Näyttö 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Näyttö 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Näyttö 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Näyttö 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Näyttö 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Näyttö 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Näyttö 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Näyttö 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Näyttö 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Näyttö 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "pois päältä"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Näyttö 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Näyttö 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Näyttö 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "päällä"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (tai yhteensopiva LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (tai yhteensopiva LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (tai yhteensopiva LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (tai yhteensopiva nestekidenäyttö) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Sisäinen VDF-näyttö"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Sisäinen TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "vain 1024x600 -kuva"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "vain 320x240 -kuva"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "vain 800x480 -kuva"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "vain 800x600 -kuva"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "vain muokatun koon kuva"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "vain muokatun koon kuva 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Sisäinen Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 päivää, 1 rivi"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 päivää, 2 riviä"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 päivää, 1 rivi"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 päivää, 2 riviä"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 päivää, vertikaalinen näkymä"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 päivää, 1 rivi"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 päivää, 2 riviä"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 päivää, vertikaalinen näkymä"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Nykyinen lämpötila [+C]"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Nykyinen lämpötila [-C]"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Nykyinen"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Nykyinen lämpötila"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Kaikki"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Lämpötila"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Lämpötila+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Lämpötila+Co2+Ilmanpaine"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Lämpötila+Kosteus"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Moduli 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Moduli 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Moduli 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Moduli 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Moduli 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Moduli 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Moduli 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Moduli 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Moduli 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Moduli 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Moduli 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Moduli 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Moduli 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Moduli 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Moduli 2+6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Moduli 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Moduli 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Moduli 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Moduli 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Moduli 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Moduli 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Moduli 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Moduli 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "käyttäjän valitsema"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Palkki"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Palkki+Arvo"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Nuppi"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Nuppi+Arvo"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analoginen"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analoginen+Päivämäärä"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analoginen+Päivämäärä+Viikonpäivä"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analoginen+Päivämäärä+Viikonpäivä 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Päivämäärä"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Päivämäärä+Aika"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Päivämäärä+Aika+Viikonpäivä"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "\"Läppä\"-mallinen päivämäärä"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "\"Läppä\"-mallinen viikonpäivä"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Aika"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Aika+Viikonpäivä"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Viikonpäivä"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "keskellä"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "vasen"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "oikea"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Laajennettu"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Laajennettu (lyhyt)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Lyhyt"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Lyhyt (laajennettu)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Lyhyt+Laajennettu"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Kuukausi"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Kuukausi+Otsikko"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Viikko"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Viikko+Otsikko"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "ei Kalenteria"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Päivämäärät: 1 rivi"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Päivämäärät: 3 riviä"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Päivämäärät: 5 riviä"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Päivämäärät: 9 riviä"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Päivämäärät: suppea, 2 riviä"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Päivämäärät: suppea, 3 riviä"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "ei Päivämääriä"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Alleviiva"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Alleviiva 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Kehys"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Päivämäärät"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Päivämäärät: suppea"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Päivämäärät: suppea, ei ikonia"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Päivämäärät: ei ikonia"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "ei Ikonia"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "ei ikonia, kohdenumeroiden kanssa"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "ikonin kanssa"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "ikonin ja kohdenumeron kanssa"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "ei"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Kuorma@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Kuorma@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "näytä käynnissä"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "näytä käynnissä+lepotilassa"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Aina kaikki"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Aina uusin"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Vain uusin"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Kaikki tiedot"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Vain etäisyys"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Etäisyys + valaistu %"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Etäisyys + kuuvaihe"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Vain valaistu %"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Valaistu % + kuuvaihe"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Vain kuuvaihe"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Kanava"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Kanava+Otsikko"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Kanava"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Kanava+Otsikko"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "sama väri"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "kyllä +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "kyllä"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "vertikaalinen"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horisontaalinen"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "kaikki"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Kulma"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Kulma+Ajansiirto"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Ajansiirto"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "vain etenemispalkki"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "jäljellä oleva aika minuutteina"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "jäljellä oleva aika minuutteina (Koko 1,5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "jäljellä oleva aika minuutteina (Koko 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "prosentteina"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "prosentteina (Koko 1,5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "prosentteina (Koko 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "jäljellä oleva aika minuutteina (yläpuolella)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "jäljellä oleva aika minuutteina (Koko 1,5/yläpuolella)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "jäljellä oleva aika minuutteina (Koko 2/yläpuolella)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "prosentteina (yläpuolella)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "prosentteina (yläpuolella/Koko 1,5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "prosentteina (yläpuolella/Koko 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "jäljellä oleva aika minuutteina (alapuolella)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "jäljellä oleva aika minuutteina (Koko 1,5/alapuolella)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "jäljellä oleva aika minuutteina (Koko 2/alapuolella)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "prosentteina (alapuolella)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "prosentteina (alapuolella/Koko 1,5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "prosentteina (alapuolella/Koko 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "nykyinen 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "nykyinen 00:00 (Koko 1,5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "nykyinen 00:00 (Koko 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "nykyinen 00:00 (yläpuolella)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "nykyinen 00:00 (yläpuolella/koko 1,5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "nykyinen 00:00 (yläpuolella/koko 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "nykyinen 00:00 (alapuolella)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "nykyinen 00:00 (alapuolella/koko 1,5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "nykyinen 00:00 (alapuolella/koko 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella/koko 1,5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella/koko 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "absoluuttinen loppuaika"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "absoluuttinen loppuaika (Koko 1,5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "absoluuttinen loppuaika (Koko 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella/koko 1,5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella/koko 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Nopea (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normaali (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alphabetic"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "sekalainen"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "parempi/hidas"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "huonompi/nopea (vain kuva)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "huonompi/nopea (kaikki)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + sovitus (korkea laatu, hidas)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + sovitus (huonompi laatu, nopea)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "ei cachea + ei sovitusta"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Sisäinen viritin"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB-viritin"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Nyt/Seuraava"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normaali"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "pelkistetty"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript, ei virkistystä"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Uudelleenlataus"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normaali"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - vierekkäin"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "vaihtoehtoinen Kopio-tila/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "kyllä + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "kyllä, pitkä"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "kyllä, lyhyt"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Coversearch"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "aina"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "Päällä+Media+Valmiustila"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Valmiustila"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - väri"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - harmaasävy/väri"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x eteenpäinkelaus"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x eteenpäinkelaus, tyyppi 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Pitkä eteenpäinkelaus"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Pitkä eteenpäinkelaus tyyppi 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Info-näppäin"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Mykistys"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Pitkä Info-painike"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x taaksepäinkelaus"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x taaksepäinkelaus, tyyppi 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Pitkä taaksepäinkelaus"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Pitkä taaksepäinkelaus tyyppi 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "kyllä, laajennettu"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Normaali konsoli"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Laajennettu lokitiedosto"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Normaali lokitiedosto"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "pois päältä"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (täysi)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normaali (täysi)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "säädetty (musta)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "säädetty (läpinäkyvä)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "Mykistä, tai määritelty painike"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "mikä tahansa painike"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Aika+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Aika+Kesto+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Aika+Pituus+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "half left"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "half right"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Kehys x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Line"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "ei Palkkia"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "ei Reunusta"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Liukuväri"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Varjostetut reunat"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normaali"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Positio alla"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Positio vasemmalla"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Positio oikealla"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Sijainti"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Nimi"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Ei yhteyttä"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Verkkoyhteys"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Päällä ja pois päältä"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "vain ajastimen käyttö"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "käytä aloitusaikaa"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "ei koko ajastusta"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "näytä koko ajastus"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "yksi rivi"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "kaksi riviä"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Muistia saatavilla"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Muistia vapaana"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "kokonäyttö"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "kyllä, paitsi tiedot"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "Itä"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "Itäkoillinen"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "Itäkaakko"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "Pohjoinen"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "Koillinen"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "Pohjoiskoillinen"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "Pohjoisluode"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "Luode"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "Etelä"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "Kaakko"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "Eteläkaakko"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "Etelälounas"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "Lounas"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "Länsi"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "Länsiluode"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "Länsiluode"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Lataa aktiivinen asetustiedosto"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Lataa oletukset / Tyhjennä konfiguraatio"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Tallenna tiedostoon... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Lataa tiedosto : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Poista tiedosto?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "poistettu"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "nyt asetettu : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux Asetukset"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Peruuta"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Tallenna"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Käynnistä näytöt uudelleen"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Aseta Päällä >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "ei LCD1 -kuvatiedostoa"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "ei LCD2 -kuvatiedostoa"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "ei LCD3 -kuvatiedostoa"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux päällä"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Tyyppi"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 Kierto"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Taustaväri"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Taustakuva [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Kirkkaus"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Yövalaistus"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 Virkistys"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Tyyppi"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Kierto"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Taustaväri"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Taustakuva [ok]"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Kirkkaus"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Yövalaistus"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 Virkistys"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Tyyppi"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Kierto"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Taustaväri"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Taustakuva [ok]"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Kirkkaus"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Yövalaistus"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 Virkistys"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "VDF-näytön mitat"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "VDF-näyttön  poikkeama"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "VDF-näytön väri"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "VDF-näyttö, aktivoi Käynnissä -tilassa"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "VDF-näyttö, aktivoi Media -tilassa"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "VDF-näyttö, aktivoi valmiustilassa"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [näytettävä aika]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- mikä LCD-näyttö"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Näytä tilassa"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- OSD:n koko"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Tausta/Läpinäkyvyys"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Fast Grab lower quality"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Popup-Teksti"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Poistu-painike"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Fontin koko"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Positio"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Kohdistus"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Tekstin väri"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Taustaväri"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Fontti"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Aktiivinen näyttö"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Valitse vaihdettava näyttö - Näyttö"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Valitse vaihdettava näyttö - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Valitse kierrätettävät näytöt"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Näytön 1 vaihtumisaika"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Näyttö 2 vaihtumisaika"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Näyttö 3 vaihtumisaika"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Näyttö 4 vaihtumisaika"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Näyttö 5 vaihtumisaika"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Näyttö 6 vaihtumisaika"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Näyttö 7 vaihtumisaika"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Näyttö 8 vaihtumisaika"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Näyttö 9 vaihtumisaika"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Kuvan vaihtumisaika"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Kuvien järjestys"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Rekursiivinen kuvahakemisto"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Kuvakoon muokkauksen kuvanlaatu"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Kuvan nopea päivitysaika [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Kuvan formaatti [vain kuva]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Taustakuvan tyyppi"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Sää-API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Sää: API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Sää: API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Sää: Kaupunki"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Sää: Kaupunki 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Sää-ikonin polku [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Sää-ikoni zoom"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Sää: Alhaisen lämpötilan väri"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Sää: Korkean lämpötilan väri"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Sää: Läpiväkyvyys"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Sää: Tuulen nopeusyksikkö"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Sää: Tuuli tietorivit"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Sää: Sateen mahdollisuus"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Sade Zoom"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Sateen väri"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Sade: Käytä väriä 2 paikasta"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Sateen väri 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Sää Kosteus Väri"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Sää: Erotin"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Sään: Trendinuolet"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Sää: Lisätiedot"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra Zoom"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Näytä viileän lämpötilan ero paikasta"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Kaupungin lisäväri"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Viileän lisäväri"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Pienin arvo"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Suurin arvo"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteo URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Kuu-ikonin polku [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Tallennuskuva [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Kaksoispainallus vaihtaa näyttöä"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Painike näytön vaihtamiseen"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Painike, näyttö päälle/pois"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall: Kuvien polku"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall: Rivien määrä"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall: Listojen määrä"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall: Kuvien määrä"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall: Kuvien asettelu"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall: Kuvan läpinäkyvyys"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall: Kuvahaku"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall: Tuntimäärä, jonka jälkeen puhelut poistetaan"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall: Popup-aika"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall: Popup-LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall: Popup-väri"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall: Kuva [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Kalenteri: ics-polku [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Kalenteri: ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Kalenteri: planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Kalenteri: Lauantain väri"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Kalenteri: Sunnuntain väri"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Kalenteri: Reunojen paksuus"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Kalenteri: Päivän tapahtumien esikatselu"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Kalenteri: Aikavyöhykkeen korjaus"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Kalenteri: Läpinäkyvyys"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Kalenteri: Kyselyiden aikaväli"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Viritin: Väri"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Viritin: Väri aktiivisena"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Viritin: Väri, kun laite päällä"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Palvelunhaku ensin"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Signaalitason korjaus"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Globaali Fontti [ok]"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Fontti 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Fontti 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Fontti 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Fontti 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Fontti 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Posti 1 Yhteystapa"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Posti 1 Palvelin"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Posti 1 [Näyttönimi:] Käyttäjätunnus"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Posti 1 Salasana"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Posti 2 Yhteystapa"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Posti 2 Palvelin"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Posti 2 [Näyttönimi:] Käyttäjätunnus"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Posti 2 Salasana"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Posti 3 Yhteystapa"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Posti 3 Palvelin"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Posti 3 [Näyttönimi:] Käyttäjätunnus"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Posti 3 Salasana"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Posti 4 Yhteystapa"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Posti 4 Palvelin"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Posti 4 [Näyttönimi:] Käyttäjätunnus"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Posti 4 Salasana"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Posti 5 Yhteystapa"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Posti 5 Palvelin"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Posti 5 [Näyttönimi:] Käyttäjätunnus"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Posti 5 Salasana"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Posti: Kyselyväli"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Posti: IMAP-rajan kesto päivissä"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Posti: Näytä \"Tyhjennä postilaatikot\""
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Posti: Näytä paivämäärä"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Posti: Piilota s-postiosoite"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Etälaite 1 [Näyttönimi:]IP/Nimi"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Etälaite 2 [Näyttönimi:]IP/Nimi"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Etälaite 3 [Näyttönimi:]IP/Nimi"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Etälaite 4 [Näyttönimi:]IP/Nimi"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Etälaite 5 [Näyttönimi:]IP/Nimi"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Etälaitteen pollaus joka minuutti"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Etälaitteen ajastus [Näyttönimi:]IP/Nimi"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Etälaitteen ajastuksen pollaus joka minuutti"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW-muuntimen kyselyväli"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW-muuntimen osoite"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "Cloudconvert.org WWW ApiKey"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "Convertapi.com WWW ApiKey"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF: Virkistä [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF: Virkistystyyppi"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF: Viive"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF: Estä IP:(t)"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF: Ulkoasu"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Tallenna kuva WebIF:lle"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG: Syöte LCD 1 Päälle"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG: Syöte LCD 1 Portti"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG: Syöte LCD 1 Virtuaalinen kirkkaus"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG: Syöte LCD 2 Päälle"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG: Syöte LCD 2 Portti"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG: Syöte LCD 2 Virtuaalinen kirkkaus"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG: Syöte LCD 3 Päälle"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG: Syöte LCD 3 Portti"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG: Syöte LCD 3 Virtuaalinen kirkkaus"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG: Kierto"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG: Virheen sattuessa, uudelleenkäynnistys"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG: Otsikkotila"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos: IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos: Ping Aikakatkaisu [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos: Play-tarkistus"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos: Virkistä [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound: Ping Aikakatkaisu [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound: Toisto-tarkistus"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound: Virkistä [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast: IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast: Palvelimen IP [valinnainen]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast: Ping-aikakatkaisu [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast: Play-tarkistus"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast: Virkistä [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast: Kansikuva"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD: Mukautettu leveys"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD: Mukautettu korkeus"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD: Mukautettu leveys 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD: Mukautettu korkeus 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD: pois päältä kun sammutettuna"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Näytön viive [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Ketjut per LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Show Crash Corner"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Näytä 'ei ....' Viestejä"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Tallennusväline: Pakota luku"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Tallennusväline: Taustaväri"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Tallennusväline: Palkin väri"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Tallennusväline: Väri, kun tilaa on vähän jäljellä"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Verkkotarkistus aktiivinen"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Vaihda ruutubufferia [jos mahdollista]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Asetukset: Varmuuskopion polku [ok]"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Asetukset: Palauta kaikki asetukset"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debug-Lokit > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Ei taustavaloa"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Taustavalo päällä"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Ei taustavaloa viikonloppuisin"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Taustavalo Viikkonloppuisin päällä"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Automaattisesti pois päältä"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Tausta"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Kuva [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Piconin koko"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Jaettu näyttö"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Kokonäyttö"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Tekstin koko"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Läpinäkyvyys"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Piconien polku [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Piconien polku 2[ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Piconien cachen polku [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Kello"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "- Tyyppi"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analoginen kello"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Kellon ja pvm väli"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Koko"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Varjoreunat"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Kello 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Kanavan nimi"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- suurin määrä rivejä"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Pituus"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Ohjelman numero"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Ohjelmainfo"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Tyyppi"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Ohjelmainfo 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Seuraavan ohjelman info"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Laajennettu kuvaus"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- näytä Info kun tämä on tyhjä"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Etenemispalkki"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Tekstin väri"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Reunat"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Varjostettu"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Yksikkö min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Laitteen tekniset tiedot"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Viritininfo"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensorit"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Laitteen tekniset tiedot 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Signaalitason palkki"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Liukuväri"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Palkin pienin vaihteluväli"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Palkin suurin vaihteluväli"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satelliitti"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Tarjoaja"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Käytetty viritin"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- vain aktiivinen Viritin"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Seuraava ajastus"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Äänenvoimakkuus"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Mykistä"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bittinopeus"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Verkkoyhteys [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Näytä tila"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Aikakatkaisu [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Verkkonimi:Osoite"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Ulkoinen IP-osoite"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- ulkoinen IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Tallennusvälineet"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- Vapaan tilan varoitus"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- Lisätietoa"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Tallennusväline"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "Kiintolevy"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Miten sää-tiedot näytetään"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Sää 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo-Sääasema"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Asema"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Moduli"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Käyttäjän asettama moduli"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Nimi"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Väri 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Väri 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Väri 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Väri 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Väri 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Väri 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo-sääasema 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Indikaattori"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Palkin pituus"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo \"Tuntuu kuin\""
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Kuuvaihe"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Tietorivit"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Trendinuolet"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Auringonnousu"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Näytä oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Tiedosto [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Näytä ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Näytä Tekstitiedosto"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Näytä Tekstitiedosto 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Näytä Tekstitiedosto 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Näytä HTTP-teksti"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW Internet-muunnin"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP Leveys"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP Korkeus"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Leikkaa kohdasta X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Leikkaa kohdasta Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Leikkaa leveyttä [0=pois päältä]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Leikkaa korkeutta [0=pois päältä]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Näytä kuva"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Tiedosto tai polku [ok]"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Suurin korkeus"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Nopea päivitys"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Näytä kuva 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Näytä kuva 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Näytä kuva 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Rajat"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- S-posti tilit"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- Suurin leveys"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Etälaitteen ajastin"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Kuvakoko"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Kuvan positio"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Kuvan kohdistus"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Ulkoasu"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Kuluvan päivän taustaväri"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Selosteen väri"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Päivämäärät: Lista"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
-msgstr "Tapahtumapalkki"
+msgstr "Tapatumapalkki"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popup Näyttö"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Näytä Teksti 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Teksti"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Näytä Teksti 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
-msgstr "Suorakulmio 1"
+msgstr "Rectangle 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Positio x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Positio y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Koko x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Koko y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
-msgstr "Suorakulmio 2"
+msgstr "Rectangle 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Tallentaa"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
-msgstr "Nykivä TV-kuva"
+msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Vaihdossa käytettävä näyttö"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Otsikko"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Infot"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Näytä kansikuva"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Hakupolku [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Etsi kansikuva [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Oletus Kansikuva [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
-msgstr "- Piconi ensin"
+msgstr "- Picon ensin"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Leikattu"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Lataa kansikuva"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Lataa tyyppi"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
-msgstr "- Google API-Avain console.developers.google.com/apis"
+msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD-näyttö"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Näyttötila: Päällä"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Aseta Media >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Näyttötila: Media"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Aseta Valmiustila >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Näyttötila: Valmiustilassa"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Aseta Globaali >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Valitse hakemisto"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Valitse tiedosto"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Valitse fontti"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Nykyinen arvo: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 msgstr ""
-"Käyttöliittymä pitää käynnistää uudelleen, jotta asetukset astuvat voimaan.\n"
-"Haluatko uudelleenkäynnistää nyt?"
+"Käyttöliittymä pitää käynnistää uudelleen jotta asetukset astuvat voimaan.\n"
+"Haluatko uudelleenkäynnistää?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
-msgstr "Käyttöliittymän uudelleenkäynnistys nyt?"
+msgstr "Käyttöliittymän uudelleenkäynnisty nyt?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Sisätila"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Ulkoilma"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Sadetta"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Tuuli"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Uusikuu"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Kasvava Kuunsirppi"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Ensimmäinen Neljännes"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Kasvava Kuu"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Täysikuu"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Vähenevä Kuu"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Kolmas Neljännes"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Vähenevä Kuunsirppi"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Kuva ei ole saatavilla"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "ei Ajastusta"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM ei ole päällä"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "ei Puheluita"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Postia  %d Uusia  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "Netatmo-Pluginia ei ole asennettu"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Näytönvaihto"
 
@@ -3954,105 +4187,3 @@ msgstr "LCD4linux Näytönvaihto"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Sää Tuulen suunta"
-
-#~ msgid "Backup Config"
-#~ msgstr "Varmuuskopioi asetukset"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "VDF-näyttö"
-
-#~ msgid "Crashlog"
-#~ msgstr "Kaatumisloki"
-
-#~ msgid "Delete"
-#~ msgstr "Poista"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Poista lokitiedosto"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Lataa lokitiedosto"
-
-#~ msgid "Exec"
-#~ msgstr "Exec"
-
-#~ msgid "Font"
-#~ msgstr "Fontti"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "Käyttöliittymän uudelleenkäynnistys tarvitaan"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Laite ei tue IP-turvallisuutta"
-
-#~ msgid "Key"
-#~ msgstr "Painikkeet"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Lista tallennusvälineistä"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG: Syöte"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Ei lainkaan, tai väärä tiedosto valittu. Yritä uudelleen!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Kotihakemisto"
-
-#~ msgid "Picture"
-#~ msgstr "Kuva"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Popup-Teksti"
-
-#~ msgid "Restore Config"
-#~ msgstr "Palauta asetukset"
-
-#~ msgid "Save Config"
-#~ msgstr "Tallenna asetukset"
-
-#~ msgid "Screen"
-#~ msgstr "Näyttö"
-
-#~ msgid "Show"
-#~ msgstr "Näytä"
-
-#~ msgid "Show Externals"
-#~ msgstr "Näytä ulkoiset"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Viritin"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW-muunnin"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "kopioi Valmiustilaan"
-
-#~ msgid "copy to Media"
-#~ msgstr "kopioi Media-tilaan"
-
-#~ msgid "copy to On"
-#~ msgstr "kopioi Päällä-tilaan"
-
-#~ msgid "other"
-#~ msgstr "muut"
-
-#~ msgid "set Settings"
-#~ msgstr "aseta Asetukset"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "Pysäytä ruutujen kierrätys"

--- a/LCD4linux/po/fr.po
+++ b/LCD4linux/po/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:07+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:16+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -13,3831 +13,4064 @@ msgstr ""
 "X-Poedit-KeywordsList: _;gettext;gettext_noop\n"
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Ven"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Lun"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sam"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Police"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Dim"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Clé"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Jeu"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Mar"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Mer"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Image"
 
-#: plugin.py:288
-msgid "black"
-msgstr "noir"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Popup-Texte"
 
-#: plugin.py:288
-msgid "white"
-msgstr "blanc"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "gris"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Tuner"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "argent"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW Convertisseur"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "gris ardoise"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "bleu-vert"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Ecran"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "or"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "jaune-vert"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "jaune"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "orange foncé"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "rouge foncé"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "rouge indien"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "orange"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "orangé"
-
-#: plugin.py:292
-msgid "red"
-msgstr "rouge"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomate"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "vert foncé"
-
-#: plugin.py:293
-msgid "green"
-msgstr "vert"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "vert prairie"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "vert clair"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "citron vert"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "bleu"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "bleu violet"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "bleu de cadet"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "bleu fleur de maïs"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "bleu foncé"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "bleu clair"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "cyan"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "orchidée noire"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "rose intense"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violet"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "brun"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "moccasin"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olive"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "brun rosé"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "brun sable"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Écran 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Écran 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Écran 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Écran 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Écran 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Écran 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Écran 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Écran 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Écran 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Écran 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Écran 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Écran 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Écran 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Écran 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Écran 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Écran 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Écran 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Écran 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Écran 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Écran 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Écran 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Écran 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Écran 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Écran 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Écran 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Écran 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Écran 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Écran 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Écran 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "hors"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Écran 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Écran 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Écran 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "en"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2 h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3 h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5 h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (ou compatible LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (ou compatible LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (ou compatible LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (ou compatible LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H ancien 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Interne TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Interne Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "seulement image 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "seulement image 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "seulement image 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "seulement image 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "seulement image taille personnalisée"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "seulement image de taille personnalisée 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "InterneVu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 jours 1 Ligne"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 jours 2 Lignes"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 Jours 1 Ligne"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 Jours 2 Lignes"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 Jours Vue Verticale"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 Days 1 Line"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 Days 2 Lines"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 Days Vertical View"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "TempErature actuelle (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Température actuelle (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Actuel"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Température actuelle"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Tout"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Température"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Température+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Température+Co2+Pression"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Températur+Humidité"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Modul 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Modul 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Modul 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Modul 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Modul 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Modul 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Modul 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Modul 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Modul 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Module 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Modul 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Modul 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Modul 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Modul 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Module 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Modul 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Modul 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Module 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Modul 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Module 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Modul 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Module 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Module 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "défini par l'utilisateur"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Bar"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Bar+Valeur"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Boutton"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Boutton+Valeur"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analogique"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analogique+Date"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analogique+Date+jour de la semaine"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analogique+Date+Joursemaine 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Date"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Date+Heure"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Date+Heure+jour de la semaine"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Date de conception des volets"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Flaps Design Jour de semaine"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Heure"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Heure+Jour de la semaine"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Jour semaine"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "centre"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "gauche"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "droit"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Etendu"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Etendu (court)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Court"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Court (Etendu)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Court+Etendu"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Mois"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Mois+entête"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Semaine"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Semaine+entête"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "pas de Calendrier"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Dates 1 Ligne"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Dates 3 Lignes"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Dates 5 Lignes"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Dates 9 Lignes"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Dates compactes 2 Lignes"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Dates compactes 3 Lignes"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "pas de Dates"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Sous-ligné"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Sous-ligné 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Cadre"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Dates"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Dates compactes"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Dates compactes pas d'icône"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Dates pas d'icône"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "pas d'icône"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "pas d'icône, avec numéro cible"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "avec Icône"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "avec Icône & Numméro cible"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "tpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "non"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Charge@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Charge@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "afficher actif"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "afficher actif+dormant"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Toujours tout"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Toujours nouveau"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Seulement nouveau"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Toutes les Informations"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Distance seulement"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Distance+Éclairage"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Distance+Moonphase"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Éclairage seulement"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Illumination+Phase de Lune"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Phase de lune uniquement"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Chaîne"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Chaîne+Titre"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Chaîne"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Chaîne+Titre"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "même couleur"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "oui +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "oui"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "verticalement"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontallement"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Global"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "tous"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Coin"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Corner+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+PauseDirect"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "seulement barre de progression"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "avec les minutes restantes"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "avec les minutes restantes (taille 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "avec les minutes restantes (taille 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "avec pourcentage"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "avec pourcentage (taille 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "avec pourcentage (taille 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "avec les minutes restantes (au-dessus)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "avec les minutes restantes (au-dessus/taille 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "avec les minutes restantes (au-dessus/taille 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "avec pourcentage (au-dessus)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "avec pourcentage (au-dessus/taille 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "avec pourcentage (au-dessus/taille 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "avec les minutes restantes (en-dessous)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "avec les minutes restantes (en-dessous/taille 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "avec les minutes restantes (en-dessous/taille 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "avec pourcentage (en-dessous)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "avec pourcentage (en-dessous/taille 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "avec pourcentage (en-dessous/taille 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "avec actuel 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "avec actuel 00:00 (taille 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "avec actuel 00:00 (taille 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "avec actuel 00:00 (au-dessus)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "avec actuel 00:00 (au-dessus/taille 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "avec actuel 00:00 (au-dessus/taille 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "avec actuel 00:00 (en-dessous)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "avec actuel 00:00 (en-dessous/taille 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "avec actuel 00:00 (en-dessous/taille 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "avec pourcentage minutes / Total (dessus)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "avec poucentage minutes / Total (dessus/Taille 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "avec pourcentage minutes / Total (dessus/Taille 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "avec heure de fin absolue"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "avec heure de fin absolue (taille 1,5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "avec heure de fin absolue (taille 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "avec Minutes Total / Heure de fin (ci-dessus)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "avec Minutes Total / Heure de fin (ci-dessus / Taille 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "avec Minutes Total / Heure de fin (ci-dessus/Taille 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Mode rapide (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alphabétique"
-
-#: plugin.py:386
-msgid "random"
-msgstr "aléatoire"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "meilleur/lent"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "bas/rapide (image seulement)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "bas/rapide (tout)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + ajustement (haute qualité, lent)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + ajustement (basse qualité, rapide)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "pas de cache + pas d'ajustement"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Insérer Tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Actuellement/suivant"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "reduit"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript pas de Rafraîchissement"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Recharger"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - cote à cote"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OuvrirMapMétéo"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "MétéoDévérouillée"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternatif Mode-Copie/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "oui + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "oui, long"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "oui, court"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Recherche couverture"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "toujours"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "En+Média+Veille"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Veille"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Média"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "En"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - couleur"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - échelle de gris/couleur"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x touche avance rapide"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x touche avance rapide type 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Long touche avance rapide"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Long touche avance rapide Type 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x touche Info"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x mute"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Long touche info"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x touche retour rapide"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x touche retour rapide type 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Long touche retour rapide"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Long touche retour rapide Type 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "oui, étendu"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Console normale"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Logfile étendu"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Logfile normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "désactivé"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Média"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Média"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (complet)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normal (complet)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "rogné (noir)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "rogné (transparent)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE ou touches définies"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "n'importe quelle Clé"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Heure+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Heure+Durée+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Heure+Longueur+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "moitié gauche"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "moitié droite"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Cadre x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Ligne"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "pas de Bar"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "pas de cadre"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Dégradé"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Bords ombrés"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Position en dessous"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Position gauche"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Position droite"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Position"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Nom"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Hors-ligne"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "En ligne"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "En ligne+Hors ligne"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "seulement utiliser prog"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "utiliser délai"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "pas d'enregistrement complet"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "afficher programmation total"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "en ligne"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "deux lignes"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Mémoire disponible"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Mémoire libre"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "plein écran"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "oui excepté les enregistrements"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "O"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ONO"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "OSO"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NO"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNO"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNW"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NW"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SO"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSO"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSW"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SW"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "W"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "WNW"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "WSW"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Charger fichier configuration actif"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Charger les valeurs par défaut / Config vide"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Sauvegarder fichier de configuration... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Charger fichier : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Effacer fichier?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "effacé"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "actuellement défini : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "Paramètres LCD4linux"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Mode"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Fermer"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Sauver"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Relancer affichages"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Réglages en >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Veille"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "pas de fichier image LCD1"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "pas de fichier image LCD2"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "pas de fichier image LCD3"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux activé"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Type"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 Rotation"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Couleur du fond"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Image de fond [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Luminosité"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Mode nuit"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 Rafraîchir"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Type"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Rotation"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Couleur de fond"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Image de fond [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Luminosité"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Mode nuit"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 Rafraîchir"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Type"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Rotation"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Couleur du fond"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Image de fond [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Luminosité"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Mode nuit"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 Rafraîchir"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD Dimension"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Décalage"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD Couleur"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD Activer le mode-En"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD Activer le mode-Média"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD Activer le mode-Veille"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [afficher l'heure]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- Quel LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Afficher en mode"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Taille OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Fond/Transparence"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Saisie rapide qualité plus faible"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Texte popup"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Effacer la clé"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Taille Police"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Position"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Alignement"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Couleur"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Couleur du fond"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Police"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Ecran actif"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Ecran sélection commutation  - Ecran"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Ecran sélection commutation  - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Ecran utilisé pour changer"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Durée de changement écran 1"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Ecran 2 Temps de changement"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Ecran 3 Temps de changement"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Ecran 4 Temps de changement"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Ecran 5 Temps de changement"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Ecran 6 Temps de changement"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Ecran 7 Temps de changement"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Ecran 8 Temps de changement"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Ecran 9 Temps de changement"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Vitesse de changement des images"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Trier image"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Répertoire image récursive"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Image qualité de la mise à l'échelle"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Image mise à jour rapide [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Type photo [seulement photo]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Type photo arrière plan"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Météo API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Météo API-Touche OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key MétéoDévérouillée"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Ville météo"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Ville météo 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Chemin vers les icônes météo [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Zoom icône météo"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Météo couleur des températures basses"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Météo couleur des températures hautes"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Météo transparence"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Météo unité vitesse vent"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Météo Vent Lignes d'informations"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Météo risque de pluie"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Zoom Pluie"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Couleur Pluie"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Couleur de pluie 2 de"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Couleur Pluie 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Météo lignes"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Météo Flèches de Tendance"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Météo Infos extra"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Zoom Extra"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Afficher différence température ressentie"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Couleur ville extra"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Couleur froide extra"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo plage min CO2"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo plage max CO2"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "URL météo"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Chemin des icônes de lune [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Enregistrement photo [OK]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Interrupteurs double-boutons"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Touche pour changer d'écran"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Touche pour écran En/Hors"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall chemin des images [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall nombre de ligne par entrée"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall nombre d'entrées de la liste"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall nombre d'images"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall orientation image"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall transparence photo"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall recherche photos"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall supprimer les appels après heures"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall durée du popup"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall popup LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall couleur popup"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall image du cadre [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Calendrier chemin-ics [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Calendrier URL-ics"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Calendrier PlanerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Calendrier couleur samedi"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Calendrier couleur dimanche"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Calendrier épaisseur ligne"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Calendrier prévisualisation de l'événement du jour"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Calendrier correction fuseau horaire"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Calendrier transparence"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Calendrier interval requête"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Couleur tuner"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Couleur tuner actif"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Activer la couleur du tuner"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Recherche service en premier"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Signal-Correction qualité"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Police global [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Police 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Police 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Police 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Police 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Police 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 Connection"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 Serveur"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Nom affiché:]Nom utilisateur"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 Mot de passe"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 Connection"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 Serveur"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Nom affiché:]Nom utilisateur"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 Mot de passe"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 Connection"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Serveur"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Nom affiché:]Nom utilisateur"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 Mot de passe"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 Connection"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 Serveur"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Nom affiché:]Nom utilisateur"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 Mot de passe"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 Connection"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 Serveur"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Nom affiché:]Nom utilisateur"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 Mot de passe"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Interval requête mail"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Mail IMAP limiter aux dernier jours"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail Afficher les boîtes vides"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Mail Afficher les dates"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Mail Cacher adresse mail"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Boite 1 distante [AfficherNom:]IP/Nom"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Boite 2 distante [AfficherNom:]IP/Nom"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Boite 3 distante [AfficherNom:]IP/Nom"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Boite 4 distante [AfficherNom:]IP/Nom"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Boite 5 distante [AfficherNom:]IP/Nom"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Boite distante requête toutes les minutes"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Remote Box Timer [NomAffiché:]IP/Nom"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Remote Box Timer Sondage toutes les minutes"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW convertisseur interval requête"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW utilisation convertisseur"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey depuis cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey depuis convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF rafraîchissement [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF type de rafraîchissement"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF délai d'init"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF autoriser IP"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF rejeter IP"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF Design"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Sauver comme image pour WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 activé"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 Port"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 Luminosité virtuelle"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 activé"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 Port"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 Luminosité virtuelle"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 activé"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 Port"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 Luminosité virtuelle"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "Cycle MJPEG"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "Redémarrage de MJPEG en cas d'erreur"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG mode Header"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Timeout[ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Play Check"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Rafraîchissement[s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Ping Timeout [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound Play Check (en)"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Rafraîchir [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Serveur IP [optionnel]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Timeout[ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Play Check"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Rafraîchissement[s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Pochette"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD largeur personnalisée"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD hauteur personnalisée"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD Largeur personnalisée 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD Hauteur personnalisée 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "Écran LCD éteint lors de l'arrêt"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Timing! calc tous temps comme temps/5*2 mode rapide"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Délai d'affichage [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Processus par LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Afficher Couverture Crash"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Afficher 'non ...' messages"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Périphérique-Stockage: Forcer la lecture"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Dispositifs de stockage : Couleur arrière"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Dispositifs de stockage : Barre de couleurs"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Dispositifs de stockage : Couleur Pleine"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Contrôle réseau actif"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Commuter TamponFram [si possible"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Config chemin sauvegarde [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Config restauration tous les paramètres"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Journal-Debug > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Rétro-éclairage hors [définir hors=en]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Rétro-éclairage On"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Rétro-éclairage Weekend hors [définir hors=en]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Rétro-Eclairage Weekend On"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Auto-OFF"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Arrière plan"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Photo [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Taille Picon"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Ecran partagé"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Plein écran"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Taille du texte"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparence"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Chemin Picon [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Chemin Picon 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Chemin du cache Picon [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Horloge"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Type"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Horloge analogique"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Espacement"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Taille"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Bords ombrés"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Horloge 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Nom du programme"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- Lignes maximum"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Longueur"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Numéro du programme"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Info programme"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Type"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Programme Info 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Info programme suivant"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Description étendue"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- utiliser Info lorsqu'il est vide"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Barre de progression"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Couleur Texte"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Entourage"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Ombré"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Unité min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informations"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Info Tuner"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Senseurs"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informations 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Afficher Barre de qualité"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Dégradé"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Bar plage Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Bar plage Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satellite"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Opérateur"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Tuner utilisé"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- Seulement le tuner actif"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Evénement prog suivant"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volume"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Mute"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Vidéo"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "En ligne [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Afficher état"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Temps dépassé [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- En ligne Nom:Adresse"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Adresse IP externe"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- URL IP externe"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Périphériques-Stockages"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- avertissement libre"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- Info extra"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Nom du périphérique"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Météo"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Type Météo"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Météo 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Météo-Station Météo"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Station"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Module"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Module défini par l'utilisateur"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Base"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Nom"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Couleur 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Couleur 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Couleur 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Couleur 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Couleur 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Couleur 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo indicateur CO2"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Longueur [Bar]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Indicateur confort"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Phase de lune"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Lignes d'information"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Flèches de Tendance"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Levé du soleil"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Afficher oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Fichier [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Afficher ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Afficher fichier texte"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Afficher fichier texte 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Afficher fichier texte 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Afficher texte HTTP"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-Internet convertisseur"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- Largeur HTTP"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- Hauteur HTTP"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Couper à partir de X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Couper à partir de Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Couper Largeur [désactiver = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Couper Hauteur [désactiver = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Afficher image"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Fichier ou Chemin [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Taille max Hauteur"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Mise-à-jour rapide"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Afficher image 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Afficher image 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Afficher image 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Lignes"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Compteur Mail"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- Largeur max"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Boite distante"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Minuterie de boîte à distance"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Taille Image"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Position Image"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Alignement Image"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Calendrier"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF autoriser IP"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Aucun ou mauvais fichier sélectionné, essayer un fichier correct d'abord!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Mode"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Sécurité IP non supporté par récepteur"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Crashlog"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Afficher"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Effacer"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Nom de fichier"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Restaurer configuration"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Sauvegarde config"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Effacer fichier log"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Télécharger fichier log"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Sauver configuration"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "stopper cycle écran"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Global"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "En"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Média"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Veille"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "Redémarrage de l'IGU nécessaire"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Élément"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "autre"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "définir les paramètres"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "copier vers en"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "copier vers média"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "copier vers repos"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Exec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Afficher externe"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Liste des périphériques de stockage"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Dossier parent"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Ven"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Lun"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sam"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Dim"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Jeu"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Mar"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Mer"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "noir"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "blanc"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "gris"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "argent"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "gris ardoise"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "bleu-vert"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "or"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "jaune-vert"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "jaune"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "orange foncé"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "rouge foncé"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "rouge indien"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "orange"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "orangé"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "rouge"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomate"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "vert foncé"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "vert"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "vert prairie"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "vert clair"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "citron vert"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "bleu"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "bleu violet"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "bleu de cadet"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "bleu fleur de maïs"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "bleu foncé"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "bleu clair"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "cyan"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "orchidée noire"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "rose intense"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violet"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "brun"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "moccasin"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olive"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "brun rosé"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "brun sable"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Écran 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Écran 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Écran 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Écran 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Écran 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Écran 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Écran 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Écran 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Écran 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Écran 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Écran 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Écran 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Écran 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Écran 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Écran 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Écran 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Écran 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Écran 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Écran 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Écran 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Écran 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Écran 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Écran 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Écran 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Écran 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Écran 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Écran 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Écran 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Écran 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "hors"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Écran 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Écran 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Écran 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "en"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2 h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3 h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5 h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (ou compatible LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (ou compatible LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (ou compatible LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (ou LCD compatible) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H ancien 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Interne Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Interne TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "seulement image 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "seulement image 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "seulement image 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "seulement image 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "seulement image taille personnalisée"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "seulement image de taille personnalisée 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "InterneVu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 jours 1 Ligne"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 jours 2 Lignes"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 Jours 1 Ligne"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 Jours 2 Lignes"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 Jours Vue Verticale"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 Days 1 Line"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 Days 2 Lines"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 Days Vertical View"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "TempErature actuelle (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Température actuelle (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Actuel"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Température actuelle"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Tout"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Température"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Température+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Température+Co2+Pression"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Températur+Humidité"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Modul 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Modul 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Modul 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Modul 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Modul 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Modul 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Modul 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Modul 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Modul 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Module 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Modul 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Modul 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Modul 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Modul 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Module 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Modul 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Modul 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Module 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Modul 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Module 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Modul 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Module 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Module 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "défini par l'utilisateur"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Bar"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Bar+Valeur"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Boutton"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Boutton+Valeur"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analogique"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analogique+Date"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analogique+Date+jour de la semaine"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analogique+Date+Joursemaine 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Date"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Date+Heure"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Date+Heure+jour de la semaine"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Date de conception des volets"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Flaps Design Jour de semaine"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Heure"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Heure+Jour de la semaine"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Jour semaine"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "centre"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "gauche"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "droit"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Etendu"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Etendu (court)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Court"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Court (Etendu)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Court+Etendu"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Mois"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Mois+entête"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Semaine"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Semaine+entête"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "pas de Calendrier"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Dates 1 Ligne"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Dates 3 Lignes"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Dates 5 Lignes"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Dates 9 Lignes"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Dates compactes 2 Lignes"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Dates compactes 3 Lignes"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "pas de Dates"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Sous-ligné"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Sous-ligné 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Cadre"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Dates"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Dates compactes"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Dates compactes pas d'icône"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Dates pas d'icône"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "pas d'icône"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "pas d'icône, avec numéro cible"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "avec Icône"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "avec Icône & Numméro cible"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "tpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "non"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Charge@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Charge@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "afficher actif"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "afficher actif+dormant"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Toujours tout"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Toujours nouveau"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Seulement nouveau"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Toutes les Informations"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Distance seulement"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Distance+Éclairage"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Distance+Moonphase"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Éclairage seulement"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Illumination+Phase de Lune"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Phase de lune uniquement"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Chaîne"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Chaîne+Titre"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Chaîne"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Chaîne+Titre"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "même couleur"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "oui +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "oui"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "verticalement"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontallement"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "tous"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Coin"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Corner+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+PauseDirect"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "seulement barre de progression"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "avec les minutes restantes"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "avec les minutes restantes (taille 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "avec les minutes restantes (taille 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "avec pourcentage"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "avec pourcentage (taille 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "avec pourcentage (taille 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "avec les minutes restantes (au-dessus)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "avec les minutes restantes (au-dessus/taille 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "avec les minutes restantes (au-dessus/taille 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "avec pourcentage (au-dessus)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "avec pourcentage (au-dessus/taille 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "avec pourcentage (au-dessus/taille 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "avec les minutes restantes (en-dessous)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "avec les minutes restantes (en-dessous/taille 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "avec les minutes restantes (en-dessous/taille 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "avec pourcentage (en-dessous)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "avec pourcentage (en-dessous/taille 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "avec pourcentage (en-dessous/taille 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "avec actuel 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "avec actuel 00:00 (taille 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "avec actuel 00:00 (taille 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "avec actuel 00:00 (au-dessus)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "avec actuel 00:00 (au-dessus/taille 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "avec actuel 00:00 (au-dessus/taille 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "avec actuel 00:00 (en-dessous)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "avec actuel 00:00 (en-dessous/taille 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "avec actuel 00:00 (en-dessous/taille 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "avec pourcentage minutes / Total (dessus)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "avec poucentage minutes / Total (dessus/Taille 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "avec pourcentage minutes / Total (dessus/Taille 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "avec heure de fin absolue"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "avec heure de fin absolue (taille 1,5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "avec heure de fin absolue (taille 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "avec Minutes Total / Heure de fin (ci-dessus)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "avec Minutes Total / Heure de fin (ci-dessus / Taille 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "avec Minutes Total / Heure de fin (ci-dessus/Taille 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Mode rapide (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alphabétique"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "aléatoire"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "meilleur/lent"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "bas/rapide (image seulement)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "bas/rapide (tout)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + ajustement (haute qualité, lent)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + ajustement (basse qualité, rapide)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "pas de cache + pas d'ajustement"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Insérer Tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Actuellement/suivant"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "reduit"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript pas de Rafraîchissement"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Recharger"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - cote à cote"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OuvrirMapMétéo"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "MétéoDévérouillée"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternatif Mode-Copie/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "oui + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "oui, long"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "oui, court"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Recherche couverture"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "toujours"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "En+Média+Veille"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Veille"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - couleur"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - échelle de gris/couleur"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x touche avance rapide"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x touche avance rapide type 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Long touche avance rapide"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Long touche avance rapide Type 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x touche Info"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x mute"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Long touche info"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x touche retour rapide"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x touche retour rapide type 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Long touche retour rapide"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Long touche retour rapide Type 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "oui, étendu"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Console normale"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Logfile étendu"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Logfile normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "désactivé"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Média"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Média"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (complet)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normal (complet)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "rogné (noir)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "rogné (transparent)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "MUTE ou touches définies"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "n'importe quelle Clé"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Heure+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Heure+Durée+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Heure+Longueur+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "moitié gauche"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "moitié droite"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Cadre x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Ligne"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "pas de Bar"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "pas de cadre"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Dégradé"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Bords ombrés"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Position en dessous"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Position gauche"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Position droite"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Position"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Nom"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Hors-ligne"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "En ligne"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "En ligne+Hors ligne"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "seulement utiliser prog"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "utiliser délai"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "pas d'enregistrement complet"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "afficher programmation total"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "en ligne"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "deux lignes"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Mémoire disponible"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Mémoire libre"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "plein écran"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "oui excepté les enregistrements"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "O"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ONO"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "OSO"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NO"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNO"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNW"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NW"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SO"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSO"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSW"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SW"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "W"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "WNW"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "WSW"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Charger fichier configuration actif"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Charger les valeurs par défaut / Config vide"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Sauvegarder fichier de configuration... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Charger fichier : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Effacer fichier?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "effacé"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "actuellement défini : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "Paramètres LCD4linux"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Fermer"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Sauver"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Relancer affichages"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Réglages en >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "pas de fichier image LCD1"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "pas de fichier image LCD2"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "pas de fichier image LCD3"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux activé"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Type"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 Rotation"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Couleur du fond"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Image de fond [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Luminosité"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Mode nuit"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 Rafraîchir"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Type"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Rotation"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Couleur de fond"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Image de fond [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Luminosité"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Mode nuit"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 Rafraîchir"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Type"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Rotation"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Couleur du fond"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Image de fond [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Luminosité"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Mode nuit"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 Rafraîchir"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD Dimension"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Décalage"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD Couleur"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD Activer le mode-En"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD Activer le mode-Média"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD Activer le mode-Veille"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [afficher l'heure]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- Quel LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Afficher en mode"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Taille OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Fond/Transparence"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Saisie rapide qualité plus faible"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Texte popup"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Effacer la clé"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Taille Police"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Position"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Alignement"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Couleur"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Couleur du fond"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Police"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Ecran actif"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Ecran sélection commutation  - Ecran"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Ecran sélection commutation  - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Ecran utilisé pour changer"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Durée de changement écran 1"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Ecran 2 Temps de changement"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Ecran 3 Temps de changement"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Ecran 4 Temps de changement"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Ecran 5 Temps de changement"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Ecran 6 Temps de changement"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Ecran 7 Temps de changement"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Ecran 8 Temps de changement"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Ecran 9 Temps de changement"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Vitesse de changement des images"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Trier image"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Répertoire image récursive"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Image qualité de la mise à l'échelle"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Image mise à jour rapide [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Type photo [seulement photo]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Type photo arrière plan"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Météo API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Météo API-Touche OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key MétéoDévérouillée"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Ville météo"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Ville météo 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Chemin vers les icônes météo [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Zoom icône météo"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Météo couleur des températures basses"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Météo couleur des températures hautes"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Météo transparence"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Météo unité vitesse vent"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Météo Vent Lignes d'informations"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Météo risque de pluie"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Zoom Pluie"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Couleur Pluie"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Couleur de pluie 2 de"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Couleur Pluie 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Météo Humidité Couleur"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Météo lignes"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Météo Flèches de Tendance"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Météo Infos extra"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Zoom Extra"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Afficher différence température ressentie"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Couleur ville extra"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Couleur froide extra"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo plage min CO2"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo plage max CO2"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "URL météo"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Chemin des icônes de lune [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Enregistrement photo [OK]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Interrupteurs double-boutons"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Touche pour changer d'écran"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Touche pour écran En/Hors"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall chemin des images [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall nombre de ligne par entrée"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall nombre d'entrées de la liste"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall nombre d'images"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall orientation image"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall transparence photo"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall recherche photos"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall supprimer les appels après heures"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall durée du popup"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall popup LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall couleur popup"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall image du cadre [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Calendrier chemin-ics [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Calendrier URL-ics"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Calendrier PlanerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Calendrier couleur samedi"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Calendrier couleur dimanche"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Calendrier épaisseur ligne"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Calendrier prévisualisation de l'événement du jour"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Calendrier correction fuseau horaire"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Calendrier transparence"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Calendrier interval requête"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Couleur tuner"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Couleur tuner actif"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Activer la couleur du tuner"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Recherche service en premier"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Signal-Correction qualité"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Police global [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Police 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Police 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Police 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Police 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Police 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 Connection"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 Serveur"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Nom affiché:]Nom utilisateur"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 Mot de passe"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 Connection"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 Serveur"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Nom affiché:]Nom utilisateur"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 Mot de passe"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 Connection"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Serveur"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Nom affiché:]Nom utilisateur"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 Mot de passe"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 Connection"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 Serveur"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Nom affiché:]Nom utilisateur"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 Mot de passe"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 Connection"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 Serveur"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Nom affiché:]Nom utilisateur"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 Mot de passe"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Interval requête mail"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Mail IMAP limiter aux dernier jours"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail Afficher les boîtes vides"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Mail Afficher les dates"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Mail Cacher adresse mail"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Boite 1 distante [AfficherNom:]IP/Nom"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Boite 2 distante [AfficherNom:]IP/Nom"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Boite 3 distante [AfficherNom:]IP/Nom"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Boite 4 distante [AfficherNom:]IP/Nom"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Boite 5 distante [AfficherNom:]IP/Nom"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Boite distante requête toutes les minutes"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Remote Box Timer [NomAffiché:]IP/Nom"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Remote Box Timer Sondage toutes les minutes"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW convertisseur interval requête"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW utilisation convertisseur"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey depuis cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey depuis convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF rafraîchissement [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF type de rafraîchissement"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF délai d'init"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF rejeter IP"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF Design"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Sauver comme image pour WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 activé"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 Port"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 Luminosité virtuelle"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 activé"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 Port"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 Luminosité virtuelle"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 activé"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 Port"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 Luminosité virtuelle"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "Cycle MJPEG"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "Redémarrage de MJPEG en cas d'erreur"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG mode Header"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Timeout[ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Play Check"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Rafraîchissement[s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Ping Timeout [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound Play Check (en)"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Rafraîchir [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Serveur IP [optionnel]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Timeout[ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Play Check"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Rafraîchissement[s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Pochette"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD largeur personnalisée"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD hauteur personnalisée"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD Largeur personnalisée 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD Hauteur personnalisée 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "Écran LCD éteint lors de l'arrêt"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing! calc tous temps comme temps/5*2 mode rapide"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Délai d'affichage [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Processus par LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Afficher Couverture Crash"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Afficher 'non ...' messages"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Périphérique-Stockage: Forcer la lecture"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Dispositifs de stockage : Couleur arrière"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Dispositifs de stockage : Barre de couleurs"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Dispositifs de stockage : Couleur Pleine"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Contrôle réseau actif"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Commuter TamponFram [si possible"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Config chemin sauvegarde [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Config restauration tous les paramètres"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Journal-Debug > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Rétro-éclairage hors [définir hors=en]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Rétro-éclairage On"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Rétro-éclairage Weekend hors [définir hors=en]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Rétro-Eclairage Weekend On"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Auto-OFF"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Arrière plan"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Photo [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Taille Picon"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Ecran partagé"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Plein écran"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Taille du texte"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparence"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Chemin Picon [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Chemin Picon 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Chemin du cache Picon [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Horloge"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Type"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Horloge analogique"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Espacement"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Taille"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Bords ombrés"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Horloge 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Nom du programme"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- Lignes maximum"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Longueur"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Numéro du programme"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Info programme"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Type"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Programme Info 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Info programme suivant"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Description étendue"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- utiliser Info lorsqu'il est vide"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Barre de progression"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Couleur Texte"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Entourage"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Ombré"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Unité min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informations"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Info Tuner"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Senseurs"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informations 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Afficher Barre de qualité"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Dégradé"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Bar plage Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Bar plage Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satellite"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Opérateur"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Tuner utilisé"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- Seulement le tuner actif"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Evénement prog suivant"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volume"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Mute"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Vidéo"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "En ligne [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Afficher état"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Temps dépassé [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- En ligne Nom:Adresse"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Adresse IP externe"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- URL IP externe"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Périphériques-Stockages"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- avertissement libre"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- Info extra"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Nom du périphérique"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Type Météo"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Météo 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Météo-Station Météo"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Station"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Module"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Module défini par l'utilisateur"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Nom"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Couleur 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Couleur 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Couleur 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Couleur 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Couleur 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Couleur 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo indicateur CO2"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Longueur [Bar]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Indicateur confort"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Phase de lune"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Lignes d'information"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Flèches de Tendance"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Levé du soleil"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Afficher oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Fichier [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Afficher ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Afficher fichier texte"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Afficher fichier texte 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Afficher fichier texte 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Afficher texte HTTP"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-Internet convertisseur"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- Largeur HTTP"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- Hauteur HTTP"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Couper à partir de X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Couper à partir de Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Couper Largeur [désactiver = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Couper Hauteur [désactiver = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Afficher image"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Fichier ou Chemin [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Taille max Hauteur"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Mise-à-jour rapide"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Afficher image 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Afficher image 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Afficher image 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Lignes"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Compteur Mail"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- Largeur max"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Minuterie de boîte à distance"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Taille Image"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Position Image"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Alignement Image"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Disposition"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Couleur arrière plan jour actuel"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Couleur sous titre"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Liste des dates"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Evénement icône barre"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popup écran"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Afficher le texte 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Texte"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Afficher le texte 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Position x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Position y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Taille x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Taille y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Enregistrement"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Sacades TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Ecrans utilisés pour le changement"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Titre"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Infos"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Afficher couverture"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Chemin de recherche [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Trouver le fichier de couverture [ok]"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Couverture par défaut [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon d'abord"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Coupé"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Télécharger la couverture"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Type de téléchargement"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD affichage"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux - Affichage 'En'"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Réglages média >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux - Affichage 'Lecteur médias'"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Réglages veille >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux - Affichage 'Veille'"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Réglages globaux >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Choisir un répertoire"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Choisir fichier"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Choisir police"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Valeur actuelle: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3845,95 +4078,95 @@ msgstr ""
 "IGU doit être relancée pour appliquer les changements.\n"
 "Voulez-vous relancer l'IGU maintenant?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Redémarrer l'IGU maintenant?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Intérieur"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Extérieure"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Pluie"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Vent"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Nouvelle lune"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Premier quart"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Croissant de cire"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Lune croissante"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Pleine lune"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Lune décroissante"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Croissant décroissant"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Dernier Quart"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Photo non disponible"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "pas de programmation"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM ne fonctionne pas"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "pas d'appel"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d Neu  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "pas de plugiciel Netatmo installé"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "Commutateur d'écran LCD4linux"
 
@@ -3951,111 +4184,3 @@ msgstr "Commutateur d'écran LCD4linux"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Météo Direction du vent"
-
-#~ msgid "Backup Config"
-#~ msgstr "Sauvegarde config"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Crashlog"
-
-#~ msgid "Delete"
-#~ msgstr "Effacer"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Effacer fichier log"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Télécharger fichier log"
-
-#~ msgid "Element"
-#~ msgstr "Élément"
-
-#~ msgid "Exec"
-#~ msgstr "Exec"
-
-#~ msgid "Filename"
-#~ msgstr "Nom de fichier"
-
-#~ msgid "Font"
-#~ msgstr "Police"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "Redémarrage de l'IGU nécessaire"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Sécurité IP non supporté par récepteur"
-
-#~ msgid "Key"
-#~ msgstr "Clé"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Liste des périphériques de stockage"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Aucun ou mauvais fichier sélectionné, essayer un fichier correct d'abord!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Dossier parent"
-
-#~ msgid "Picture"
-#~ msgstr "Image"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Popup-Texte"
-
-#~ msgid "Restore Config"
-#~ msgstr "Restaurer configuration"
-
-#~ msgid "Save Config"
-#~ msgstr "Sauver configuration"
-
-#~ msgid "Screen"
-#~ msgstr "Ecran"
-
-#~ msgid "Show"
-#~ msgstr "Afficher"
-
-#~ msgid "Show Externals"
-#~ msgstr "Afficher externe"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Tuner"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW Convertisseur"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "copier vers repos"
-
-#~ msgid "copy to Media"
-#~ msgstr "copier vers média"
-
-#~ msgid "copy to On"
-#~ msgstr "copier vers en"
-
-#~ msgid "other"
-#~ msgstr "autre"
-
-#~ msgid "set Settings"
-#~ msgstr "définir les paramètres"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "stopper cycle écran"

--- a/LCD4linux/po/it.po
+++ b/LCD4linux/po/it.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:07+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:16+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Italian <>\n"
 "Language: it\n"
@@ -17,3832 +17,4065 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Ven"
-
-#: plugin.py:263
-msgid "Mon"
-msgstr "Lun"
-
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sat"
-
-#: plugin.py:263
-msgid "Sun"
-msgstr "Dom"
-
-#: plugin.py:263
-msgid "Thur"
-msgstr "Gio"
-
-#: plugin.py:263
-msgid "Tue"
-msgstr "Mar"
-
-#: plugin.py:263
-msgid "Wed"
-msgstr "Mer"
-
-#: plugin.py:288
-msgid "black"
-msgstr "nero"
-
-#: plugin.py:288
-msgid "white"
-msgstr "bianco"
-
-#: plugin.py:289
-msgid "gray"
-msgstr "grigio"
-
-#: plugin.py:289
-msgid "silver"
-msgstr "argento"
-
-#: plugin.py:289
-msgid "slategray"
-msgstr "ardesia"
-
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "acqua marina"
-
-#: plugin.py:291
-msgid "gold"
-msgstr "oro"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "verde giallo"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "giallo"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "arancione scuro"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "rosso scuro"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "rosso indiano"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "arancione"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "rosso arancio"
-
-#: plugin.py:292
-msgid "red"
-msgstr "rosso"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "pomodoro"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "verde scuro"
-
-#: plugin.py:293
-msgid "green"
-msgstr "verde"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "verde prato"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "verde chiaro"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "limetta"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "blu"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "blu viola"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "blu cadetto"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "blu fiordaliso"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "blu scuro"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indaco"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "blu chiaro"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "ciano"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "orchidea scuro"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "rosa scuro"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violetta"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "marrone"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "mocassino"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "oliva"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "marrone rosato"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "marrone sabbia"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Display 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Display 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Display 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Display 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Display 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Display 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Display 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Display 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Display 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Display 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Display 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Display 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Display 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Display 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Display 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Display 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Display 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Display 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Display 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Display 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Display 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Display 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Display 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Display 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Display 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Display 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Display 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Display 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Display 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "off"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Display 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Display 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Display 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "on"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (o LCD compatibili) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (o LCD compatibili) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (o LCD compatibili) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (o LCD compatibili) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H alt 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H vecchio 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "TFT-LCD 400x240 interno"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Box-Skin-LCD interno"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "solo formato 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "solo formato 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "solo formato 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "solo formato 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "solo formato immagine personalizzato"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "solo formato immagine personalizzato 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Vu+Duo2 LCD 400x240 interno"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 giorni 1 linea"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 giorni 2 linee"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 giorni 1 linea"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 giorni 2 linee"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 giorni vista verticale"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 giorni 1 linea"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 giorni 2 linee"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 giorni vista verticale"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Temperatura corrente (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Temperatura corrente (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Corrente"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Temperatura corrente"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Tutti"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperatura"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperatura+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperatura+Co2+Pressione"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperatura+Umidità"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Modulo 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Modulo 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Modulo 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Modulo 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Modulo 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Modulo 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Modulo 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Modulo 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Modulo 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Modulo 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Modulo 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Modulo 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Modulo 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Modulo 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Modulo 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Modulo 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Modulo 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Modulo 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Modulo 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Modulo 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Modulo 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Modulo 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Modulo 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "definito dall'utente"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Barra"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Barra+Valore"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Percepita"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Percepita+Valore"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analogico"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analogico+Data"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analogico+Data+Giorno feriale"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analogico+Data+Giorno feriale 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Data"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Data+Ora"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Data+Ora+Giorni feriali"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Data di progettazione dei lembi"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Design dei lembi nei giorni feriali"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Ora"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Orario+Giorni feriali"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Feriale"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "centro"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "sinistra"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "destra"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Esteso"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Esteso (breve)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Breve"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Breve (esteso)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Breve+Esteso"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Mese"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Mese+Intestazione"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Settimana"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Settimana+Intestazione"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "no calendario"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Appuntamenti 1 linea"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Appuntamenti 3 linee"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Appuntamenti 5 linee"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Appuntamenti 9 linee"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Appuntamenti compatto 2 linee"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Appuntamenti compatto 3 linee"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "no data"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Sottolineato"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Sottolineato 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Riquadro"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Appuntamenti"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Appuntamenti compatto"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Appuntamenti compatto no icona"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Appuntamenti no icona"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "no icona"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "no icona, con numero di destinazione"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "con icona"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "con icona e numero di destinazione"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "no"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Carica@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Carica@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "visualizza esecuzione"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "visualizza esecuzione+standby"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Sempre tutto"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Sempre nuovo"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Solo nuovo"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Tutte le informazioni"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Solo distanza"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Distanza+Illuminazione"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Distanza+Fase lunare"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Solo illuminazione"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Illuminazione+Fase lunare"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Solo Fasi lunari"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Canale"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Canale+Titolo"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Canale"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Canale+Titolo"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "stesso colore"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "sì + 25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "si"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "verticale"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "orizzontale"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Globale"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "tutti"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Angolo"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Angolo+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "solo barra avanzamento"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "con minuti restanti"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "con minuti restanti (dimensione 1,5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "con minuti restanti (dimensione 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "con percentuale"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "con percentuale (dimensione 1,5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "con percentuale (dimensione 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "con minuti restanti (sopra)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "con minuti restanti (sopra/dimensione 1,5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "con minuti restanti (sopra/dimensioni 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "con percentuale (sopra)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "con percentuale (sopra/dimensione 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "con percentuale (sopra/dimensione 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "con minuti restanti (sotto)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "con minuti restanti (sotto/dimensione 1,5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "con minuti restanti (sotto/dimensione 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "con percentuale (sotto)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "con percentuale (sotto/dimensione 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "con percentuale (sotto/dimensione 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "con corrente 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "con corrente 00:00 (dimensione 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "con corrente 00:00 (dimensione 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "con corrente 00:00 (sopra)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "con corrente 00:00 (sopra/dimensione 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "con corrente 00:00 (sopra/dimensione 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "con corrente 00:00 (sotto)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "con corrente 00:00 (sotto/dimensione 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "con corrente 00:00 (sotto/taglia 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "con percentuale minuti / totale (sopra)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "con percentuale minuti / totale (sopra/dimensione 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "con percentuale minuti / totale (sopra/dimensione 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "con assoluto orario fine"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "con assoluto orario fine (Size 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "con assoluto orario fine (Size 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "con minuti totale / orario fine (sopra)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "con minuti totale /orario fine (sopra/dimensione 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "con minuti totale / orario fine (sopra/taglia 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Fastmode (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normale (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alfabetico"
-
-#: plugin.py:386
-msgid "random"
-msgstr "casuale"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "migliore/lento"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "basso/veloce (solo immagine)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "basso/veloce (tutti)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + regolazione (alta qualità, lento)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + regolazione (bassa qualità, veloce)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "no cache + no regolazioni"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Spina sintonizzatore"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "Sintonizzatore USB"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Ora/Successivo"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normale"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "ridotto"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript nessun aggiornamento"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Ricarica"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normale"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - affiancati"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "copia modalità alternativa/DM800hd (24 bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "sì + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "sì, lungo"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "sì, breve"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Ricerca cover"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
+
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
+
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Carattere"
+
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Tasto"
+
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
+
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
+
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Immagine"
+
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Testo-popup"
+
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
+
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Sintonizzatore"
+
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "Convertitore WWW"
+
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
+
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Display"
+
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "sempre"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Media+Standby"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Standby"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "On"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "Colore - 32bit"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - scala di grigi/colori"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x Tasto avanzamento veloce"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x Tasto avanzamento veloce tipo 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Tasto lungo avanti veloce"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Tasto lungo avanti veloce tipo 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Tasto Info"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Muto"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Tasto lungo info"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x Tasto indietro veloce"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x Tasto indietro veloce tipo 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Tasto lungo indietro veloce"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Tasto lungo indietro veloce tipo 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "sì, esteso"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Console normale"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "File di registro esteso"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "File di registro normale"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "disabilitato"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (completo)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normale (completo)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "profilati (nero)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "profilati (trasparenti)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE o tasti definiti"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "qualsiasi tasto"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Orario+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Orario+Durata+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini - EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Orario+Durata+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "metà sinistra"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "metà destra"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Riquadro x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Linea"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "no barra"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "no riquadro"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradiente"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Bordi ombrati"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normale"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Posizione sotto"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Posizione sinistra"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Posizione destra"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Posizione"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Nome"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Offline"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Online"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Online+Offline"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "utilizzare solo Timer"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "utilizzare lasso di tempo"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "no Timer totale"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "visualizza timer totale"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "una riga"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "due linee"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Memoria disponibile"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Memoria libera"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "display intero"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "sì tranne registrazioni"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ENE"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "ESE"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NE"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNE"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNO"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NO"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SE"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSE"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSO"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SO"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "O"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "ONO"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "OSO"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Carica file di configurazione attivo"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Carica predefiniti/Configurazione vuota"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Salva configurazione nel file... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Carica il file: %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Eliminare il file?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "eliminato"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "impostato attualmente: %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux impostazioni"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Modalità"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Annulla"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Salva"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Riavvia LCD"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Imposta On >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Idle"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "no LCD1 Tema-File"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "no LCD2 Tema-File"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "no LCD3 Tema-File"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux abilitato"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 tipo"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 ruotare"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 colore sfondo"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 tema sfondo [OK] >"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 luminosità"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 riduzione notturna"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 aggiornamento"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 tipo"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 ruotare"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 colore sfondo"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 tema sfondo [OK] >"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 luminosità"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 riduzione notturna"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 aggiornamento"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 tipo"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 ruotare"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 colore sfondo"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 tema sfondo [OK] >"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 luminosità"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 riduzione notturna"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 aggiornamento"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD dimensioni"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Offset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD colore"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD abilita modalità On"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD abilita modalità Media"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD abilita modalità Idle"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [mostra orario]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- quale LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Mostra in modalità"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Dimensioni OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Trasparenza sfondo"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Grab veloce qualità inferiore"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Testo popup"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Tasto Cancella"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Dimensioni testo"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Posizione"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Allineamento"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Colore"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Colore sfondo"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Carattere"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Display attivo"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Display selettore - Display"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Display selettore - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Display utilizzati per cambiare"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Display 1 cambio tempo"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Schermata 2 modifica ora"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Schermata 3 modifica ora"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Schermata 4 modifica ora"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Schermata 5 modifica ora"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Schermata 6 modifica ora"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Schermata 7 modifica ora"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Schermata 8 modifica ora"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Schermata 9 modifica ora"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Tempo cambio immagini"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Ordina immagini"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Directory immagini ricorsiva"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Qualità immagine per il ridimensionamento"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Aggiornamento immagine Quick Time [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Tipo di immagine [solo immagine]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Formato immagine sfondo"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Meteo API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Meteo API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Meteo API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Meteo città"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Meteo città 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Meteo - Percorso icona [OK] >"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Meteo - Zoom icona"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Meteo bassa temperatura colore"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Meteo alta temperatura colore"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Meteo trasparenza"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Meteo unità di velocità vento"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Meteo linee informative sul vento"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Possibilità di pioggia"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Zoom pioggia"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Colore pioggia"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Pioggia utilizza colore 2 da"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Colore pioggia 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Meteo linee"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Meteo frecce di tendenza"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Meteo informazioni extra"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra Zoom"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Mostra differenza temperatura percepita"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extra color City"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extra colore Chill"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Stazione meteo CO2 campo min"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Stazione meteo CO2 campo max"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteo URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Luna-Percorso-Icona [OK] >"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Registrazione immagine [OK] >"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Interruttori a doppio pulsante"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Tasto per cambiare schermo"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Tasto per schermo On/Off"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall percorso immagini [OK] >"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall numero di linee per voce"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall numero di voci di elenco"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall numero di immagini"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall orientamento immagini"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall trasparenza immagini"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall cerca immagini"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall elimina chiamate dopo ore"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall popup-ora"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall LCD popup"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall colore popup"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall riquadro [OK] >"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Calendario percorso ics [OK] >"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Calendario URL ics"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Calendario planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Calendario colore Sabato"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Calendario colore Domenica"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Spessore linea calendario"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Anteprima calendario giorno evento"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Correzione calendario fuso orario"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Trasparenza calendario"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Intervallo di polling del calendario"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Colore sintonizzatore"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Colore attivo sintonizzatore"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Colore sintonizzatore On"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Ricerca prima servizio"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Segnale - correzione qualità"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Carattere globale [OK] >"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Carattere 1 [OK] >"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Carattere 2 [OK] >"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Carattere 3 [OK] >"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Carattere 4 [OK] >"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Carattere 5 [OK] >"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 connessione"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 Server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Displayname:] Nome utente"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 password"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 connessione"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 Server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Displayname:] Nome utente"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 password"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 connessione"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Displayname:] Nome utente"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 password"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 connessione"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 Server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Displayname:] Nome utente"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 password"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 connessione"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 Server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Displayname:] Nome utente"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 password"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Mail intervallo sondaggio"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Mail IMAP limite per ultimi giorni"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail mostra mailbox vuote"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Mail mostra data"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Mail nascondere mailadress"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Ricevitore remoto 1 [Displayname:] IP/Nome"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Ricevitore remoto 2 [Displayname:] IP/Nome"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Ricevitore remoto 3 [Displayname:] IP/Nome"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Ricevitore remoto 4 [Displayname:] IP/Nome"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Ricevitore remoto 5 [Displayname:] IP/Nome"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Sondaggio ricevitore remoto ogni minuti"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Timer ricevitore remoto [Displayname:] IP/Nome"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Timer sondaggio ricevitore remoto ogni minuti"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "Intervallo sondaggio convertitore WWW"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "Utilizzo convertitore WWW"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey da cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey da convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF aggiornamento [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF tipo aggiornamento"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF ritardo inizio"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP consentito"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP negato"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF Design"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Salva come immagine per WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 abilita"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 porta"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 luminosità virtuale"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 abilita"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 porta"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 luminosità virtuale"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 abilitato"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 porta"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 luminosità virtuale"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG cicli"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG riavvia in caso di errore"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG modalità intestazione"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Timeout [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos test riproduzione"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos aggiornamento [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "Timeout ping BlueSound [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound test riproduzione"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound aggiornamento [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast IP del Server [opzionale]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast ping timeout [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast test riproduzione"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast aggiornamento [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast cover"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD larghezza personalizzata"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD altezza personalizzata"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD larghezza personalizzata 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD altezza personalizzata 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD off quando spegni"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Timing ! Calcola tutti in Time/5*2 in Fastmode"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Ritardo di visualizzazione [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Righe per LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Mostra angolo crash"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Mostra 'nessun ....' messaggio"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Dispositivi di archiviazione: Forza lettura"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Dispositivi di archiviazione: Colore sfondo"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Dispositivi di archiviazione: Colore barra"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Dispositivi di archiviazione: Colore pieno"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Test della rete attivato"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Cambia FrameBuffer [se possibile]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Configurazione percorso Backup [OK] >"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Ripristina tutte le impostazioni"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debug-Logging > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Retroilluminazione Off [Off -> On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Retroilluminazione ON"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Retroilluminazione week end OFF"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Retroilluminazione week end ON"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Auto-OFF"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Sfondo"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Immagine [OK] >"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Dimensioni picon"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Display sdoppiato"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Display intero"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Dimensioni testo"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Trasparenza"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Percorso picon [OK] >"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Percorso picon 2 [OK] >"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Percorso cache picon [OK] >"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Orologio"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "- Tipo"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Orologio analogico"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Spaziatura"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Dimensioni"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Bordi ombrati"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Orologio 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Nome del programma"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- massimo righe"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Lunghezza"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Numero del programma"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Informazioni programma"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Tipo"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Informazioni programma 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Successiva info programma"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Descrizione estesa"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- utilizzare info quando vuoto"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Barra di avanzamento"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Testo a colori"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Bordi"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Ombreggiato"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Unità min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informazioni"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Informazioni sintonizzatore"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensori"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informazioni 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Barra qualità segnale"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradiente"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Barra campo Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Barra campo Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satellite"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Provider"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Sintonizzatore usato"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- solo sintonizzatore attivo"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Prossimo evento timer"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volume"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Muto"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Online [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Mostra stato"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Timeout [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Nome in linea:Indirizzo"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Indirizzo IP esterno"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- external IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Dispositivi di archiviazione"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- senza avviso"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- informazioni extra"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Nome dispositivo"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Meteo"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Tipo meteo"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Meteo 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo - Stazione meteo"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Stazione"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Modulo"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Modulo definito dall'utente"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Base"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Nome"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Colore 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Colore 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Colore 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Colore 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Colore 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Colore 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Stazione meteo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Stazione meteo indicatore CO2"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Lunghezza [Barra]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Stazione meteo indicatore comfort"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Fase lunare"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Linee informative"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Frecce di tendenza"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Alba"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Mostra oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- File [OK] >"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Mostra ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Mostra file di testo"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Mostra file di testo 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Mostra file di testo 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Mostra testo HTTP"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "Convertitore WWW-Internet"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- Larghezza HTTP"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- Altezza HTTP"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Taglio da X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Taglio da Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Larghezza di taglio [disattivare = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Altezza di taglio [disattivare = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Mostra immagine"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- File o percorso [OK] >"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Dimensioni max altezza"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Aggiornamento rapido"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Mostra immagine 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Mostra immagine 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Mostra immagine 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Linee"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Conto E-Mail"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- larghezza max"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Ricevitore remoto"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Timer ricevitore remoto"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Dimensione immagine"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Posizione immagine"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Allineamento immagine"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Calendario"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP consentito"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Nessun file selezionato o sbagliato, prova prima un file corretto!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Modalità"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Sicurezza IP non supportata dal ricevitore"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Crashlog"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Mostra"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Elimina"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Nome del file"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Ripristina configurazione"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Backup configurazione"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Elimina file di log"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Scarica file di log"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Salva configurazione"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "interrompere ciclo display"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Globale"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "On"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Idle"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "È necessario riavviare la GUI"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Elemento"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "altro"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "imposta configurazioni"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "copia in On"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "copia in Media"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "copia in Idle"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Esegui"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Mostra esterni"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Elenco dei dispositivi di archiviazione"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Directory Superiore"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Ven"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Lun"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sat"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Dom"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Gio"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Mar"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Mer"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "nero"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "bianco"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "grigio"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "argento"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "ardesia"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "acqua marina"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "oro"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "verde giallo"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "giallo"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "arancione scuro"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "rosso scuro"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "rosso indiano"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "arancione"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "rosso arancio"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "rosso"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "pomodoro"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "verde scuro"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "verde"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "verde prato"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "verde chiaro"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "limetta"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "blu"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "blu viola"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "blu cadetto"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "blu fiordaliso"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "blu scuro"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indaco"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "blu chiaro"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "ciano"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "orchidea scuro"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "rosa scuro"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violetta"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "marrone"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "mocassino"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "oliva"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "marrone rosato"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "marrone sabbia"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Display 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Display 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Display 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Display 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Display 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Display 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Display 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Display 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Display 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Display 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Display 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Display 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Display 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Display 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Display 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Display 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Display 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Display 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Display 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Display 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Display 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Display 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Display 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Display 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Display 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Display 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Display 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Display 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Display 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "off"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Display 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Display 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Display 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "on"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (o LCD compatibili) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (o LCD compatibili) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (o LCD compatibili) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (o LCD compatibile) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H alt 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H vecchio 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Box-Skin-LCD interno"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "TFT-LCD 400x240 interno"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "solo formato 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "solo formato 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "solo formato 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "solo formato 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "solo formato immagine personalizzato"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "solo formato immagine personalizzato 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Vu+Duo2 LCD 400x240 interno"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 giorni 1 linea"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 giorni 2 linee"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 giorni 1 linea"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 giorni 2 linee"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 giorni vista verticale"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 giorni 1 linea"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 giorni 2 linee"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 giorni vista verticale"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Temperatura corrente (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Temperatura corrente (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Corrente"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Temperatura corrente"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Tutti"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperatura+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperatura+Co2+Pressione"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperatura+Umidità"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Modulo 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Modulo 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Modulo 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Modulo 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Modulo 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Modulo 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Modulo 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Modulo 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Modulo 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Modulo 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Modulo 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Modulo 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Modulo 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Modulo 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Modulo 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Modulo 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Modulo 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Modulo 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Modulo 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Modulo 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Modulo 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Modulo 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Modulo 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "definito dall'utente"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Barra"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Barra+Valore"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Percepita"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Percepita+Valore"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analogico"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analogico+Data"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analogico+Data+Giorno feriale"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analogico+Data+Giorno feriale 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Data"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Data+Ora"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Data+Ora+Giorni feriali"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Data di progettazione dei lembi"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Design dei lembi nei giorni feriali"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Ora"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Orario+Giorni feriali"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Feriale"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "centro"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "sinistra"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "destra"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Esteso"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Esteso (breve)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Breve"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Breve (esteso)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Breve+Esteso"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Mese"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Mese+Intestazione"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Settimana"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Settimana+Intestazione"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "no calendario"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Appuntamenti 1 linea"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Appuntamenti 3 linee"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Appuntamenti 5 linee"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Appuntamenti 9 linee"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Appuntamenti compatto 2 linee"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Appuntamenti compatto 3 linee"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "no data"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Sottolineato"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Sottolineato 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Riquadro"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Appuntamenti"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Appuntamenti compatto"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Appuntamenti compatto no icona"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Appuntamenti no icona"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "no icona"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "no icona, con numero di destinazione"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "con icona"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "con icona e numero di destinazione"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "no"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Carica@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Carica@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "visualizza esecuzione"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "visualizza esecuzione+standby"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Sempre tutto"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Sempre nuovo"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Solo nuovo"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Tutte le informazioni"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Solo distanza"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Distanza+Illuminazione"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Distanza+Fase lunare"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Solo illuminazione"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Illuminazione+Fase lunare"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Solo Fasi lunari"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Canale"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Canale+Titolo"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Canale"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Canale+Titolo"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "stesso colore"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "sì + 25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "si"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "verticale"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "orizzontale"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "tutti"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Angolo"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Angolo+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "solo barra avanzamento"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "con minuti restanti"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "con minuti restanti (dimensione 1,5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "con minuti restanti (dimensione 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "con percentuale"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "con percentuale (dimensione 1,5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "con percentuale (dimensione 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "con minuti restanti (sopra)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "con minuti restanti (sopra/dimensione 1,5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "con minuti restanti (sopra/dimensioni 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "con percentuale (sopra)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "con percentuale (sopra/dimensione 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "con percentuale (sopra/dimensione 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "con minuti restanti (sotto)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "con minuti restanti (sotto/dimensione 1,5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "con minuti restanti (sotto/dimensione 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "con percentuale (sotto)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "con percentuale (sotto/dimensione 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "con percentuale (sotto/dimensione 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "con corrente 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "con corrente 00:00 (dimensione 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "con corrente 00:00 (dimensione 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "con corrente 00:00 (sopra)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "con corrente 00:00 (sopra/dimensione 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "con corrente 00:00 (sopra/dimensione 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "con corrente 00:00 (sotto)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "con corrente 00:00 (sotto/dimensione 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "con corrente 00:00 (sotto/taglia 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "con percentuale minuti / totale (sopra)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "con percentuale minuti / totale (sopra/dimensione 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "con percentuale minuti / totale (sopra/dimensione 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "con assoluto orario fine"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "con assoluto orario fine (Size 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "con assoluto orario fine (Size 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "con minuti totale / orario fine (sopra)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "con minuti totale /orario fine (sopra/dimensione 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "con minuti totale / orario fine (sopra/taglia 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Fastmode (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normale (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alfabetico"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "casuale"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "migliore/lento"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "basso/veloce (solo immagine)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "basso/veloce (tutti)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + regolazione (alta qualità, lento)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + regolazione (bassa qualità, veloce)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "no cache + no regolazioni"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Spina sintonizzatore"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "Sintonizzatore USB"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Ora/Successivo"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normale"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "ridotto"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript nessun aggiornamento"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Ricarica"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normale"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - affiancati"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "copia modalità alternativa/DM800hd (24 bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "sì + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "sì, lungo"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "sì, breve"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Ricerca cover"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "sempre"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Media+Standby"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Standby"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "Colore - 32bit"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - scala di grigi/colori"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x Tasto avanzamento veloce"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x Tasto avanzamento veloce tipo 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Tasto lungo avanti veloce"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Tasto lungo avanti veloce tipo 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Tasto Info"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Muto"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Tasto lungo info"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x Tasto indietro veloce"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x Tasto indietro veloce tipo 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Tasto lungo indietro veloce"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Tasto lungo indietro veloce tipo 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "sì, esteso"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Console normale"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "File di registro esteso"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "File di registro normale"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "disabilitato"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (completo)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normale (completo)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "profilati (nero)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "profilati (trasparenti)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "MUTE o tasti definiti"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "qualsiasi tasto"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Orario+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Orario+Durata+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini - EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Orario+Durata+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "metà sinistra"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "metà destra"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Riquadro x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Linea"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "no barra"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "no riquadro"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradiente"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Bordi ombrati"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normale"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Posizione sotto"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Posizione sinistra"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Posizione destra"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Posizione"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Nome"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Offline"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Online"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Online+Offline"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "utilizzare solo Timer"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "utilizzare lasso di tempo"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "no Timer totale"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "visualizza timer totale"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "una riga"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "due linee"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Memoria disponibile"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Memoria libera"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "display intero"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "sì tranne registrazioni"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ENE"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "ESE"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NE"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNE"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNO"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NO"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SE"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSE"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSO"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SO"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "O"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "ONO"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "OSO"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Carica file di configurazione attivo"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Carica predefiniti/Configurazione vuota"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Salva configurazione nel file... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Carica il file: %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Eliminare il file?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "eliminato"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "impostato attualmente: %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux impostazioni"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Annulla"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Salva"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Riavvia LCD"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Imposta On >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "no LCD1 Tema-File"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "no LCD2 Tema-File"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "no LCD3 Tema-File"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux abilitato"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 tipo"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 ruotare"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 colore sfondo"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 tema sfondo [OK] >"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 luminosità"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 riduzione notturna"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 aggiornamento"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 tipo"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 ruotare"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 colore sfondo"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 tema sfondo [OK] >"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 luminosità"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 riduzione notturna"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 aggiornamento"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 tipo"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 ruotare"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 colore sfondo"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 tema sfondo [OK] >"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 luminosità"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 riduzione notturna"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 aggiornamento"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD dimensioni"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Offset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD colore"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD abilita modalità On"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD abilita modalità Media"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD abilita modalità Idle"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [mostra orario]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- quale LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Mostra in modalità"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Dimensioni OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Trasparenza sfondo"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Grab veloce qualità inferiore"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Testo popup"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Tasto Cancella"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Dimensioni testo"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Posizione"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Allineamento"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Colore"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Colore sfondo"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Carattere"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Display attivo"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Display selettore - Display"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Display selettore - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Display utilizzati per cambiare"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Display 1 cambio tempo"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Schermata 2 modifica ora"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Schermata 3 modifica ora"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Schermata 4 modifica ora"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Schermata 5 modifica ora"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Schermata 6 modifica ora"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Schermata 7 modifica ora"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Schermata 8 modifica ora"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Schermata 9 modifica ora"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Tempo cambio immagini"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Ordina immagini"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Directory immagini ricorsiva"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Qualità immagine per il ridimensionamento"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Aggiornamento immagine Quick Time [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Tipo di immagine [solo immagine]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Formato immagine sfondo"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Meteo API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Meteo API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Meteo API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Meteo città"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Meteo città 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Meteo - Percorso icona [OK] >"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Meteo - Zoom icona"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Meteo bassa temperatura colore"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Meteo alta temperatura colore"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Meteo trasparenza"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Meteo unità di velocità vento"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Meteo linee informative sul vento"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Possibilità di pioggia"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Zoom pioggia"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Colore pioggia"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Pioggia utilizza colore 2 da"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Colore pioggia 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Tempo Umidità Colore"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Meteo linee"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Meteo frecce di tendenza"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Meteo informazioni extra"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra Zoom"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Mostra differenza temperatura percepita"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extra color City"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extra colore Chill"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Stazione meteo CO2 campo min"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Stazione meteo CO2 campo max"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteo URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Luna-Percorso-Icona [OK] >"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Registrazione immagine [OK] >"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Interruttori a doppio pulsante"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Tasto per cambiare schermo"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Tasto per schermo On/Off"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall percorso immagini [OK] >"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall numero di linee per voce"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall numero di voci di elenco"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall numero di immagini"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall orientamento immagini"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall trasparenza immagini"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall cerca immagini"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall elimina chiamate dopo ore"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall popup-ora"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall LCD popup"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall colore popup"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall riquadro [OK] >"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Calendario percorso ics [OK] >"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Calendario URL ics"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Calendario planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Calendario colore Sabato"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Calendario colore Domenica"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Spessore linea calendario"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Anteprima calendario giorno evento"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Correzione calendario fuso orario"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Trasparenza calendario"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Intervallo di polling del calendario"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Colore sintonizzatore"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Colore attivo sintonizzatore"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Colore sintonizzatore On"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Ricerca prima servizio"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Segnale - correzione qualità"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Carattere globale [OK] >"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Carattere 1 [OK] >"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Carattere 2 [OK] >"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Carattere 3 [OK] >"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Carattere 4 [OK] >"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Carattere 5 [OK] >"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 connessione"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 Server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Displayname:] Nome utente"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 password"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 connessione"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 Server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Displayname:] Nome utente"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 password"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 connessione"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Displayname:] Nome utente"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 password"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 connessione"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 Server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Displayname:] Nome utente"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 password"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 connessione"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 Server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Displayname:] Nome utente"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 password"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Mail intervallo sondaggio"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Mail IMAP limite per ultimi giorni"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail mostra mailbox vuote"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Mail mostra data"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Mail nascondere mailadress"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Ricevitore remoto 1 [Displayname:] IP/Nome"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Ricevitore remoto 2 [Displayname:] IP/Nome"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Ricevitore remoto 3 [Displayname:] IP/Nome"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Ricevitore remoto 4 [Displayname:] IP/Nome"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Ricevitore remoto 5 [Displayname:] IP/Nome"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Sondaggio ricevitore remoto ogni minuti"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Timer ricevitore remoto [Displayname:] IP/Nome"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Timer sondaggio ricevitore remoto ogni minuti"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "Intervallo sondaggio convertitore WWW"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "Utilizzo convertitore WWW"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey da cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey da convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF aggiornamento [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF tipo aggiornamento"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF ritardo inizio"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP negato"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF Design"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Salva come immagine per WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 abilita"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 porta"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 luminosità virtuale"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 abilita"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 porta"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 luminosità virtuale"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 abilitato"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 porta"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 luminosità virtuale"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG cicli"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG riavvia in caso di errore"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG modalità intestazione"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Timeout [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos test riproduzione"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos aggiornamento [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "Timeout ping BlueSound [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound test riproduzione"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound aggiornamento [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast IP del Server [opzionale]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast ping timeout [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast test riproduzione"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast aggiornamento [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast cover"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD larghezza personalizzata"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD altezza personalizzata"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD larghezza personalizzata 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD altezza personalizzata 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD off quando spegni"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing ! Calcola tutti in Time/5*2 in Fastmode"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Ritardo di visualizzazione [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Righe per LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Mostra angolo crash"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Mostra 'nessun ....' messaggio"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Dispositivi di archiviazione: Forza lettura"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Dispositivi di archiviazione: Colore sfondo"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Dispositivi di archiviazione: Colore barra"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Dispositivi di archiviazione: Colore pieno"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Test della rete attivato"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Cambia FrameBuffer [se possibile]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Configurazione percorso Backup [OK] >"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Ripristina tutte le impostazioni"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debug-Logging > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Retroilluminazione Off [Off -> On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Retroilluminazione ON"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Retroilluminazione week end OFF"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Retroilluminazione week end ON"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Auto-OFF"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Sfondo"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Immagine [OK] >"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Dimensioni picon"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Display sdoppiato"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Display intero"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Dimensioni testo"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Trasparenza"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Percorso picon [OK] >"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Percorso picon 2 [OK] >"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Percorso cache picon [OK] >"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Orologio"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "- Tipo"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Orologio analogico"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Spaziatura"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Dimensioni"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Bordi ombrati"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Orologio 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Nome del programma"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- massimo righe"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Lunghezza"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Numero del programma"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Informazioni programma"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Tipo"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Informazioni programma 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Successiva info programma"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Descrizione estesa"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- utilizzare info quando vuoto"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Barra di avanzamento"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Testo a colori"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Bordi"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Ombreggiato"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Unità min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informazioni"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Informazioni sintonizzatore"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensori"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informazioni 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Barra qualità segnale"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradiente"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Barra campo Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Barra campo Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satellite"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Provider"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Sintonizzatore usato"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- solo sintonizzatore attivo"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Prossimo evento timer"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volume"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Muto"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Online [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Mostra stato"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Timeout [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Nome in linea:Indirizzo"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Indirizzo IP esterno"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- external IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Dispositivi di archiviazione"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- senza avviso"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- informazioni extra"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Nome dispositivo"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Tipo meteo"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Meteo 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo - Stazione meteo"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Stazione"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Modulo"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Modulo definito dall'utente"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Nome"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Colore 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Colore 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Colore 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Colore 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Colore 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Colore 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Stazione meteo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Stazione meteo indicatore CO2"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Lunghezza [Barra]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Stazione meteo indicatore comfort"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Fase lunare"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Linee informative"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Frecce di tendenza"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Alba"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Mostra oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- File [OK] >"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Mostra ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Mostra file di testo"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Mostra file di testo 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Mostra file di testo 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Mostra testo HTTP"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "Convertitore WWW-Internet"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- Larghezza HTTP"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- Altezza HTTP"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Taglio da X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Taglio da Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Larghezza di taglio [disattivare = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Altezza di taglio [disattivare = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Mostra immagine"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- File o percorso [OK] >"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Dimensioni max altezza"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Aggiornamento rapido"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Mostra immagine 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Mostra immagine 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Mostra immagine 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Linee"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Conto E-Mail"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- larghezza max"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Timer ricevitore remoto"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Dimensione immagine"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Posizione immagine"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Allineamento immagine"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Layout"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Colore sfondo giorno attuale"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Colore didascalia"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Lista appuntamenti"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Icona barra evento"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Display popup"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- LCD popup"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Mostra testo 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Testo"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Mostra testo 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rettangolo 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Posizione x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Posizione y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Dimensioni x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Dimensioni y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rettangolo 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Registrazione"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Schermi utilizzati per la modifica"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Titolo"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Informazioni"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Mostra cover"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Ricerca percorso [OK] >"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Trova file di copertina [ok]"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Copertina predefinita [OK] >"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Prima picon"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Rifilata"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Scarica la copertina"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Tipo di download"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "Display LCD"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux modalità display On"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Imposta Media >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux lettore multimediale in modalità display"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Imposta Idle >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux in modalità di visualizzazione Idle"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Imposta globale >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Scegli cartella"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Scegli file"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Scegli carattere"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - valore corrente: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3850,95 +4083,95 @@ msgstr ""
 "La GUI necessita di un riavvio per applicare le modifiche.\n"
 "Vuoi riavviare la GUI ora?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Riavviare la GUI?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Interno"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Esterni"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Pioggia"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Vento"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Luna nuova"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Primo quarto"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Mezzaluna crescente"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Luna crescente"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Luna piena"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Luna calante"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Pericolo crescente"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Ultimo quarto"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Immagine non disponibile"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "no Timer"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM non in esecuzione"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "no chiamate"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d Nuovo  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "no installato Netatmo-Plugin"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux interruttore schermo"
 
@@ -3956,111 +4189,3 @@ msgstr "LCD4linux interruttore schermo"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Meteo Direzione del vento"
-
-#~ msgid "Backup Config"
-#~ msgstr "Backup configurazione"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Crashlog"
-
-#~ msgid "Delete"
-#~ msgstr "Elimina"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Elimina file di log"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Scarica file di log"
-
-#~ msgid "Element"
-#~ msgstr "Elemento"
-
-#~ msgid "Exec"
-#~ msgstr "Esegui"
-
-#~ msgid "Filename"
-#~ msgstr "Nome del file"
-
-#~ msgid "Font"
-#~ msgstr "Carattere"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "È necessario riavviare la GUI"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Sicurezza IP non supportata dal ricevitore"
-
-#~ msgid "Key"
-#~ msgstr "Tasto"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Elenco dei dispositivi di archiviazione"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Nessun file selezionato o sbagliato, prova prima un file corretto!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Directory Superiore"
-
-#~ msgid "Picture"
-#~ msgstr "Immagine"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Testo-popup"
-
-#~ msgid "Restore Config"
-#~ msgstr "Ripristina configurazione"
-
-#~ msgid "Save Config"
-#~ msgstr "Salva configurazione"
-
-#~ msgid "Screen"
-#~ msgstr "Display"
-
-#~ msgid "Show"
-#~ msgstr "Mostra"
-
-#~ msgid "Show Externals"
-#~ msgstr "Mostra esterni"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Sintonizzatore"
-
-#~ msgid "WWW Converter"
-#~ msgstr "Convertitore WWW"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "copia in Idle"
-
-#~ msgid "copy to Media"
-#~ msgstr "copia in Media"
-
-#~ msgid "copy to On"
-#~ msgstr "copia in On"
-
-#~ msgid "other"
-#~ msgstr "altro"
-
-#~ msgid "set Settings"
-#~ msgstr "imposta configurazioni"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "interrompere ciclo display"

--- a/LCD4linux/po/lt.po
+++ b/LCD4linux/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Vytenis P. vyteniui@gmail.com\n"
@@ -12,3831 +12,4064 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Pen"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Pir"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Aparato LCD ekranas"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Šeš"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Šriftai"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Sek"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Mygtukai"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Ket"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG srautas"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Ant"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "Ekrano meniu"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Tre"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Vaizdai"
 
-#: plugin.py:288
-msgid "black"
-msgstr "juoda"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Iškylantis tekstas"
 
-#: plugin.py:288
-msgid "white"
-msgstr "balta"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos grotuvas"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "pilka"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Imtuvas"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "sidabrinė"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW keitiklis"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "melsvai pilka"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "akvamarinas"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Ekranas"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "auksinė"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "žaliai geltona"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "geltona"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "tamsiai oranžinė"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "tamsiai raudona"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "rusvai raudona"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "oranžinė"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "raudonai oranžinė"
-
-#: plugin.py:292
-msgid "red"
-msgstr "raudona"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomato"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "tamsiai žalia"
-
-#: plugin.py:293
-msgid "green"
-msgstr "žalia"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "žolės žalia"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "šviesiai žalia"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "laimo žalia"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "mėlyna"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "mėlynai violetinė"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "kariška žydra"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "rugiagėlių mėlyna"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "tamsiai mėlyna"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "šviesiai mėlyna"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "cianas"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "tamsi orchidėjų"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "sodriai rožinė"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "purpurinė"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violetinė"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "ruda"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "smėlio"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "alyvų žalia"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "rausvai ruda"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "smėlio ruda"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Ekranai 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Ekranai 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Ekranai 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Ekranai 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Ekranai 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Ekranai 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Ekranai 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Ekranai 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Ekranai 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Ekranai 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Ekranai 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Ekranai 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Ekranai 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Ekranai 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Ekranai 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Ekranai 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Ekranai 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Ekranai 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Ekranai 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Ekranai 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Ekranas 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Ekranas 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Ekranas 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Ekranas 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Ekranas 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Ekranas 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Ekranas 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Ekranas 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Ekranas 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "išjungta"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Ekranai 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Ekranai 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Ekranai 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "įjungta"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2val"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3val"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40sek"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50sek"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5val"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5sek"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10sek"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15sek"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20sek"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30sek"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (arba suderinamas LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (arba suderinamas LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (arba suderinamas LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (arba suderinamas LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Vidinis TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Vidinis aparato LCD ekranas"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "tik vaizdas 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "tik vaizdas 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "tik vaizdas 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "tik vaizdas 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "tik pasirinkto dydžio vaizdas"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "tik savo dydžio paveikslėlis 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Vidinis Vu+ Duo2 400x240 LCD"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 dienos  1 eilute"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 dienos  2 eilutėmis"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 dienos  1 eilute"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 dienos  2 eilutėmis"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 dienos vertikaliai"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 dienos  1 eilute"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 dienos  2 eilutėmis"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 dienos vertikaliai"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Temperatūra dabar (+°C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Temperatūra dabar (-°C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Dabartinis"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Temperatūra dabar"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Visi"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperatūra"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperatūra+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperatūra+Co2+slėgis"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperatūra+drėgnumas"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Modulis 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Moduliai 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Moduliai 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Moduliai 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Moduliai 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Moduliai 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Moduliai 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Moduliai 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Moduliai 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Moduliai 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Modulis 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Moduliai 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Moduliai 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Moduliai 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Moduliai 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Modulis 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Moduliai 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Moduliai 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Modulis 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Moduliai 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Modulis 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Moduliai 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Modulis 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "pasirinktas"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Juosta"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Juosta + reikšmė"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Mygtukas"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Mygtukas+skaitmuo"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analoginis"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analoginis+data"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analoginis +data+savaitės diena"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analoginis+data+savaitės diena 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Data"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Data+laikas"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Data+laikas+savaitės diena"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Datos dizainas"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Savaitės dienos dizainas"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Laikas"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Laikas+savaitės diena"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Savaitės diena"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "centras"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "kairė"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "dešinė"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Išplėstinis"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Išplėstinis (trumpas)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Trumpas"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Trumpas (išplėstinis)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Trumpas+išplėstinis"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Mėnuo"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Mėnuo+antraštė"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Savaitė"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Savaitė+antraštė"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "be kalendoriaus"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Datos 1 eilutė"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Datos 3 eilutės"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Datos 5 eilutės"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Datos 9 eilutės"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Datos glaustai 2 eilutės"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Datos glaustai 3 eilutės"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "be datų"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Pabraukti"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Pabraukti 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Rėmelis"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Datos"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Datos glaustai"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Datos glaustai be piktogramų"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Datos be piktogramų"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "be piktogramos"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "be piktogramos, su užduoties numeriu"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "su piktograma"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "su piktograma ir užduoties numeriu"
-
-#: plugin.py:329
-msgid "C"
-msgstr "°C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "°C + apsukos"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "°C + apsukos 2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "aps/min"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "aps./min. 2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "ne"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Apkrova@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Apkrova@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "rodyti paleistį"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "rodyti paleistį+budėjimą"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Visada visi"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Visada nauji"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Tik naujus"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Visa Informacija"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "tik Atstumas"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Atstumas+Apšvietimas"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Atstumas+Mėnulio fazė"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "tik Apšvietimas"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Apšvietimas+Mėnulio fazė"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "tik Mėnulio fazė"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Kanalas"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Kanalas+pavadinimas"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Piktograma+kanalas"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Piktograma+kanalas+pavadinimas"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Piktograma"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "tos pačios spalvos"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "taip +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "taip"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "vertikaliai"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontaliai"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Visuotinis"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "visi"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Kampas"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Kampas+laiko poslinkis"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Piktograma+laiko poslinkis"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "tik eigos juosta"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "su likusiom minutėm"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "su likusiom minutėm (dydis 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "su likusiom minutėm (dydis 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "su procentais"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "su procentais (dydis 1,5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "su procentais (dydis 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "su likusiom minutėm (virš)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "su likusiom minutėm (virš/dydis 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "su likusiom minutėm (virš/dydis 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "su procentais (virš)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "su procentais (virš/dydis 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "su procentais (virš/dydis 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "su likusiom minutėm (žemiau)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "su likusiom minutėm (žemiau/dydis 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "su likusiom minutėm (žemiau/dydis 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "su procentais (žemiau)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "su procentais (žemiau/dydis 1,5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "su procentais (žemiau/dydis 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "su dabartiniu 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "su dabartiniu 00:00 (dydis 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "su dabartiniu 00:00 (dydis 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "su dabartiniu 00:00 (virš)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "su dabartiniu 00:00 (virš/dydis 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "su dabartiniu 00:00 (virš/dydis 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "su dabartiniu 00:00 (žemiau)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "su dabartiniu 00:00 (žemiau/dydis 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "su dabartiniu 00:00 (žemiau/dydis 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "su procentais minutės/Iš viso (virš)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "su procentais minutės/Iš viso (virš/dydis 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "su procentais minutės/Iš viso (virš/dydis 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "su absoliučiu pabaigos laiku"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "su absoliučiu pabaigos laiku (dydis 1,5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "su absoliučiu pabaigos laiku (dydis 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "su minutėmis Iš viso/pab.laikas (virš)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "su minutėmis Iš viso/pab.laikas (virš/dydis 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "su minutėmis Iš viso/pab.laikas (virš/dydis2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Greitasis režimas (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normalus (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "pagal abėcėlę"
-
-#: plugin.py:386
-msgid "random"
-msgstr "atsitiktinis"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "geriau / lėčiau"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "mažas/greitas (tik vaizdams)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "mažas/greitas (viskam)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "podėlis+nustatymas (aukšta kokybė, lėtai)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "podėlis+nustatymas (žema kokybė, greitai)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "be podėlio + be nustatymų"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Prijungtas imtuvas"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB imtuvas"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Dabar/sekantis"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "įprastas"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "sumažintas"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Java skriptas"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Java scenarijus neatnaujinant"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Įkelti iš naujo"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normalus"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - sugretinimas"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternatyvus kopijavimo režimas/DM800HD (24bitų)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "taip + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "taip, ilgos"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "taip, trumpos"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/val"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Viršelių paieška"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "visada"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "Įjungta+multimedija+budėjimas"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Budėjimo režimas"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Multimedija"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "Įjungta"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bitų spalvos"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bitų juodai-balta/spalvota"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x '>>' mygtukas"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x '>>' mygtukas, 2 tipas"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Ilgas '>>' paspaudimas"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Ilgas '>>' paspaudimas 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x 'Info' mygtukas"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x 'Mute' mygtukas"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Ilgas 'Info' paspaudimas"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x '<<' mygtukas"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x '<<' mygtukas, 2 tipas"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Ilgas '<<' paspaudimas"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Ilgas '<<' paspaudimas 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "taip, išplėstas"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Konsolė"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Išsamus žurnalas"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Normalus žurnalas"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "išjungta"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radijas"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radijas+multimedija"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+radijas"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+radijas+multimedija"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (visas)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "įprastas (visas)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "apkirpta (juodas)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "apkirpta (skaidrus)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "'MUTE', arba priskirti mygtukai"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "bet kuris mygtukas"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Informacija"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Laikas+informacija"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Laikas+trukmė+informacija"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "MiniEPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Laikas+ilgis+informacija"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "pusiau kairėn"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "pusiau dešinėn"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Rėmelis x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Eilutė"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "be juostos"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "be rėmelio"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradientas"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Tamsinti kraštus"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normalus"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Piktograma+pozicija žemiau"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Piktograma+pozicija kairėje"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Piktograma+pozicija dešinėje"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Padėtis"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Pavadinimas"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Atsijungus"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Prisijungus"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Prisijungus+atsijungus"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "naudoti tik laikmatį"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "naudoti įvado laiką"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "be galutinio laikmačio"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "rodyti galutinį laikmatį"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "viena eilutė"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "dvi eilutės"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Prieinama atmintis"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Laisva atmintis"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "visas ekranas"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+Ekrano meniu"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "taip, išskyrus įrašus"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "R"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "RŠR"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "RPR"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "Š"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "ŠR"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "ŠŠR"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "ŠŠV"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "ŠV"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "P"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "PR"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "PPR"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "PPV"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "PV"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "V"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "VŠV"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "VPV"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%y.%m.%d %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%Y-%b-%d"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Įkelti aktyvų konfigūracijos failą"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Atkurti numatytas reikšmes / Valyti konfigūraciją"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Išsaugoti nustatymus į failą... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Įkelti failą : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Pašalinti failą?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "pašalinta"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "dabar nustatyta: %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux nustatymai"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Režimas"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Atšaukti"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Išsaugoti"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Paleisti iš naujo"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Įjungtas >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Neveikla"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "nėra LCD 1 vaizdo failo"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "nėra LCD 2 vaizdo failo"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "nėra LCD 3 vaizdo failo"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "ĮJUNGTI  LCD4linux"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 tipas"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 pasukti"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 fono spalva"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 fono paveikslėlis [Ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 šviesumas"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 pritemdymas nakčiai"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 atnaujinti"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 tipas"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 pasukti"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 fono spalva"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 fono paveikslėlis [Ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 šviesumas"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 pritemdymas nakčiai"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 atnaujinti"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 tipas"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 pasukti"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 fono spalva"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 fono paveikslėlis [Ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 šviesumas"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 pritemdymas nakčiai"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 atnaujinti"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Aparato LCD matmenys"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Aparato LCD poslinkis"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Aparato LCD spalva"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Įjungtame režime aparato LCD įjungtas"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Multimedijos režime aparato LCD įjungtas"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Neveiklos režime aparato LCD įjungtas"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "Ekrano meniu [kiek laiko rodyti]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- Kuriame LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Rodyti režimuose"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Ekrano meniu dydis"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Fonas / skaidrumas"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Greitesnis, žemesnės kokybės"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Iškylantis tekstas"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Išvalyti"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Šrifto dydis"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Vertikali pozicija"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Horizontalus lygiavimas"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Spalva"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Fono spalva"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Šriftas"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Aktyvus ekranas"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Ekranų perjungimas - Ekranas"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Ekranų perjungimas - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Ekranai, naudojami keitimui"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "1 ekrano rodymo laikas"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- 2 ekrano rodymo laikas"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- 3 ekrano rodymo laikas"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- 4 ekrano rodymo laikas"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- 5 ekrano rodymo laikas"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- 6 ekrano rodymo laikas"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- 7 ekrano rodymo laikas"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- 8 ekrano rodymo laikas"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- 9 ekrano rodymo laikas"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Vaizdų keitimosi laikas"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Vaizdų rūšiavimas"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Vaizdų rekursinis katalogas"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Vaizdų kokybė mažinant"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Vaizdų atnaujinimo intervalas [sek.]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Vaizdo failų tipas [tik vaizdai]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Fono paveikslėlio tipas"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Orų API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Orų API raktas OpenWeatherMap puslapyje"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Miestas, kurio orus rodyti"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "2 miestas, kurio orus rodyti"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Kelias į orų piktogramas [Ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Orų piktogramos dydis"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Neigiamos temperatūros spalva"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Teigiamos temperatūros spalva"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Orų lango skaidrumas"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Vėjo greičio matavimo vienetai"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Oras Vėjas Informacijos linijos"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Lietaus tikimybė"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Lietaus piešinio dydis"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Lietaus spalva"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Lietaus naudojama spalva 2 iš"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Lietaus spalva 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Orų linijos"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Orų tendencijų rodyklės"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Papildoma orų informacija"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Papildomos informacijos dydis"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Rodyti temperatūrų skirtumą"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Papildoma spalva miestui"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Papildoma spalva šalčiui"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 min. lygis"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 maks. lygis"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteotarnybos internetinis adresas"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Kelias į mėnulio piktogramą [Ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Užfiksuotą vaizdą išsaugoti į [Ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Dvigubo paspaudimo perjungimai"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Ekranų kaitos mygtukas"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Ekrano įjungimo/išjungimo mygtukas"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall paveikslėlių kelias [Ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall įrašo eilučių skaičius"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall sąrašo įrašų skaičius"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall paveikslėlių skaičius"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall paveikslėlių kryptis"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall paveikslėlių skaidrumas"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall paveikslėlių  paieška"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall pašalinti kvietimus po (val.)"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall iškylančio lango rodymo laikas"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall iškylantį langą rodyti"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall iškylančio lango spalva"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall lango paveikslėlis [Ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Kelias į kalendoriaus piktogramas [Ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Kalendoriaus piktogramų internetinis adresas"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Kalendoriaus-planuotojo FS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Šeštadienio spalva kalendoriuje"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Sekmadienio spalva kalendoriuje"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Kalendoriaus  eilutės storis"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Renginių peržiūra-kalendorinių dienų"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Kalendoriaus korekcija pagal laiko juostą"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Kalendoriaus skaidrumas"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Kalendoriaus užklausos intervalas"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Imtuvo raidės spalva"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Aktyvaus imtuvo raidės spalva"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Veikiančio imtuvo raidės spalva"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Kanalų paieška"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T signalo kokybės korekcija"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Visuotinis šriftas [Ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Šriftas 1 [Ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Šriftas 2 [Ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Šriftas 3 [Ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Šriftas 4 [Ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Šriftas 5 [Ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Paštas 1 - prisijungti"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Paštas 1 - serveris"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Paštas 1 [vardas:] vartotojas"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Paštas 1 - slaptažodis"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Paštas 2 - prisijungti"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Paštas 2 - serveris"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Paštas 2 [vardas:] vartotojas"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Paštas 2 - slaptažodis"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Paštas 3 - prisijungti"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Paštas 3 - serveris"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Paštas 3 [vardas:] vartotojas"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Paštas 3 - slaptažodis"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Paštas 4 - prisijungti"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Paštas 4 - serveris"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Paštas 4 [vardas:] vartotojas"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Paštas 4 - slaptažodis"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Paštas 5 - prisijungti"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Paštas 5 - serveris"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Paštas 5 [vardas:] vartotojas"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Paštas 5 - slaptažodis"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Pašto tikrinimo intervalas"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "IMAP pašto rodymo apribojimas (X paskutinių dienų)"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Paštas - rodyti ir tuščias dėžutes"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Paštas - rodyti datą"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Paštas - slėpti el. pašto adresą"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Nuotolinis aparatas 1 [vardas:]IP/vartotojas"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Nuotolinis aparatas 2 [vardas:]IP/vartotojas"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Nuotolinis aparatas 3 [vardas:]IP/vartotojas"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Nuotolinis aparatas 4 [vardas:]IP/vartotojas"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Nuotolinis aparatas 5 [vardas:]IP/vartotojas"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Nuotolinio aparato užklausa kas [min.]"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Nuotolinio aparato laikmatis [vardas:]IP/vartotojas"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Nuotolinio aparato laikmačio užklausa kas [min.]"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW keitiklio užklausų intervalas"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW keitiklio naudojimas"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW API raktas iš cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW API raktas iš convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF atnaujinti kas [sek.]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF atnaujinimo būdas"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF inicijavimo delsa"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF leidžiami IP"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF uždrausti IP"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF išvaizda"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Išsaugoti, kaip WebIF paveikslėlį"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG srautas į LCD 1 įjungtas"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG srauto į LCD 1 prievadas"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG srauto į LCD 1 virtualus šviesumas"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG srautas į LCD 2 įjungtas"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG srauto į LCD 2 prievadas"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG srauto į LCD 2 virtualus šviesumas"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG srautas į LCD 3 įjungtas"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG srauto į LCD 3 prievadas"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG srauto į LCD 3 virtualus šviesumas"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG ciklai"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG paleistas iš naujo po klaidos"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG antraštės dydis"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP adresas"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos ping intervalas [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos veiklos tikrinimas"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos atnaujinimo intervalas [sek.]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound ping intervalas [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound veiklos tikrinimas"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound atnaujinimo intervalas [sek.]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast serverio IP [pasirinktinai]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast 'ping' atsakas [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast tikrinimas"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast atnaujinimas [sek.]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast viršelis"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD pasirinktinis plotis"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD pasirinktinis aukštis"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD pasirinktinis plotis 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD pasirinktinis aukštis 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "Išjungti LCD, išjungus aparatą"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Greitąjame režime laiką skaičiuoti pagal 'laiką/5*2'"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Delsa [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Gijų viename LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Rodyti gedimo kampelį"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Rodyti 'ne ....' pranešimus"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Priverstinai skaityti prijungtas laikmenas"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Laikmenos - fono spalva"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Laikmenos - juosta (spalva)"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Laikmenos - užpildyta (spalva)"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Tikrinti prisijungimą prie tinklo"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Kadrų įkėlimas į podėlį [jei įmanoma]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Nustatymų atsarginės kopijos kelias [Ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Atkurti visus nustatymus"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Klaidų žurnalas > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Pašvietimo išjungimas [Off = įjungta]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Pašvietimo įjungimas"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Pašvietimo išjungimas savaitgaliais [Off = įjungta]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Pašvietimo įjungimas savaitgaliais"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD automatinis išjungimas"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Fonas"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Kelias iki paveikslėlio [Ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Piktogramos dydis"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Ekrano perskyrimas"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Pilnas ekranas"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Teksto dydis"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Skaidrumas"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Kelias į piktogramas [Ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Kelias į piktogramas 2 [Ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Piktogramų podėlio kelias [Ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Piktograma 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Laikrodis"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Tipas"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analoginis laikrodis"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Tarpai"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Dydis"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Tamsinti kraštus"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Laikrodis 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Programos pavadinimas"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- Daugiausiai eilučių"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Ilgis"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Programos numeris"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Programos informacija"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Tipas"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Programos informacija 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Sekančios programos informacija"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Išsamus aprašymas"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- Nesant aprašymo, rodyti informaciją"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Eigos juosta"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Spalvotas tekstas"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Kraštinė"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Užtamsinta"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Vienetai - min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Sistemos informacija"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Informacija apie imtuvą"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Jutikliai"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Sistemos informacija 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Signalo kokybės juosta"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradientas"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Min. diapazonas"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Maks. diapazonas"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Palydovas"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Tiekėjas"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Naudojamas imtuvas"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- Tik aktyvus imtuvas"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Sekančio įvykio laikmatis"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Garsas"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Nutildyti"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Garsas / Vaizdas"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitų dažnis"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Prisijungimas [ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Rodyti būklę"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Intervalas [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Tinklo vardas: adresas"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Išorinis IP adresas"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- išorinis IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Laikmenos"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- Perspėjimas, likus laisvos vietos"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- Papildoma informacija"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Įrenginio pavadinimas"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Orai"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Padidinti"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Orų tipas"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Orai 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteorologinė stotis"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Stotis"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Modulis"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Vartotojo pasirinktas modulis"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Bazinė"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Pavadinimas"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Spalva 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Spalva 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Spalva 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Spalva 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Spalva 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Spalva 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 kiekio rodiklis"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Ilgis [juosta]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo komforto rodiklis"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Mėnulio fazė"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Informacijos eilutės"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Tendencijų rodyklės"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Saulėtekis"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Rodyti Oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Kelias į failą [Ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Rodyti ECM informaciją"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Rodyti tekstinį failą"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Rodyti tekstinį failą 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Rodyti tekstinį failą 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Rodyti HTTP tekstą"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- Internetinis adresas"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-internetinis keitiklis"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP plotis"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP aukštis"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Kirpti nuo X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Kirpti nuo Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Pločio apkirpimas [išjungti = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Aukščio apkirpimas [išjungti = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Rodyti vaizdą"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Kelias iki failo [Ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Dydis maks. aukštis"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Greitas atnaujinimas"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Rodyti vaizdą 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Rodyti vaizdą 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Rodyti vaizdą 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Paštas"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Eilutės"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Pašto paskyra"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- Maksimalus plotis"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Nuotolinis aparatas"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Nuotolinio aparato laikmatis"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Paveikslo dydis"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Paveikslo pozicija"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Paveikslo lygiavimas"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Kalendorius"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF leidžiami IP"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Failas nepasirinktas, arba neteisingas, bandykite pasirinkti teisingą!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Režimas"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "IP saugumo aparatas nepalaiko"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Lūžio žurnalas"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Rodyti"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Pašalinti"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Failo pavadinimas"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Nustatymų atkūrimas"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Nustatymų atsarginė kopija"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Pašalinti žurnalą"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Parsisiųsti žurnalą"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Išsaugoti nustatymus"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "stabdyti ekranų kaitą"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Visuotinis"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "Įjungta"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Multimedija"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Neveikla"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "Reikia paleisti grafinę aplinką iš naujo"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Elementas"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "kita"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "patvirtinti pakeitimus"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "kopijuoti į 'Įjungtas'"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "kopijuoti į 'Multimedija'"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "kopijuoti į 'Neveikla'"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Vykd"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Rodyti išorinius"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Saugojimo įrenginių sąrašas"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Tėvų katalogas"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Pen"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Pir"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Šeš"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Sek"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Ket"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Ant"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Tre"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "juoda"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "balta"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "pilka"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "sidabrinė"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "melsvai pilka"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "akvamarinas"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "auksinė"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "žaliai geltona"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "geltona"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "tamsiai oranžinė"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "tamsiai raudona"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "rusvai raudona"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "oranžinė"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "raudonai oranžinė"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "raudona"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomato"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "tamsiai žalia"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "žalia"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "žolės žalia"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "šviesiai žalia"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "laimo žalia"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "mėlyna"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "mėlynai violetinė"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "kariška žydra"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "rugiagėlių mėlyna"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "tamsiai mėlyna"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "šviesiai mėlyna"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "cianas"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "tamsi orchidėjų"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "sodriai rožinė"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "purpurinė"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violetinė"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "ruda"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "smėlio"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "alyvų žalia"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "rausvai ruda"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "smėlio ruda"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Ekranai 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Ekranai 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Ekranai 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Ekranai 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Ekranai 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Ekranai 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Ekranai 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Ekranai 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Ekranai 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Ekranai 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Ekranai 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Ekranai 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Ekranai 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Ekranai 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Ekranai 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Ekranai 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Ekranai 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Ekranai 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Ekranai 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Ekranai 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Ekranas 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Ekranas 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Ekranas 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Ekranas 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Ekranas 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Ekranas 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Ekranas 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Ekranas 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Ekranas 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "išjungta"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Ekranai 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Ekranai 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Ekranai 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "įjungta"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2val"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3val"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40sek"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50sek"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5val"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5sek"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10sek"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15sek"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20sek"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30sek"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (arba suderinamas LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (arba suderinamas LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (arba suderinamas LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (arba suderinamas LCD) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Vidinis aparato LCD ekranas"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Vidinis TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "tik vaizdas 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "tik vaizdas 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "tik vaizdas 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "tik vaizdas 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "tik pasirinkto dydžio vaizdas"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "tik savo dydžio paveikslėlis 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Vidinis Vu+ Duo2 400x240 LCD"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 dienos  1 eilute"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 dienos  2 eilutėmis"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 dienos  1 eilute"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 dienos  2 eilutėmis"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 dienos vertikaliai"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 dienos  1 eilute"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 dienos  2 eilutėmis"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 dienos vertikaliai"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Temperatūra dabar (+°C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Temperatūra dabar (-°C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Dabartinis"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Temperatūra dabar"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Visi"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperatūra"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperatūra+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperatūra+Co2+slėgis"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperatūra+drėgnumas"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Modulis 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Moduliai 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Moduliai 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Moduliai 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Moduliai 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Moduliai 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Moduliai 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Moduliai 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Moduliai 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Moduliai 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Modulis 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Moduliai 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Moduliai 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Moduliai 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Moduliai 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Modulis 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Moduliai 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Moduliai 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Modulis 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Moduliai 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Modulis 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Moduliai 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Modulis 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "pasirinktas"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Juosta"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Juosta + reikšmė"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Mygtukas"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Mygtukas+skaitmuo"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analoginis"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analoginis+data"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analoginis +data+savaitės diena"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analoginis+data+savaitės diena 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Data"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Data+laikas"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Data+laikas+savaitės diena"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Datos dizainas"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Savaitės dienos dizainas"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Laikas"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Laikas+savaitės diena"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Savaitės diena"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "centras"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "kairė"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "dešinė"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Išplėstinis"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Išplėstinis (trumpas)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Trumpas"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Trumpas (išplėstinis)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Trumpas+išplėstinis"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Mėnuo"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Mėnuo+antraštė"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Savaitė"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Savaitė+antraštė"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "be kalendoriaus"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Datos 1 eilutė"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Datos 3 eilutės"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Datos 5 eilutės"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Datos 9 eilutės"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Datos glaustai 2 eilutės"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Datos glaustai 3 eilutės"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "be datų"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Pabraukti"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Pabraukti 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Rėmelis"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Datos"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Datos glaustai"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Datos glaustai be piktogramų"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Datos be piktogramų"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "be piktogramos"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "be piktogramos, su užduoties numeriu"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "su piktograma"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "su piktograma ir užduoties numeriu"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "°C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "°C + apsukos"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "°C + apsukos 2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "aps/min"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "aps./min. 2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "ne"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Apkrova@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Apkrova@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "rodyti paleistį"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "rodyti paleistį+budėjimą"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Visada visi"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Visada nauji"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Tik naujus"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Visa Informacija"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "tik Atstumas"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Atstumas+Apšvietimas"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Atstumas+Mėnulio fazė"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "tik Apšvietimas"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Apšvietimas+Mėnulio fazė"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "tik Mėnulio fazė"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Kanalas"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Kanalas+pavadinimas"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Piktograma+kanalas"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Piktograma+kanalas+pavadinimas"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Piktograma"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "tos pačios spalvos"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "taip +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "taip"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "vertikaliai"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontaliai"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "visi"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Kampas"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Kampas+laiko poslinkis"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Piktograma+laiko poslinkis"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "tik eigos juosta"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "su likusiom minutėm"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "su likusiom minutėm (dydis 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "su likusiom minutėm (dydis 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "su procentais"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "su procentais (dydis 1,5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "su procentais (dydis 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "su likusiom minutėm (virš)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "su likusiom minutėm (virš/dydis 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "su likusiom minutėm (virš/dydis 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "su procentais (virš)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "su procentais (virš/dydis 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "su procentais (virš/dydis 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "su likusiom minutėm (žemiau)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "su likusiom minutėm (žemiau/dydis 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "su likusiom minutėm (žemiau/dydis 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "su procentais (žemiau)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "su procentais (žemiau/dydis 1,5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "su procentais (žemiau/dydis 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "su dabartiniu 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "su dabartiniu 00:00 (dydis 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "su dabartiniu 00:00 (dydis 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "su dabartiniu 00:00 (virš)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "su dabartiniu 00:00 (virš/dydis 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "su dabartiniu 00:00 (virš/dydis 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "su dabartiniu 00:00 (žemiau)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "su dabartiniu 00:00 (žemiau/dydis 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "su dabartiniu 00:00 (žemiau/dydis 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "su procentais minutės/Iš viso (virš)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "su procentais minutės/Iš viso (virš/dydis 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "su procentais minutės/Iš viso (virš/dydis 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "su absoliučiu pabaigos laiku"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "su absoliučiu pabaigos laiku (dydis 1,5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "su absoliučiu pabaigos laiku (dydis 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "su minutėmis Iš viso/pab.laikas (virš)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "su minutėmis Iš viso/pab.laikas (virš/dydis 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "su minutėmis Iš viso/pab.laikas (virš/dydis2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Greitasis režimas (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normalus (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "pagal abėcėlę"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "atsitiktinis"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "geriau / lėčiau"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "mažas/greitas (tik vaizdams)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "mažas/greitas (viskam)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "podėlis+nustatymas (aukšta kokybė, lėtai)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "podėlis+nustatymas (žema kokybė, greitai)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "be podėlio + be nustatymų"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Prijungtas imtuvas"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB imtuvas"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Dabar/sekantis"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "įprastas"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "sumažintas"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Java skriptas"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Java scenarijus neatnaujinant"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Įkelti iš naujo"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normalus"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - sugretinimas"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternatyvus kopijavimo režimas/DM800HD (24bitų)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "taip + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "taip, ilgos"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "taip, trumpos"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/val"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Viršelių paieška"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "visada"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "Įjungta+multimedija+budėjimas"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Budėjimo režimas"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bitų spalvos"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bitų juodai-balta/spalvota"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x '>>' mygtukas"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x '>>' mygtukas, 2 tipas"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Ilgas '>>' paspaudimas"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Ilgas '>>' paspaudimas 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x 'Info' mygtukas"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x 'Mute' mygtukas"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Ilgas 'Info' paspaudimas"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x '<<' mygtukas"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x '<<' mygtukas, 2 tipas"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Ilgas '<<' paspaudimas"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Ilgas '<<' paspaudimas 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "taip, išplėstas"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Konsolė"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Išsamus žurnalas"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Normalus žurnalas"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "išjungta"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radijas"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radijas+multimedija"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+radijas"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+radijas+multimedija"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (visas)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "įprastas (visas)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "apkirpta (juodas)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "apkirpta (skaidrus)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "'MUTE', arba priskirti mygtukai"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "bet kuris mygtukas"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Informacija"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Laikas+informacija"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Laikas+trukmė+informacija"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "MiniEPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Laikas+ilgis+informacija"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "pusiau kairėn"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "pusiau dešinėn"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Rėmelis x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Eilutė"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "be juostos"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "be rėmelio"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradientas"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Tamsinti kraštus"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normalus"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Piktograma+pozicija žemiau"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Piktograma+pozicija kairėje"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Piktograma+pozicija dešinėje"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Padėtis"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Pavadinimas"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Atsijungus"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Prisijungus"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Prisijungus+atsijungus"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "naudoti tik laikmatį"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "naudoti įvado laiką"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "be galutinio laikmačio"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "rodyti galutinį laikmatį"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "viena eilutė"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "dvi eilutės"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Prieinama atmintis"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Laisva atmintis"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "visas ekranas"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+Ekrano meniu"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "taip, išskyrus įrašus"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "R"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "RŠR"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "RPR"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "Š"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "ŠR"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "ŠŠR"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "ŠŠV"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "ŠV"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "P"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "PR"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "PPR"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "PPV"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "PV"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "V"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "VŠV"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "VPV"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%y.%m.%d %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%Y-%b-%d"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Įkelti aktyvų konfigūracijos failą"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Atkurti numatytas reikšmes / Valyti konfigūraciją"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Išsaugoti nustatymus į failą... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Įkelti failą : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Pašalinti failą?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "pašalinta"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "dabar nustatyta: %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux nustatymai"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Atšaukti"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Išsaugoti"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Paleisti iš naujo"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Įjungtas >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "nėra LCD 1 vaizdo failo"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "nėra LCD 2 vaizdo failo"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "nėra LCD 3 vaizdo failo"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "ĮJUNGTI  LCD4linux"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 tipas"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 pasukti"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 fono spalva"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 fono paveikslėlis [Ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 šviesumas"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 pritemdymas nakčiai"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 atnaujinti"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 tipas"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 pasukti"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 fono spalva"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 fono paveikslėlis [Ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 šviesumas"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 pritemdymas nakčiai"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 atnaujinti"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 tipas"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 pasukti"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 fono spalva"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 fono paveikslėlis [Ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 šviesumas"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 pritemdymas nakčiai"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 atnaujinti"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Aparato LCD matmenys"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Aparato LCD poslinkis"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Aparato LCD spalva"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Įjungtame režime aparato LCD įjungtas"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Multimedijos režime aparato LCD įjungtas"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Neveiklos režime aparato LCD įjungtas"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "Ekrano meniu [kiek laiko rodyti]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- Kuriame LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Rodyti režimuose"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Ekrano meniu dydis"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Fonas / skaidrumas"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Greitesnis, žemesnės kokybės"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Iškylantis tekstas"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Išvalyti"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Šrifto dydis"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Vertikali pozicija"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Horizontalus lygiavimas"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Spalva"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Fono spalva"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Šriftas"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Aktyvus ekranas"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Ekranų perjungimas - Ekranas"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Ekranų perjungimas - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Ekranai, naudojami keitimui"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "1 ekrano rodymo laikas"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- 2 ekrano rodymo laikas"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- 3 ekrano rodymo laikas"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- 4 ekrano rodymo laikas"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- 5 ekrano rodymo laikas"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- 6 ekrano rodymo laikas"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- 7 ekrano rodymo laikas"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- 8 ekrano rodymo laikas"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- 9 ekrano rodymo laikas"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Vaizdų keitimosi laikas"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Vaizdų rūšiavimas"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Vaizdų rekursinis katalogas"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Vaizdų kokybė mažinant"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Vaizdų atnaujinimo intervalas [sek.]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Vaizdo failų tipas [tik vaizdai]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Fono paveikslėlio tipas"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Orų API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Orų API raktas OpenWeatherMap puslapyje"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Miestas, kurio orus rodyti"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "2 miestas, kurio orus rodyti"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Kelias į orų piktogramas [Ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Orų piktogramos dydis"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Neigiamos temperatūros spalva"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Teigiamos temperatūros spalva"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Orų lango skaidrumas"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Vėjo greičio matavimo vienetai"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Oras Vėjas Informacijos linijos"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Lietaus tikimybė"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Lietaus piešinio dydis"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Lietaus spalva"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Lietaus naudojama spalva 2 iš"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Lietaus spalva 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Orai Drėgmė Spalva"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Orų linijos"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Orų tendencijų rodyklės"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Papildoma orų informacija"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Papildomos informacijos dydis"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Rodyti temperatūrų skirtumą"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Papildoma spalva miestui"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Papildoma spalva šalčiui"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 min. lygis"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 maks. lygis"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteotarnybos internetinis adresas"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Kelias į mėnulio piktogramą [Ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Užfiksuotą vaizdą išsaugoti į [Ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Dvigubo paspaudimo perjungimai"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Ekranų kaitos mygtukas"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Ekrano įjungimo/išjungimo mygtukas"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall paveikslėlių kelias [Ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall įrašo eilučių skaičius"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall sąrašo įrašų skaičius"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall paveikslėlių skaičius"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall paveikslėlių kryptis"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall paveikslėlių skaidrumas"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall paveikslėlių  paieška"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall pašalinti kvietimus po (val.)"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall iškylančio lango rodymo laikas"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall iškylantį langą rodyti"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall iškylančio lango spalva"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall lango paveikslėlis [Ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Kelias į kalendoriaus piktogramas [Ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Kalendoriaus piktogramų internetinis adresas"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Kalendoriaus-planuotojo FS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Šeštadienio spalva kalendoriuje"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Sekmadienio spalva kalendoriuje"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Kalendoriaus  eilutės storis"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Renginių peržiūra-kalendorinių dienų"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Kalendoriaus korekcija pagal laiko juostą"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Kalendoriaus skaidrumas"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Kalendoriaus užklausos intervalas"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Imtuvo raidės spalva"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Aktyvaus imtuvo raidės spalva"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Veikiančio imtuvo raidės spalva"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Kanalų paieška"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T signalo kokybės korekcija"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Visuotinis šriftas [Ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Šriftas 1 [Ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Šriftas 2 [Ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Šriftas 3 [Ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Šriftas 4 [Ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Šriftas 5 [Ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Paštas 1 - prisijungti"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Paštas 1 - serveris"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Paštas 1 [vardas:] vartotojas"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Paštas 1 - slaptažodis"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Paštas 2 - prisijungti"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Paštas 2 - serveris"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Paštas 2 [vardas:] vartotojas"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Paštas 2 - slaptažodis"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Paštas 3 - prisijungti"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Paštas 3 - serveris"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Paštas 3 [vardas:] vartotojas"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Paštas 3 - slaptažodis"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Paštas 4 - prisijungti"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Paštas 4 - serveris"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Paštas 4 [vardas:] vartotojas"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Paštas 4 - slaptažodis"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Paštas 5 - prisijungti"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Paštas 5 - serveris"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Paštas 5 [vardas:] vartotojas"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Paštas 5 - slaptažodis"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Pašto tikrinimo intervalas"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "IMAP pašto rodymo apribojimas (X paskutinių dienų)"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Paštas - rodyti ir tuščias dėžutes"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Paštas - rodyti datą"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Paštas - slėpti el. pašto adresą"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Nuotolinis aparatas 1 [vardas:]IP/vartotojas"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Nuotolinis aparatas 2 [vardas:]IP/vartotojas"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Nuotolinis aparatas 3 [vardas:]IP/vartotojas"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Nuotolinis aparatas 4 [vardas:]IP/vartotojas"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Nuotolinis aparatas 5 [vardas:]IP/vartotojas"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Nuotolinio aparato užklausa kas [min.]"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Nuotolinio aparato laikmatis [vardas:]IP/vartotojas"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Nuotolinio aparato laikmačio užklausa kas [min.]"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW keitiklio užklausų intervalas"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW keitiklio naudojimas"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW API raktas iš cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW API raktas iš convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF atnaujinti kas [sek.]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF atnaujinimo būdas"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF inicijavimo delsa"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF uždrausti IP"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF išvaizda"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Išsaugoti, kaip WebIF paveikslėlį"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG srautas į LCD 1 įjungtas"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG srauto į LCD 1 prievadas"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG srauto į LCD 1 virtualus šviesumas"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG srautas į LCD 2 įjungtas"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG srauto į LCD 2 prievadas"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG srauto į LCD 2 virtualus šviesumas"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG srautas į LCD 3 įjungtas"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG srauto į LCD 3 prievadas"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG srauto į LCD 3 virtualus šviesumas"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG ciklai"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG paleistas iš naujo po klaidos"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG antraštės dydis"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP adresas"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos ping intervalas [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos veiklos tikrinimas"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos atnaujinimo intervalas [sek.]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound ping intervalas [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound veiklos tikrinimas"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound atnaujinimo intervalas [sek.]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast serverio IP [pasirinktinai]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast 'ping' atsakas [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast tikrinimas"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast atnaujinimas [sek.]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast viršelis"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD pasirinktinis plotis"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD pasirinktinis aukštis"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD pasirinktinis plotis 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD pasirinktinis aukštis 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "Išjungti LCD, išjungus aparatą"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Greitąjame režime laiką skaičiuoti pagal 'laiką/5*2'"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Delsa [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Gijų viename LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Rodyti gedimo kampelį"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Rodyti 'ne ....' pranešimus"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Priverstinai skaityti prijungtas laikmenas"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Laikmenos - fono spalva"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Laikmenos - juosta (spalva)"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Laikmenos - užpildyta (spalva)"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Tikrinti prisijungimą prie tinklo"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Kadrų įkėlimas į podėlį [jei įmanoma]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Nustatymų atsarginės kopijos kelias [Ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Atkurti visus nustatymus"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Klaidų žurnalas > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Pašvietimo išjungimas [Off = įjungta]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Pašvietimo įjungimas"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Pašvietimo išjungimas savaitgaliais [Off = įjungta]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Pašvietimo įjungimas savaitgaliais"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD automatinis išjungimas"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Fonas"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Kelias iki paveikslėlio [Ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Piktogramos dydis"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Ekrano perskyrimas"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Pilnas ekranas"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Teksto dydis"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Skaidrumas"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Kelias į piktogramas [Ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Kelias į piktogramas 2 [Ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Piktogramų podėlio kelias [Ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Piktograma 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Laikrodis"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Tipas"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analoginis laikrodis"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Tarpai"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Dydis"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Tamsinti kraštus"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Laikrodis 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Programos pavadinimas"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- Daugiausiai eilučių"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Ilgis"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Programos numeris"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Programos informacija"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Tipas"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Programos informacija 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Sekančios programos informacija"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Išsamus aprašymas"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- Nesant aprašymo, rodyti informaciją"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Eigos juosta"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Spalvotas tekstas"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Kraštinė"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Užtamsinta"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Vienetai - min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Sistemos informacija"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Informacija apie imtuvą"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Jutikliai"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Sistemos informacija 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Signalo kokybės juosta"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradientas"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Min. diapazonas"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Maks. diapazonas"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Palydovas"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Tiekėjas"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Naudojamas imtuvas"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- Tik aktyvus imtuvas"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Sekančio įvykio laikmatis"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Garsas"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Nutildyti"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Garsas / Vaizdas"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitų dažnis"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Prisijungimas [ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Rodyti būklę"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Intervalas [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Tinklo vardas: adresas"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Išorinis IP adresas"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- išorinis IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Laikmenos"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- Perspėjimas, likus laisvos vietos"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- Papildoma informacija"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Įrenginio pavadinimas"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Padidinti"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Orų tipas"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Orai 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteorologinė stotis"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Stotis"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Modulis"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Vartotojo pasirinktas modulis"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Bazinė"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Pavadinimas"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Spalva 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Spalva 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Spalva 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Spalva 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Spalva 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Spalva 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 kiekio rodiklis"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Ilgis [juosta]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo komforto rodiklis"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Mėnulio fazė"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Informacijos eilutės"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Tendencijų rodyklės"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Saulėtekis"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Rodyti Oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Kelias į failą [Ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Rodyti ECM informaciją"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Rodyti tekstinį failą"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Rodyti tekstinį failą 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Rodyti tekstinį failą 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Rodyti HTTP tekstą"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- Internetinis adresas"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-internetinis keitiklis"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP plotis"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP aukštis"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Kirpti nuo X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Kirpti nuo Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Pločio apkirpimas [išjungti = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Aukščio apkirpimas [išjungti = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Rodyti vaizdą"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Kelias iki failo [Ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Dydis maks. aukštis"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Greitas atnaujinimas"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Rodyti vaizdą 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Rodyti vaizdą 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Rodyti vaizdą 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Eilutės"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Pašto paskyra"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- Maksimalus plotis"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Nuotolinio aparato laikmatis"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Paveikslo dydis"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Paveikslo pozicija"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Paveikslo lygiavimas"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Išdėstymas"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Šios dienos fono spalva"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Antraštės spalva"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Datų sąrašas"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Įvykio piktogramų juosta"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Iškylantis vaizdas"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Iškylantis LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Rodyti tekstą 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Tekstas"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Rodyti tekstą 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Stačiakampis 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Pozicija X"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Pozicija Y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Dydis X"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Dydis Y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Stačiakampis 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Įrašymas"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Ekranai, naudojami keitimui"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Antraštė"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Informacijos"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Rodyti viršelį"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Paieškos kelias [Ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Raskite viršelio failą"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Numatytasis viršelis [Ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Pirmiausiai piktograma"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Apipjaustytas"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Parsisiųsti viršelius"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Parsisiuntimo būdas"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API raktas console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD ekranas"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Ekranas-'Įjungta' režimas"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Multimedija >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Ekranas-Mediagrotuvo režimas"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Neveikla >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Ekranas-Neveiklos režimas"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "VISUOTINIS >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Pasirinkite katalogą"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Pasirinkite failą"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Pasirinkite šriftą"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - dabartinė reikšmė: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3844,95 +4077,95 @@ msgstr ""
 "Kad pakeitimai įsigaliotų, grafinę aplinką reikia paleisti iš naujo.\n"
 "Ar norite paleisti iš naujo dabar?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Paleisti grafinę aplinką iš naujo dabar?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Viduje"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Lauke"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Lietus"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Vėjas"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Jaunatis"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Pirmasis ketvirtis"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Vaškuojantis pusmėnulis"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Augantis mėnulis"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Pilnatis"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Mažėjantis mėnulis"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Mažėjantis pusmėnulis"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Paskutinis ketvirtis"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%Y.%m.%d"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Paveikslėlis neprieinamas"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "be laikmačio"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM neveikia"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "be skambučių"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d laiškų %d naujų %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "neįdiegtas Netatmo-Plugin"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Ekranų perjungimas"
 
@@ -3950,112 +4183,3 @@ msgstr "LCD4linux Ekranų perjungimas"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Orai Vėjo kryptis"
-
-#~ msgid "Backup Config"
-#~ msgstr "Nustatymų atsarginė kopija"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Aparato LCD ekranas"
-
-#~ msgid "Crashlog"
-#~ msgstr "Lūžio žurnalas"
-
-#~ msgid "Delete"
-#~ msgstr "Pašalinti"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Pašalinti žurnalą"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Parsisiųsti žurnalą"
-
-#~ msgid "Element"
-#~ msgstr "Elementas"
-
-#~ msgid "Exec"
-#~ msgstr "Vykd"
-
-#~ msgid "Filename"
-#~ msgstr "Failo pavadinimas"
-
-#~ msgid "Font"
-#~ msgstr "Šriftai"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "Reikia paleisti grafinę aplinką iš naujo"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "IP saugumo aparatas nepalaiko"
-
-#~ msgid "Key"
-#~ msgstr "Mygtukai"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Saugojimo įrenginių sąrašas"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG srautas"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr ""
-#~ "Failas nepasirinktas, arba neteisingas, bandykite pasirinkti teisingą!"
-
-#~ msgid "OSD"
-#~ msgstr "Ekrano meniu"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Tėvų katalogas"
-
-#~ msgid "Picture"
-#~ msgstr "Vaizdai"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Iškylantis tekstas"
-
-#~ msgid "Restore Config"
-#~ msgstr "Nustatymų atkūrimas"
-
-#~ msgid "Save Config"
-#~ msgstr "Išsaugoti nustatymus"
-
-#~ msgid "Screen"
-#~ msgstr "Ekranas"
-
-#~ msgid "Show"
-#~ msgstr "Rodyti"
-
-#~ msgid "Show Externals"
-#~ msgstr "Rodyti išorinius"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos grotuvas"
-
-#~ msgid "Tuner"
-#~ msgstr "Imtuvas"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW keitiklis"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "kopijuoti į 'Neveikla'"
-
-#~ msgid "copy to Media"
-#~ msgstr "kopijuoti į 'Multimedija'"
-
-#~ msgid "copy to On"
-#~ msgstr "kopijuoti į 'Įjungtas'"
-
-#~ msgid "other"
-#~ msgstr "kita"
-
-#~ msgid "set Settings"
-#~ msgstr "patvirtinti pakeitimus"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "stabdyti ekranų kaitą"

--- a/LCD4linux/po/nl.po
+++ b/LCD4linux/po/nl.po
@@ -2,3841 +2,4074 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:08+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:18+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SearchPath-0: ..\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Vr"
-
-#: plugin.py:263
-msgid "Mon"
-msgstr "Ma"
-
-#: plugin.py:263
-msgid "Sat"
-msgstr "Za"
-
-#: plugin.py:263
-msgid "Sun"
-msgstr "Zo"
-
-#: plugin.py:263
-msgid "Thur"
-msgstr "Do"
-
-#: plugin.py:263
-msgid "Tue"
-msgstr "Di"
-
-#: plugin.py:263
-msgid "Wed"
-msgstr "Wo"
-
-#: plugin.py:288
-msgid "black"
-msgstr "zwart"
-
-#: plugin.py:288
-msgid "white"
-msgstr "wit"
-
-#: plugin.py:289
-msgid "gray"
-msgstr "grijs"
-
-#: plugin.py:289
-msgid "silver"
-msgstr "zilver"
-
-#: plugin.py:289
-msgid "slategray"
-msgstr "leigrijs"
-
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "zeegroen"
-
-#: plugin.py:291
-msgid "gold"
-msgstr "goud"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "groengeel"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "geel"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "donker oranje"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "donker rood"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indianred"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "oranje"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "oranjerood"
-
-#: plugin.py:292
-msgid "red"
-msgstr "rood"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomaat"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "donker groen"
-
-#: plugin.py:293
-msgid "green"
-msgstr "groen"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "grasgroen"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "licht groen"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "limoen"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "blauw"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "blauw paars"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "blauw-grijs"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "korenbloem blauw"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "donker blauw"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "licht blauw"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "groenblauw"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "donker paars"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "diep paars"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "paars"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "bruin"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "moccasin"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olijf"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "roze bruin"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "zandbruin"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Scherm 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Scherm 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Scherm 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Scherm 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Scherm 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Scherm 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Scherm 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Scherm 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Scherm 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Scherm 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Scherm 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Scherm 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Scherm 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Scherm 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Scherm 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Scherm 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Scherm 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Scherm 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Scherm 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Scherm 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Scherm 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Scherm 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Scherm 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Scherm 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Scherm 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Scherm 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Scherm 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Scherm 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Scherm9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "uit"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Scherm 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Scherm1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Scherm 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "aan"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2 uur"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3 uur"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5 uur"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (of compatible LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (of compatible LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (of compatible LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (of compatible LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Intern TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Intern Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "alleen foto1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "alleen foto 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "alleen foto 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "alleen foto 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "alleen foto aangepaste grootte"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "alleen foto aangepaste grootte 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Intern Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 dagen 1 regel"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 dagen 2 regels"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 dagen 1 regel"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 dagen 2 regels"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 dagen verticaal aanzicht"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 dagen 1 regel"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 dagen 2 regels"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 dagen verticaal aanzicht"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Huidige temperatuur (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Huidige temperatuur (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Huidige"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Huidige temperatuur"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Alle"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperatuur"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperatuur+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperatuur+Co2+Druk"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperatuur+vochtigheid"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Module 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Module 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Module 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Module 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Module 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Module 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Module 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Module 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Module 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Module 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Module 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Module 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Module 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Module 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Module 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Module 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Module 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Module 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Module 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Module 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Module 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Module 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Module 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "gebruiker gedefinieerd"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Balk"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Balk+waarde"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Schakelaar"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Schakelaar+waarde"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analoog"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analoog+Datum"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analoog+Datum+Dag"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analoog+datum+dag 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Datum"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Datum+Tijd"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Datum+Tijd+ Dag"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Flapsontwerp datum"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Flapsontwerp weekdg"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Tijd"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Tijd+Dag"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Weekdag"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "midden"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "links"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "rechts"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Uitgebreid"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Uitgebreid (kort)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Kort"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Kort (verlengd)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Kort+verlengd"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Maand"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Maand+hoofd"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Week"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Week+hoofd"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "geen kalender"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Data 1 regel"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Data 3 regels"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Data 5 regels"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Data 9 regels"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Datum compact 2 regels"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Datum compact 3 regels"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "geen datums"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Onderlijnen"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Onderlijnen 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Frame"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Data"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Datum compact"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Datum compact geen icoon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Datum geen icoon"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "geen ikoon"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "geen ikoon, met doelnummer"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "met ikoon"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "met ikoon & doelnummer"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + omw"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + omw/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "omw/min"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "omw/min/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "nee"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Laad@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Laad@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "toon actief"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "toon actief + slaap"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Altijd alle"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Altijd nieuw"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Alleen nieuw"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Alle Informatie"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "alleen Afstand "
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Afstand + Verlichting"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Afstand + Maanfase"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "alleen Verlichting"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Verlichting + Maanfase"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "alleen Maanfase"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Kanaal"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Kanaal+titel"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+kanaal"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+kanaal+titel"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "zelfde kleur"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "ja +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "ja"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "vertikaal"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontaal"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Globaal"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "alle"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Hoek"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Hoek + timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "alleen voortgangsbalk"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "met resterende minuten"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "met resterende minuten (maat 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "met resterende minuten (maat 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "met percentage"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "met percentage (maat 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "met percentage (maat 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "met resterende minuten (boven)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "met resterende minuten (boven/maat 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "met resterende minuten (boven/maat 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "met percentage (boven)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "met percentage (boven/maat 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "met percentage (boven/maat 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "met resterende minuten (onder)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "met resterende minuten (onder/maat 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "met resterende minuten (onder/maat 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "met percentage (onder)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "met percentage (onder/maat 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "met percentage (onder/maat 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "met huidige 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "met huidige 00:00 (maat 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "met huidige 00:00 (maat 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "met huidige 00:00 (boven)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "met huidige 00:00 (boven/maat 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "met huidige 00:00 (boven/maat 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "met huidige 00:00 (onder)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "met huidige 00:00 (onder/maat 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "met huidige 00:00 (onder/maat 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "met percentage minuten / totaal (boven)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "met percentage minuten / totaal (boven/maat 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "met percentage minuten / totaal (boven/maat 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "met absolute eindtijd"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "met absolute eindtijd (maat 1,5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "met absolute eindtijd (maat 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "met 'Totaal minuten' / Eindtijd (boven)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "met minuten Totaal/Eindtijd (boven/maat 1,5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "met minuten Totaal/Eindtijd (boven/maat 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Snelle modus (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normaal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alfabetisch"
-
-#: plugin.py:386
-msgid "random"
-msgstr "willekeurig"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "beter/langzaam"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "laag/langzaam (alleen foto)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "laag/snel (alle)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0,5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + aanpassing (hoge kwaliteit, langzaam)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + aanpassing (lage kwaliteit, snel)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "geen cache + geen aanpassing"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Plug tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Nu/Straks"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normaal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "beperkt"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript niet verversen"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Herlaad"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normaal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - Zij-aan-zij"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeather kaart"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternatieve kopieermode/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "ja + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "ja, lang"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "ja, kort"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Cover zoeken"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
+
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
+
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Lettertype"
+
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Sleutel"
+
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
+
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
+
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Plaatje"
+
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Popuptekst"
+
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
+
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Tuner"
+
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW converter"
+
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "Web-IF"
+
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Scherm"
+
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "altijd"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "Aan+media+stand-by"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Stand-by"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Media"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "Aan"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - kleur"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - grijsschaal/kleur"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x snel vooruit toets"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x snel vooruit toets type 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Snel voorwaards toets-lang"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Snel voorwaards toets-lang type 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Info-toets"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Mute"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Info toets-lang"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x snel achteruit toets"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x snel achteruit toets type 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Snel achterwaards toets-lang"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Snel achterwaards toets-lang type 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "ja, verlengd"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Console normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Logbestand uitgebreid"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Logbestand normaal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "uitgeschakeld"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Radio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Radio+Media"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Radio+Media"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (vol)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normaal (vol)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "getrimd (zwart)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "getrimd (doorzichtig)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE of definieer toetsen"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "elke toets"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Tijd+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Tijd+Duur+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Tijd+Lengte+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "half links"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "half rechts"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Frame x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Regel"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "geen balk"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "geen rand"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradiënt"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Schaduw hoeken"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normaal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+positie beneden"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+positie links"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+positie rechts"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Positie"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Naam"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Offline"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Online"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Online+Offline"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "gebruik alleen timer"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "gebruik voorlooptijd"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "geen totaal timer"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "toon totale timer"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "één regel"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "twee regels"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Beschikbaar geheugen"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Vrij geheugen"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "vol scherm"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "ja behalve opnames"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "O"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ONO"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "EZE"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NO"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNO"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNW"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NW"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "Z"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "ZO"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "ZZO"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "ZZW"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "ZW"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "W"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "WNW"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "WZW"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Laad actieve configuratiebestand"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Laad standaard waardes / lege configuratie"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Sla configuratiebestand op ,,,(%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Laad bestand: %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Verwijder bestand?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "verwijderd"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "momenteel ingesteld: %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux instellingen"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Modus"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Annuleer"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Bevestigen"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Herstart displays"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Aan instellingen >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Idle"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "geen LCD1 foto bestand"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "geen LCD2 foto bestand"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "geen LCD3 foto bestand"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux ingeschakeld"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Type"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 Roteer"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Achtergrondkleur"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Achtergrond-Foto [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 helderheid"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 nachtreductie"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 ververs"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Type"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Roteer"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Achtergrondkleur"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Achtergrond-Foto [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 helderheid"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 nachtreductie"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 verversen"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Type"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Roteer"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Achtergrondkleur"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Achtergrond-Foto [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 helderheid"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 nachtreductie"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 verversen"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD afmetingen"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD afwijking"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD kleur"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD schakel aan-modus in"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD schakel mediamode in"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD schakel idle-modus in"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [vertoon tijd]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- Welk LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Toon in mode"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- OSD-maat"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Achtergrond/Tranparantie"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Snel binnenhalen lagere kwaliteit"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Popuptekst"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Verwijder toets"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Letter grootte"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Positie"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Uitlijning"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Kleur"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Achtergrondkleur"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Lettertype"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Actief scherm"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Schermschakelkeuze - scherm"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Schermschakelkeuze - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Schermen gebruikt voor veranderen"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Scherm 1 Verander tijd"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Scherm 2 verandert tijd"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Scherm 3 verandert tijd"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Scherm 4 verandert tijd"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Scherm 5 verandert tijd"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Scherm 6 verandert tijd"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Scherm 7 verandert tijd"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Scherm 8 verandert tijd"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Scherm 9 verandert tijd"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Plaatje verandertijd"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Plaatje volgorde"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Plaatje map omgekeerd"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Plaatje kwaliteit voor herschalen"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Plaatje snelle update-tijd [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Type plaatje [alleen plaatje]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Achtergrond-type plaatje"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Weer-API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Weer API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Weer stad"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Weer stad 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Weer-ikoon-Pad [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Weer-ikoon zoom"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Weer lage temperatuur kleur"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Weer hoge temperatuur kleur"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Weer transparantie"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Weer windsnelheid eenheid"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Weer Wind Infolijnen"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Weer regenkans"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Regen zoom"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Kleur regen"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Regen gebruik kleur 2 van"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Kleur regen 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Weer regels"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Weer trend pijlen"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Weer Extra Info"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra Zoom"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Toon gevoelstemperatuur van verschil"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extra kleur stad"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extra kleur gevoelstemperatuur"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 min bereik"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 max bereik"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Meteo URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Maan-ikoonpad [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Opnameplaatje [OK]"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Dubbele toets schakelaars"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Sleutel voor scherm veranderen"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Sleutel voor scherm aan/uit"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall pad voor plaatjes [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall aantal lijnen per ingang"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall aantal lijstingangen"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall aantal plaatjes"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall orientatie van plaatjes"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall transparantie van plaatjes"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall plaatjes zoeken"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall verwijder oproepen na uren"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Popup tijd"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall Popup LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Popup kleur"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Frame Picture [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Kalender ics-pad [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Kalender ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Kalender planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Kalender kleur zaterdag"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Kalender kleur zondag"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Kalenderlijn dikte"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Kalenderdag gebeurtenis preview"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Kalender tijdzonecorrectie"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Kalender doorzichtigheid"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Kalender Poll Interval"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Tuner kleur"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Tuner kleur actief"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Tuner kleur aan"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Eerst kanaalzoeken"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T signaalkwaliteit correctie"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Lettertype globaal [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Lettertype 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Lettertype 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Lettertype 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Lettertype 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Lettertype 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Mail 1 verbinden"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Mail 1 Server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Mail 1 [Displayname:]Gebruikersnaam"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Mail 1 Wachtwoord"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Mail 2 verbinden"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Mail 2 Server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Mail 2 [Displayname:]Gebruikersnaam"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Mail 2 wachtwoord"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Mail 3 verbinden"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Mail 3 Server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Mail 3 [Displayname:]Gebruikersnaam"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Mail 3 wachtwoord"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Mail 4 verbinden"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Mail 4 Server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Mail 4 [Displayname:]Gebruikersnaam"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Mail 4 wachtwoord"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Mail 5 verbinden"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Mail 5 Server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Mail 5 [Displayname:]Gebruikersnaam"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Mail 5 wachtwoord"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Mail Poll Interval"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Mail IMAP beperk tot laatste dagen"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mail toon lege mailboxen"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Mail toon datum"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Mail verberg mailadres"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Remote box 1 [Displayname:]IP/Name"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Remote box 2 [Displayname:]IP/Name"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Remote box 3 [Displayname:]IP/Name"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Remote box 4 [Displayname:]IP/Name"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Remote box 5 [Displayname:]IP/Name"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Remote box elke minuut controleren"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Remote box timer [Displayname:]IP/Name"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Remote box Timer elke minuut controleren"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Converter Poll Interval"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW converter gebruik"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey van cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey van convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WEB-IF verversing [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WEB-IF verversings type"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WEB-IF Initiële vertraging"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WEB-IF IP toegestaan"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WEB-IF IP verboden"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "Web-IF ontwerp"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Sla op als plaatje voor WEB-IF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Stream LCD 1 inschakelen"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 poort"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG-stream LCD 1 virtuele helderheid"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Stream LCD 2 inschakelen"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 poort"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG-stream LCD 2 virtuele helderheid"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Stream LCD 3 inschakelen"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 poort"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG-stream LCD 3 virtuele helderheid"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG cyclus"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG herstarten bij fout"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG headermode"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Timeout [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos afspeelcontrole"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos verversen [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound ping timeout [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound play check"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound ververs [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [optioneel]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Timeout [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast afspeelcontrole"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast verversen [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Cover"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD aangepaste breedte"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD aangepaste hoogte"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD aangepaste breedte 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD aangepaste hoogte 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD uit wanneer uitgeschakeld"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Timing! Alle tijden naar tijd/5*2 in snelle mode omrekenen"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Toon vertraging [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Draden per LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Toon Crash hoek"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Toon 'nee ...' berichten"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Opslagmedia: force read"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Opslagmedia: kleur achter"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Opslagmedia: kleur balk"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Opslagmedia: kleur volledig"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Netwerkcontrole aktief"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Schakel framebuffer [indien mogelijk)"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Config backuppad [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Config herstel alle instellingen"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debuglogs > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Achtergrondverlichting Uit"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Achtergrondverlichting Aan"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Achtergrondverlichting weekeinde uit"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Achtergrondverlichting  Weekeinde Aan"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Auto-UIT"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Achtergrond"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Plaatje [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon grootte"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Gedeeld scherm"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Vol scherm"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Tekst grootte"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparantie"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon-pad [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon-pad 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon cache-pad [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Klok"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Type"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analoge klok"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Spatie"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "-Grootte"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Shaduwhoeken"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Klok 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Programmanaam"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- Maximum aantal lijnen"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Lengte"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Programmanummer"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Programma-info"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Type"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Programma-info 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Info volgende programma"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Uitgebreide beschrijving"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- gebruik info indien leeg"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Voortgangsbalk"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Kleur tekst"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Rand"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Schaduw"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Eenheid min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informatie"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Tunerinfo"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensors"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informatie 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Signaalkwaliteit balk"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradiënt"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Balkbereik min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Balkbereik max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satelliet"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Provider"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Gebruikte tuner"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- Alleen actieve tuner"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Volgende timer"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volume"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Mute"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Online [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Toon status"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Timeout [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Online Naam:Adres"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Extern IP adres"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- extern IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Opslagmedia"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- Vrij waarschuwing"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- extra info"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Apparaatnaam"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Weer"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Weertype"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Weer 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo-weerstation"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Station"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Module"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Module gebruiker gedefinieerd"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Basis"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Naam"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Kleur 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Kleur 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Kleur 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Kleur 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Kleur 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Kleur 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2-indicator"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Lengte [Balk]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo comfortindicator"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Maanfase"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Infolijnen"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Trend pijlen"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Zonsopkomst"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Toon oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Bestand [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Toon  ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Toon tekstbestand"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Toon tekstbestand 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Toon tekstbestand 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Toon HTTP tekst"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-Internet Converter"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP Breedte"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP Hoogte"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Knippen vanaf X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Knippen vanaf Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Knip-breedte (uitschakelen = 0)"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Knip-hoogte (uitschakelen = 0)"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Toon foto"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Bestand of pad [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Maximale hoogte"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Snell update"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Toon foto 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Toon foto 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Toon foto 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Lijnen"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Mail account"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- Maximale breedte"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Remote box"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Remote box Timer"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Foto grootte"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Foto positie"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Foto uitlijning"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Kalender"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WEB-IF IP toegestaan"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Geen of verkeer bestand geselecteerd; probeer eerst een correct bestand!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Modus"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "IP beveiliging is niet ondersteund door de box"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Crashlog"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Toon"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Verwijder"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Bestandsnaam"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Configuratie herstellen"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Back-up configuratie"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Verwijder logbestand"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Download logbestand"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Sla configuratie op"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "stop schermcyclus"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Globaal"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "Aan"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Media"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Idle"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "GUI-herstart is noodzakelijk"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Element"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "anders"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "maak instellingen"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "kopieer naar Aan"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "kopieer naar media"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "kopieer naar inactief"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Exec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Toon externe"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Lijst van opslagmedia"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Bovengelegen map"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Vr"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Ma"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Za"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Zo"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Do"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Di"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Wo"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "zwart"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "wit"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "grijs"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "zilver"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "leigrijs"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "zeegroen"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "goud"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "groengeel"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "geel"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "donker oranje"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "donker rood"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indianred"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "oranje"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "oranjerood"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "rood"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomaat"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "donker groen"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "groen"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "grasgroen"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "licht groen"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "limoen"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "blauw"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "blauw paars"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "blauw-grijs"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "korenbloem blauw"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "donker blauw"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "licht blauw"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "groenblauw"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "donker paars"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "diep paars"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "paars"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "bruin"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "moccasin"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olijf"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "roze bruin"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "zandbruin"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Scherm 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Scherm 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Scherm 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Scherm 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Scherm 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Scherm 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Scherm 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Scherm 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Scherm 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Scherm 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Scherm 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Scherm 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Scherm 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Scherm 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Scherm 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Scherm 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Scherm 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Scherm 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Scherm 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Scherm 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Scherm 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Scherm 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Scherm 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Scherm 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Scherm 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Scherm 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Scherm 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Scherm 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Scherm9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "uit"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Scherm 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Scherm1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Scherm 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "aan"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2 uur"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3 uur"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5 uur"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (of compatible LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (of compatible LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (of compatible LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (of compatibel LCD-scherm) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Intern Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Intern TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "alleen foto1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "alleen foto 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "alleen foto 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "alleen foto 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "alleen foto aangepaste grootte"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "alleen foto aangepaste grootte 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Intern Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 dagen 1 regel"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 dagen 2 regels"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 dagen 1 regel"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 dagen 2 regels"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 dagen verticaal aanzicht"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 dagen 1 regel"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 dagen 2 regels"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 dagen verticaal aanzicht"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Huidige temperatuur (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Huidige temperatuur (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Huidige"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Huidige temperatuur"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Alle"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperatuur"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperatuur+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperatuur+Co2+Druk"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperatuur+vochtigheid"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Module 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Module 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Module 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Module 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Module 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Module 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Module 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Module 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Module 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Module 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Module 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Module 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Module 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Module 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Module 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Module 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Module 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Module 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Module 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Module 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Module 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Module 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Module 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "gebruiker gedefinieerd"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Balk"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Balk+waarde"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Schakelaar"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Schakelaar+waarde"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analoog"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analoog+Datum"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analoog+Datum+Dag"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analoog+datum+dag 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Datum"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Datum+Tijd"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Datum+Tijd+ Dag"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Flapsontwerp datum"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Flapsontwerp weekdg"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Tijd"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Tijd+Dag"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Weekdag"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "midden"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "links"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "rechts"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Uitgebreid"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Uitgebreid (kort)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Kort"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Kort (verlengd)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Kort+verlengd"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Maand"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Maand+hoofd"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Week"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Week+hoofd"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "geen kalender"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Data 1 regel"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Data 3 regels"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Data 5 regels"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Data 9 regels"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Datum compact 2 regels"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Datum compact 3 regels"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "geen datums"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Onderlijnen"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Onderlijnen 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Frame"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Data"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Datum compact"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Datum compact geen icoon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Datum geen icoon"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "geen ikoon"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "geen ikoon, met doelnummer"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "met ikoon"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "met ikoon & doelnummer"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + omw"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + omw/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "omw/min"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "omw/min/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "nee"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Laad@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Laad@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "toon actief"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "toon actief + slaap"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Altijd alle"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Altijd nieuw"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Alleen nieuw"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Alle Informatie"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "alleen Afstand "
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Afstand + Verlichting"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Afstand + Maanfase"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "alleen Verlichting"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Verlichting + Maanfase"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "alleen Maanfase"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Kanaal"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Kanaal+titel"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+kanaal"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+kanaal+titel"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "zelfde kleur"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "ja +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "ja"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "vertikaal"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontaal"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "alle"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Hoek"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Hoek + timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "alleen voortgangsbalk"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "met resterende minuten"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "met resterende minuten (maat 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "met resterende minuten (maat 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "met percentage"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "met percentage (maat 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "met percentage (maat 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "met resterende minuten (boven)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "met resterende minuten (boven/maat 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "met resterende minuten (boven/maat 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "met percentage (boven)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "met percentage (boven/maat 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "met percentage (boven/maat 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "met resterende minuten (onder)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "met resterende minuten (onder/maat 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "met resterende minuten (onder/maat 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "met percentage (onder)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "met percentage (onder/maat 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "met percentage (onder/maat 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "met huidige 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "met huidige 00:00 (maat 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "met huidige 00:00 (maat 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "met huidige 00:00 (boven)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "met huidige 00:00 (boven/maat 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "met huidige 00:00 (boven/maat 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "met huidige 00:00 (onder)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "met huidige 00:00 (onder/maat 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "met huidige 00:00 (onder/maat 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "met percentage minuten / totaal (boven)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "met percentage minuten / totaal (boven/maat 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "met percentage minuten / totaal (boven/maat 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "met absolute eindtijd"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "met absolute eindtijd (maat 1,5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "met absolute eindtijd (maat 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "met 'Totaal minuten' / Eindtijd (boven)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "met minuten Totaal/Eindtijd (boven/maat 1,5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "met minuten Totaal/Eindtijd (boven/maat 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Snelle modus (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normaal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alfabetisch"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "willekeurig"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "beter/langzaam"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "laag/langzaam (alleen foto)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "laag/snel (alle)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0,5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + aanpassing (hoge kwaliteit, langzaam)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + aanpassing (lage kwaliteit, snel)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "geen cache + geen aanpassing"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Plug tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Nu/Straks"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normaal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "beperkt"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript niet verversen"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Herlaad"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normaal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - Zij-aan-zij"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeather kaart"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternatieve kopieermode/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "ja + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "ja, lang"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "ja, kort"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Cover zoeken"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "altijd"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "Aan+media+stand-by"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Stand-by"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - kleur"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - grijsschaal/kleur"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x snel vooruit toets"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x snel vooruit toets type 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Snel voorwaards toets-lang"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Snel voorwaards toets-lang type 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Info-toets"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Mute"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Info toets-lang"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x snel achteruit toets"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x snel achteruit toets type 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Snel achterwaards toets-lang"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Snel achterwaards toets-lang type 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "ja, verlengd"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Console normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Logbestand uitgebreid"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Logbestand normaal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "uitgeschakeld"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Radio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Radio+Media"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Radio+Media"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (vol)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normaal (vol)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "getrimd (zwart)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "getrimd (doorzichtig)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "MUTE of definieer toetsen"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "elke toets"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Tijd+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Tijd+Duur+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Tijd+Lengte+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "half links"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "half rechts"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Frame x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Regel"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "geen balk"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "geen rand"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradiënt"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Schaduw hoeken"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normaal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+positie beneden"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+positie links"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+positie rechts"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Positie"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Naam"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Offline"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Online"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Online+Offline"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "gebruik alleen timer"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "gebruik voorlooptijd"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "geen totaal timer"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "toon totale timer"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "één regel"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "twee regels"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Beschikbaar geheugen"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Vrij geheugen"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "vol scherm"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "ja behalve opnames"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "O"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ONO"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "EZE"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NO"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNO"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNW"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NW"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "Z"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "ZO"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "ZZO"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "ZZW"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "ZW"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "W"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "WNW"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "WZW"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Laad actieve configuratiebestand"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Laad standaard waardes / lege configuratie"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Sla configuratiebestand op ,,,(%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Laad bestand: %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Verwijder bestand?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "verwijderd"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "momenteel ingesteld: %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux instellingen"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Annuleer"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Bevestigen"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Herstart displays"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Aan instellingen >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "geen LCD1 foto bestand"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "geen LCD2 foto bestand"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "geen LCD3 foto bestand"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux ingeschakeld"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Type"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 Roteer"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Achtergrondkleur"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Achtergrond-Foto [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 helderheid"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 nachtreductie"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 ververs"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Type"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Roteer"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Achtergrondkleur"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Achtergrond-Foto [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 helderheid"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 nachtreductie"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 verversen"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Type"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Roteer"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Achtergrondkleur"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Achtergrond-Foto [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 helderheid"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 nachtreductie"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 verversen"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD afmetingen"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD afwijking"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD kleur"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD schakel aan-modus in"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD schakel mediamode in"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD schakel idle-modus in"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [vertoon tijd]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- Welk LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Toon in mode"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- OSD-maat"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Achtergrond/Tranparantie"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Snel binnenhalen lagere kwaliteit"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Popuptekst"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Verwijder toets"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Letter grootte"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Positie"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Uitlijning"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Kleur"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Achtergrondkleur"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Lettertype"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Actief scherm"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Schermschakelkeuze - scherm"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Schermschakelkeuze - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Schermen gebruikt voor veranderen"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Scherm 1 Verander tijd"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Scherm 2 verandert tijd"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Scherm 3 verandert tijd"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Scherm 4 verandert tijd"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Scherm 5 verandert tijd"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Scherm 6 verandert tijd"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Scherm 7 verandert tijd"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Scherm 8 verandert tijd"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Scherm 9 verandert tijd"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Plaatje verandertijd"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Plaatje volgorde"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Plaatje map omgekeerd"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Plaatje kwaliteit voor herschalen"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Plaatje snelle update-tijd [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Type plaatje [alleen plaatje]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Achtergrond-type plaatje"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Weer-API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Weer API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Weer stad"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Weer stad 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Weer-ikoon-Pad [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Weer-ikoon zoom"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Weer lage temperatuur kleur"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Weer hoge temperatuur kleur"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Weer transparantie"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Weer windsnelheid eenheid"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Weer Wind Infolijnen"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Weer regenkans"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Regen zoom"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Kleur regen"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Regen gebruik kleur 2 van"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Kleur regen 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Weer Vochtigheid Kleur"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Weer regels"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Weer trend pijlen"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Weer Extra Info"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra Zoom"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Toon gevoelstemperatuur van verschil"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extra kleur stad"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extra kleur gevoelstemperatuur"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 min bereik"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 max bereik"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Meteo URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Maan-ikoonpad [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Opnameplaatje [OK]"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Dubbele toets schakelaars"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Sleutel voor scherm veranderen"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Sleutel voor scherm aan/uit"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall pad voor plaatjes [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall aantal lijnen per ingang"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall aantal lijstingangen"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall aantal plaatjes"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall orientatie van plaatjes"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall transparantie van plaatjes"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall plaatjes zoeken"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall verwijder oproepen na uren"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Popup tijd"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall Popup LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Popup kleur"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Frame Picture [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Kalender ics-pad [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Kalender ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Kalender planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Kalender kleur zaterdag"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Kalender kleur zondag"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Kalenderlijn dikte"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Kalenderdag gebeurtenis preview"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Kalender tijdzonecorrectie"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Kalender doorzichtigheid"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Kalender Poll Interval"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Tuner kleur"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Tuner kleur actief"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Tuner kleur aan"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Eerst kanaalzoeken"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T signaalkwaliteit correctie"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Lettertype globaal [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Lettertype 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Lettertype 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Lettertype 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Lettertype 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Lettertype 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Mail 1 verbinden"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Mail 1 Server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Mail 1 [Displayname:]Gebruikersnaam"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Mail 1 Wachtwoord"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Mail 2 verbinden"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Mail 2 Server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Mail 2 [Displayname:]Gebruikersnaam"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Mail 2 wachtwoord"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Mail 3 verbinden"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Mail 3 Server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Mail 3 [Displayname:]Gebruikersnaam"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Mail 3 wachtwoord"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Mail 4 verbinden"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Mail 4 Server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Mail 4 [Displayname:]Gebruikersnaam"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Mail 4 wachtwoord"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Mail 5 verbinden"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Mail 5 Server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Mail 5 [Displayname:]Gebruikersnaam"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Mail 5 wachtwoord"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Mail Poll Interval"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Mail IMAP beperk tot laatste dagen"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mail toon lege mailboxen"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Mail toon datum"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Mail verberg mailadres"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Remote box 1 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Remote box 2 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Remote box 3 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Remote box 4 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Remote box 5 [Displayname:]IP/Name"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Remote box elke minuut controleren"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Remote box timer [Displayname:]IP/Name"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Remote box Timer elke minuut controleren"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Converter Poll Interval"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW converter gebruik"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey van cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey van convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WEB-IF verversing [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WEB-IF verversings type"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WEB-IF Initiële vertraging"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WEB-IF IP verboden"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "Web-IF ontwerp"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Sla op als plaatje voor WEB-IF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Stream LCD 1 inschakelen"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 poort"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG-stream LCD 1 virtuele helderheid"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Stream LCD 2 inschakelen"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 poort"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG-stream LCD 2 virtuele helderheid"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Stream LCD 3 inschakelen"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 poort"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG-stream LCD 3 virtuele helderheid"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG cyclus"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG herstarten bij fout"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG headermode"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Timeout [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos afspeelcontrole"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos verversen [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound ping timeout [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound play check"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound ververs [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [optioneel]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Timeout [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast afspeelcontrole"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast verversen [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Cover"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD aangepaste breedte"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD aangepaste hoogte"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD aangepaste breedte 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD aangepaste hoogte 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD uit wanneer uitgeschakeld"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Timing! Alle tijden naar tijd/5*2 in snelle mode omrekenen"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Toon vertraging [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Draden per LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Toon Crash hoek"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Toon 'nee ...' berichten"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Opslagmedia: force read"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Opslagmedia: kleur achter"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Opslagmedia: kleur balk"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Opslagmedia: kleur volledig"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Netwerkcontrole aktief"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Schakel framebuffer [indien mogelijk)"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Config backuppad [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Config herstel alle instellingen"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debuglogs > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Achtergrondverlichting Uit"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Achtergrondverlichting Aan"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Achtergrondverlichting weekeinde uit"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Achtergrondverlichting  Weekeinde Aan"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Auto-UIT"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Achtergrond"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Plaatje [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon grootte"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Gedeeld scherm"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Vol scherm"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Tekst grootte"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparantie"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon-pad [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon-pad 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon cache-pad [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Klok"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Type"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analoge klok"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Spatie"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "-Grootte"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Shaduwhoeken"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Klok 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Programmanaam"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- Maximum aantal lijnen"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Lengte"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Programmanummer"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Programma-info"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Type"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Programma-info 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Info volgende programma"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Uitgebreide beschrijving"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- gebruik info indien leeg"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Voortgangsbalk"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Kleur tekst"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Rand"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Schaduw"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Eenheid min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informatie"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Tunerinfo"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensors"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informatie 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Signaalkwaliteit balk"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradiënt"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Balkbereik min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Balkbereik max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satelliet"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Provider"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Gebruikte tuner"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- Alleen actieve tuner"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Volgende timer"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volume"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Mute"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Online [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Toon status"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Timeout [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Online Naam:Adres"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Extern IP adres"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- extern IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Opslagmedia"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- Vrij waarschuwing"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- extra info"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Apparaatnaam"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Weertype"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Weer 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo-weerstation"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Station"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Module"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Module gebruiker gedefinieerd"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Basis"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Naam"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Kleur 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Kleur 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Kleur 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Kleur 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Kleur 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Kleur 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2-indicator"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Lengte [Balk]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo comfortindicator"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Maanfase"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Infolijnen"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Trend pijlen"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Zonsopkomst"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Toon oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Bestand [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Toon  ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Toon tekstbestand"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Toon tekstbestand 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Toon tekstbestand 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Toon HTTP tekst"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-Internet Converter"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP Breedte"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP Hoogte"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Knippen vanaf X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Knippen vanaf Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Knip-breedte (uitschakelen = 0)"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Knip-hoogte (uitschakelen = 0)"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Toon foto"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Bestand of pad [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Maximale hoogte"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Snell update"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Toon foto 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Toon foto 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Toon foto 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Lijnen"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Mail account"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- Maximale breedte"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Remote box Timer"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Foto grootte"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Foto positie"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Foto uitlijning"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Lay-out"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Huidige achtergrondkleur overdag"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Hoofdletterkleur"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Datumlijst"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Gebeurtenissen ikoon balk"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popupscherm"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Toon tekst 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Tekst"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Toon tekst 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Rechthoek 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Positie x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Positie y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Waarde X"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Waarde Y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Rechthoek 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Neemt op"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stotter-TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Schermen gebruikt voor veranderen"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Titel"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Infos"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Toon Cover"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Zoekpad [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Vind cover-bestand [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Default cover [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon eerst"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Bijgesneden"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Download Cover"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Download Type"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Display"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux display-modus aan"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Media instellingen >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux display-modus mediaspeler"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Idle instellingen >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux display-modus idle"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Algemene instellingen >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Kies map"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Kies bestand"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Kies lettertype"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Huidige waarde: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3844,95 +4077,95 @@ msgstr ""
 "Er is een GUI-herstart nodig om de veranderingen toe te passen.\n"
 "Wilt u nu de GUI hertarten?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "GUI nu herstarten?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Binnenshuis"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Buitenshuis"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Regen"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Wind"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Nieuwe maan"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Eerste kwartier"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Wassende halve maan"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Wassende maan"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Volle maan"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Afnemende maan"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Afnemende halve maan"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Laatste kwartier"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Afbeelding niet beschikbaar"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "geen timer"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM draait niet"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "geen oproepen"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mail  %d Nieuw  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "geen Netatmo-Plugin geïnstalleerd"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux schermschakelaar"
 
@@ -3950,111 +4183,3 @@ msgstr "LCD4linux schermschakelaar"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Weer Wind richting"
-
-#~ msgid "Backup Config"
-#~ msgstr "Back-up configuratie"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Crashlog"
-
-#~ msgid "Delete"
-#~ msgstr "Verwijder"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Verwijder logbestand"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Download logbestand"
-
-#~ msgid "Element"
-#~ msgstr "Element"
-
-#~ msgid "Exec"
-#~ msgstr "Exec"
-
-#~ msgid "Filename"
-#~ msgstr "Bestandsnaam"
-
-#~ msgid "Font"
-#~ msgstr "Lettertype"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "GUI-herstart is noodzakelijk"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "IP beveiliging is niet ondersteund door de box"
-
-#~ msgid "Key"
-#~ msgstr "Sleutel"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Lijst van opslagmedia"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Geen of verkeer bestand geselecteerd; probeer eerst een correct bestand!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Bovengelegen map"
-
-#~ msgid "Picture"
-#~ msgstr "Plaatje"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Popuptekst"
-
-#~ msgid "Restore Config"
-#~ msgstr "Configuratie herstellen"
-
-#~ msgid "Save Config"
-#~ msgstr "Sla configuratie op"
-
-#~ msgid "Screen"
-#~ msgstr "Scherm"
-
-#~ msgid "Show"
-#~ msgstr "Toon"
-
-#~ msgid "Show Externals"
-#~ msgstr "Toon externe"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Tuner"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW converter"
-
-#~ msgid "WebIF"
-#~ msgstr "Web-IF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "kopieer naar inactief"
-
-#~ msgid "copy to Media"
-#~ msgstr "kopieer naar media"
-
-#~ msgid "copy to On"
-#~ msgstr "kopieer naar Aan"
-
-#~ msgid "other"
-#~ msgstr "anders"
-
-#~ msgid "set Settings"
-#~ msgstr "maak instellingen"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "stop schermcyclus"

--- a/LCD4linux/po/pt.po
+++ b/LCD4linux/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: BH Team\n"
@@ -15,3832 +15,4065 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Sex"
-
-#: plugin.py:263
-msgid "Mon"
-msgstr "Seg"
-
-#: plugin.py:263
-msgid "Sat"
-msgstr "Sáb"
-
-#: plugin.py:263
-msgid "Sun"
-msgstr "Dom"
-
-#: plugin.py:263
-msgid "Thur"
-msgstr "Qui"
-
-#: plugin.py:263
-msgid "Tue"
-msgstr "Ter"
-
-#: plugin.py:263
-msgid "Wed"
-msgstr "Qua"
-
-#: plugin.py:288
-msgid "black"
-msgstr "preto"
-
-#: plugin.py:288
-msgid "white"
-msgstr "branco"
-
-#: plugin.py:289
-msgid "gray"
-msgstr "cinzento"
-
-#: plugin.py:289
-msgid "silver"
-msgstr "prateado"
-
-#: plugin.py:289
-msgid "slategray"
-msgstr "cinzento pizarra"
-
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "agua-marinha"
-
-#: plugin.py:291
-msgid "gold"
-msgstr "dourado"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "verde amarelo"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "amarelo"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "laranja escuro"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "roxo escuro"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "pele vermelha"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "laranja"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "alaranjado"
-
-#: plugin.py:292
-msgid "red"
-msgstr "vermelho"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomate"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "verde escuro"
-
-#: plugin.py:293
-msgid "green"
-msgstr "verde"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "verde relva"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "verde claro"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "lima"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "azul"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "azul violeta"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "azul cadete"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "azul ciano"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "azul escuro"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "azul indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "celeste"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "ciano"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "orquídea escuro"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "rosa escuro"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "magenta"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "violeta"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "castanho"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "mocasín"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "verde oliva"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "castanho rosado"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "castanho areia"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Ecrãs 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Ecrãs 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Ecrãs 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Ecrãs 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Ecrãs 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Ecrãs 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Ecrãs 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Ecrãs 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Ecrãs 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Ecrãs 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Ecrãs 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Ecrãs 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Ecrãs 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Ecrã 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Ecrãs 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Ecrãs 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Ecrãs 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Ecrãs 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Ecrãs 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Ecrãs 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Ecrã 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Ecrã 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Ecrã 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Ecrã 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Ecrã 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Ecrã 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Ecrã 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Ecrã 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Ecrã 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "off"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Ecrãs 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Ecrãs 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Ecrãs 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "on"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (ou LCD compatível) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (ou LCD compatível) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (ou LCD compatível) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (ou LCD compatível) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H old 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H old 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "TFT-LCD interno 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "LCD Box-Skin interno"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "só Imagens 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "só Imagens 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "só Imagens 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "só Imagens 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "só Imagens de tamanho configurável"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "só Imagem Personalizada Tamanho 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "LCD interno Vu+ Duo2 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 Dias 1 Linha"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 Dias 2 Linhas"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 Dias 1 Linha"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 Dias 2 Linhas"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 dias vista vertical"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 Dias 1 Linha"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 Dias 2 Linhas"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 dias vista vertical"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Temperatura atual (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Temperatura atual (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Atual"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Temperatura atual"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Tudo"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Temperatura"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Temperatura+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Temperatura+Co2+Pressão"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Temperatura+Humidade"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Módulo 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Módulos 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Módulos 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Módulos 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Módulos 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Módulos 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Módulos 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Módulos 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Módulos 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Móduloa 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Módulo 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Módulos 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Módulos 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Módulos 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Módulo 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Módulo 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Módulos 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Módulo 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Módulo 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Módulo 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Módulo 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Módulo 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Módulo 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "definido pelo usuário"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Pre"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Pre+Valor"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Botão"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Botão+Valor"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analógico"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analógico+Data"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analógico+Data+Dia da Semana"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analógico+Data+Dia da Semana 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Data"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Data+Hora"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Data+Hora+Dia da Semana"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Data no Desenho Flaps"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Dia da Semana no Desenho Flaps"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Hora"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Hora+Dia da Semana"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Dia da Semana"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "centro"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "esquerda"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "direita"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Extendido"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Extendido (Curto)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Curto"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Curto (Extendido)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Curto+Extendido"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Mês"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Mes+Cabeçalho"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Semana"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Semana+Cabeçalho"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "sem Calendário"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Datas 1 Linha"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Datas 3 Linhas"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Datas 5 Linhas"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Datas 9 Linhas"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Datas compatas en 2 Linhas"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Datas compatas en 3 Linhas"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "sem Datas"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Sublinhado"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Sublinhado 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Quadro"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Datas"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Datas compatas"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Datas compatas sem Icon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Datas sem Icon"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "sem Icons"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "sem Icon, com Número de Destino"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "com Icon"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "com Icono & Número de Destino"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "não"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "mostrar execução"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "mostrar execução+repouso"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Sempre Tudo"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Sempre Novo"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Só os Novos"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Todas as Informações"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Distância apenas"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Distância+Iluminação"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Distância + Fases da Lua"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Iluminação apenas"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Iluminação+Fase da Lua"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Fase da lua apenas"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Canal"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Canal+Título"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+Canal"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+Canal+Título"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "mesma cor"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "sim+25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "sim"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "verticalmente"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "horizontalmente"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Global"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "tudo"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Esquina"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Canto+Timeshift"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Timeshift"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "só Barra de Progreso"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "com Minutos Restantes"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "com Minutos Restantes (Tamanho 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "com Minutos Restantes (Tamanho 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "com Percentagem"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "com Percentagem (tamanho 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "con Percentagem (tamanho 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "com Minutos Restantes (acima)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "com Minutos Restantes (acima/Tamanho 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "com Minutos Restantes (acima/Tamanho 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "con Percentagem (acima)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "com Percentagem (acima/Tamanho 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "com Percentagem (acima/Tamanho 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "com Minutos Restantes (abaixo)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "com Minutos Restantes (abaixo/Tamanho 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "com Minutos Restantes (abaixo/Tamanho 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "con Percentagem (abaixo)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "com Percentagem (abaixo/Tamanho 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "com Percentagem (abaixo/Tamanho 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "com o Atual 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "com o Atual 00:00 (Tamanho 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "com o Atual 00:00 (Tamanho 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "com o Atual 00:00 (acima)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "com o Atual 00:00 (acima/Tamanho 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "com o Atual 00:00 (acima/Tamanho 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "com o Atual 00:00 (abaixo)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "com o Atual 00:00 (abaixo/Tamanho 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "com o Atual 00:00 (abaixo/Tamanho 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "com Percentagem de Minutos / Total (acima)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "com Percentagem de Minutos / Total (acima/Tamanho 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "com Percentagem de Minutos / Total (arriba/Tamanho 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "com tempo final absoluto"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "com tempo final absoluto (Tamanho 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "com tempo final absoluto (Tamanho 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "com Total de minutos / Tempo final (superior)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "com Total de minutos / Tempo final (superior/Tamanho 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "com Total de minutos / Tempo final (superior/Tamanho 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Modo Rápido (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normal (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "alfabético"
-
-#: plugin.py:386
-msgid "random"
-msgstr "aleatório"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "melhor/lento"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "baixo/rápido (só Fotos)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "baixo/rápido (tudo)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + ajuste (alta qualidade, lento)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + ajuste (baixa qualidade, rápido)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "sem cache + sem ajuste"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Sintonizador integrado"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "Sintonizador USB"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Agora/Depois"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normal"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "reduzido"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript sem atualização"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Recarregar"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normal"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - lado a lado"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "modo Cópia alternativo/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "sim + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "sim, longo"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "sim, curto"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Coversearch"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
+
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
+
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Fonte"
+
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Chave"
+
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
+
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
+
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Imagem"
+
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Texto Emergente"
+
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
+
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Sintonizador"
+
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "Conversor WWW"
+
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
+
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Ecrã"
+
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "sempre"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Mídia+Repouso"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Repouso"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Mídia"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "On"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - color"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - cor/cinzento"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x Tecla Avanço Rápido"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x Tecla Avanço Rápido Tipo 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Tecla Avanço Rápido Prolongada"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Tecla Avanço Rápido Prolongada Tipo 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Tecla Info"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Tecla MUTE"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Tecla Info Prolongada"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x Tecla Retrocesso Rápido"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x Tecla Retrocesso Rápido Tipo 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Tecla Retrocesso Rápido Prolongada"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Tecla Retrocesso Rápido Longo Tipo 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "sim, extendido"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Consola normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Arquivo de log extenso"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Arquivo de log normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "desligado"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Rádio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Rádio + Mídia"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Rádio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Rádio+Mídia"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (completo)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normal (completo)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "ajustado (preto)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "ajustado (transparente)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "MUTE ou teclas definidas"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "qualquer Chave"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Hora+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Hora+Duração+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Hora+Duração+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "metade esquerda"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "metade direita"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Quadro x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Linha"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "sem Barra"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "sem orla"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Gradiente"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Margens de Sombra"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normal"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Posição abaixo"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Posição esquerda"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Posição direita"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Posição"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Nome"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Desconetado"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Conetado"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Conetado+Desconetado"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "usar só Temporizador"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "usar hora principal"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "sem Timer completo"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "mostrar Temporizador completo"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "uma linha"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "duas linhas"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Memória disponível"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Memória livre"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "ecrã completo"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "sim, excepto gravações"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "ENE"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "ESE"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NE"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNE"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNO"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NO"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SE"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSE"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSO"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SO"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "O"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "ONO"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "OSO"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Carregar Arquivo de Configuração Ativo"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Carregar Padrões / Config vazia"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Salvar Configuração no arquivo...(%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Carregar Arquivo : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Apagar Ficheiro?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "apagado"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "ajuste atual : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "Definições do LCD4linux"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Modo"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Salvar"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Reiniciar Ecrãs"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Def On >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Idle"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "não existe Arquivo de Imagem de LCD1"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "não existe Arquivo de Imagem de LCD2"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "não existe Arquivo de Imagem de LCD"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux ativado"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "Tipo LCD 1"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- Rodar LCD 1"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- Cor de Fundo LCD 1"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- Fundo-Imagem LCD 1 [OK]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- Brilho LCD 1"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- Redução Noturna LCD 1"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- Refrescar LCD 1"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "Tipo LCD 2"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- Rodar LCD 2"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- Cor de Fundo LCD 2"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- Fundo-Imagem LCD 2 [OK]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- Brilho LCD 2"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- Redução Noturna LCD 2"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- Refrescar LCD 2"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "Tipo LCD 3"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- Rodar LCD 3"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- Cor de Fundo LCD 3"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- Fundo-Imagem LCD 3 [OK]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- Brilho LCD 3"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- Redução Noturna LCD 3"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- Refrescar LCD 3"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD Tamanho"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Desvio"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD Cor"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD Ativar Modo On"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD Ativar Modo Mídia"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD Ativar Modo Apagado"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [hora no ecrã]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- qual LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Mostrar em Modo"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Tamanho OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Fundo/Transparência"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Gravador Rápido de qualidade baixa"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Texto Emergente"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Clear Key"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Tamanho da Fonte"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Posição"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Alinhamento"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Cor"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Cor de Fundo"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Fonte"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Ecrã Ativo"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Selecionar ecrã a Mudar - LCD"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Selecionar ecrã a Mudar - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Ecrãs usados para mudar"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Tempo para mudar Ecrã 1"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 2"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 3"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 4"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 5"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 6"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 7"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 8"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Tempo de permuta de Ecrã 9"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Tempo para mudar de Imagem"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Imagens aleatórias"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Diretório Recursivo de Imagens"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Qualidade da Imagem para Redimensionar"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Tempo de Atualização Rápida de Imagen [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Tipo de Imagem [só Imagem]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Fundo - Tipo de Imagem"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "O Tempo API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Chave do Tempo API OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Cidade para o Tempo"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Cidade para o Tempo 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Percurso de Icons do Tempo [OK]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Zoom de Icons do Tempo"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Cor de Baixa Temperatura do Tempo"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Cor de Alta Temperatura do Tempo"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Transparências do Tempo"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Unidade de Velocidade do Viento no Tempo"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Linhas de informação do vento do tempo"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Possibilidade de Chuva no Tempo"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Zoom da Chuva"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Cor da Chuva"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- A Chuva usa cor 2 desde"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Cor de Chuva 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Linhas do Tempo"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Tempo Setas de Tendência"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Informações Extras do Tempo"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Zoom Extra"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Mostrar temperaturas mais frias desde a diferença"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Cor Extra da Cidade"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Cor Extra do Frio"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Intervalo Mínimo"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Intervalo Máximo"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "URL Meteo"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Percurso Icons Lunares [OK]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Imagem de Gravação [OK]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Trocas Tecla dupla"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Tecla para mudar Ecrã"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Tecla para Apagar/Acender Ecrã"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall Percurso da Imagem [OK]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Número de Linhas por Entrada"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall Número de Entradas Listadas"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall Número de Imagems"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall Orientação da Imagem"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "Transparência Imagem FritzCall"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall Busca de Imagens"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall apagar chamadas fora de horas"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Hora Emergente"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall LCD Emergente"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Cor Emergente"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Quadro de Imagem [OK]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Percurso Calendário ics [OK]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "URL Calendário ics"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Calendário planerFS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Calendário Cor Sábado"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Calendário Cor Domingo"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Calendário Linhas Finas"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Calendário Previsualização Eventos Diários"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Calendário Correção Zona Horária"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Calendário Transparência"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Calendário Intervalo"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Cor Sintonizador"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Cor Sintonizador Activo"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Cor Sintonizador Ligado"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Primeiro Busca de Canais"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "Correção da qualidade de Sinal DVB-T"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Fonte Global [OK]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Fonte 1 [OK]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Fonte 2 [OK]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Fonte 3 [OK]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Fonte 4 [OK]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Fonte 5 [OK]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Conetar E-Mail 1"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Servidor E-Mail 1"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "E-Mail 1 [Nome:]Usuário"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Senha E-Mail 1"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Conetar E-Mail 2"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Servidor E-Mail 2"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "E-Mail 2 [Nome:]Usuário\""
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Senha E-Mail 2"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Conetar E-Mail 3"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Servidor E-Mail 3"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "E-Mail 3 [Nome:]Usuário"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Senha E-Mail 3"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Conetar E-Mail 4"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Servidor E-Mail 4"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "E-Mail 4 [Nome:]Usuário"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Senha E-Mail 4"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Conetar E-Mail 5"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Servidor E-Mail 5"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "E-Mail 5 [Nome:]Usuário"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Senha E-Mail 5"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Intervalo E-Mail"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "E-Mail IMAP limitado até aos últimos dias"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Mostrar Caixas Vazias de E-Mail"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Data de Exibir o E-Mail"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "O E-Mail Esconde o Endereço"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 1 [NomeEcrã:]IP/Nome"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 2 [NomeEcrã:]IP/Nome"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 3 [NomeEcrã:]IP/Nome"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 4 [NomeEcrã:]IP/Nome"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Dispositivo Remoto 5 [NomeEcrã:]IP/Nome"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Sondar Dispositivo Remoto todos os Minutos"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Timer da box remota [Nome a exibir:]IP/Nome"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Timer da box remota pesquisa todos os Minutos"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "Intervalo Conversor WWW"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "Uso do Conversor WWW"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "Chave Api WWW de cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "Chave Api WWW de convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "Refrescamento WebIF [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "Tipo de Refrescamento WebIF"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "Atraso de Inicio WebIF"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "IP Permitido WebIF"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "IP Proibido WebIF"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "Desenho WebIF"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Guardar como Imagem para WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "Ativar Stream MJPEG LCD 1"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "Porta Stream MJPEG LCD 1"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Stream LCD 1 Brilho Virtual"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "Activar Stream MJPEG LCD 2"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "Porta Stream MJPEG LCD 2"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2 Brilho Virtual"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "Activar Stream MJPEG LCD 3"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "Porta Stream MJPEG LCD 3"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Stream LCD 3 Brilho Virtual"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "Ciclo MJPEG"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Reiniciar com erro"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "Modo de Cabeçalho MJPEG"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "IP Sonos"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Tempo limite de Ping Sonos [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Verificar reprodução Sonos"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Refrescar Sonos [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound tempo limite de Ping [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound verificar reprodução"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Refrescar [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast IP [opcional]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Tempo limite de Ping [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Verificar reprodução"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Refrescar [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Cobrir"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "Largura Personalizada do LCD"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "Altura Personalizada do LCD"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD Personalizado Largura 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD Personalizado Altura 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD Desligado ao desligar"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Hora ! calcular todas as vezes a hora/5*2 en Modo Rápido"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Atraso Ecrã [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Threads por LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Mostrar Crash"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Mostrar Mensagens 'não...'"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Forçar Leitura de Dispositivos de Armazenamento"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Dispositivos de armazenamento: Cor Fundo"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Dispositivos de armazenamento: Cor Barra"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Dispositivos de armazenamento: Cor Cheia"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Verificar rede ativa"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Por contador de planos (se for possível)"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Percurso para Guardar Configurações [OK]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Restaurar Configuração de todas as Definições"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Registo de Depuração > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Luz de Fundo Desligada [desligar ajuste Off=On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Luz de Fundo Ligada"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Luz de Fundo Fim de Semana desconetada [desligar ajuste Off=On]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Luz de Fundo Fim de Semana ligada"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Auto-OFF"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Fundo"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Imagem [OK]"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Tamanho dos Picons"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Ecrã Dividido"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- Ecrã Completo"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Tamanho do Texto"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Transparência"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Percurso Picon [OK]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Percurso Picon 2 [OK]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache Percurso [OK]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Relógio"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "- Tipo"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Relógio Analógico"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Espaçado"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Tamanho"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Margens de Sombra"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Relógio 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Nome do Programa"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- máximo de Linhas"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Duração"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Número do Programa"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Informação do Programa"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Tipo"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Informação Programa 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Informação do Próximo Programa"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Descrição Extendida"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- usar informação quando vazia"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Barra de Progresso"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Cor do Texto"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Margem"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Sombreado"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Unidade min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informações"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Informação do Tuner"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Sensores"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informações 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Barra de Qualidade do Sinal"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Gradiente"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Barra Gama Mínima"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Barra Gama Máxima"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satélite"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Operador"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Sintonizador Usado"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- só o Tuner ativo"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Próximo Evento Programado"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Volume"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "2 x Muda"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Online [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Mostrar Estado"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Descanso [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Nome Online:Endereço"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Endereço IP Externo"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- URL de IP externo"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Dispositivos de Armazenamento"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- Advertência"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- informação extra"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Nome do Dispositivo"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "O Tempo"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Zoom"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Tipo de Tempo"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "O Tempo 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Estação Metereológica do Tempo"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Estação"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Módulo"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Módulo definido pelo usuário"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Base"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Nome"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Cor 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Cor 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Cor 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Cor 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Cor 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Cor 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo Indicador de CO2"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Comprimento [Barra]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Indicador de Comodidade"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Fases da Lua"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Linhas de Informação"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Setas de Tendência"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Amanhecer"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Mostrar oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Arquivo [OK]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Mostrar ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Mostrar Arquivo de Texto"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Mostrar Arquivo de Texto 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Mostrar Arquivo de Texto 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Mostrar Texto HTTP"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "Conversor WWW-Internet"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- Largura HTTP"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- Altura HTTP"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Cortar desde X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Cortar desde Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Cortar Largura [desligar = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Cortar Altura [desligar = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Mostrar Imagem"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Arquivo ou Percurso [OK]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Tamanho Altura Máxima"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Atualização Rápida"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Mostrar Imagem 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Mostrar Imagem 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Mostrar Imagem 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "E-Mail"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Linhas"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- E-Mail Konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- Largura máxima"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Dispositivo Remoto"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Timer da box remota"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Tamanho Imagem"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- Posição Imagem"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Alinhamento Imagem"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Calendário"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "IP Permitido WebIF"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Inexistente ou arquivo não selecionado, corrigir isto primeiro!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Modo"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Segurança de IP não suportada pelo dispositivo"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Registo de Bloqueio"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Mostrar"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Apagar"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Nome do ficheiro"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Restaurar Configuração"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Guardar Configuração"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Apagar ficheiro de Depuração"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Descarregar Arquivo de Depuração"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Salvar Configuração"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "parar Ciclo de Ecrã"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Global"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "On"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Mídia"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Idle"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "É necessário reiniciar a GUI"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Elemento"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "outro"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "ajustar"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "copiar para Ligado"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "copiar para Mídia"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "copiar a Espera"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Exec"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Mostrar externas"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Lista de Dispositivos de Armazenamento"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Diretório Parental"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Sex"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Seg"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Sáb"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Dom"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Qui"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Ter"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Qua"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "preto"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "branco"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "cinzento"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "prateado"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "cinzento pizarra"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "agua-marinha"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "dourado"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "verde amarelo"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "amarelo"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "laranja escuro"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "roxo escuro"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "pele vermelha"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "laranja"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "alaranjado"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "vermelho"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomate"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "verde escuro"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "verde"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "verde relva"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "verde claro"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "lima"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "azul"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "azul violeta"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "azul cadete"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "azul ciano"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "azul escuro"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "azul indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "celeste"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "ciano"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "orquídea escuro"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "rosa escuro"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "magenta"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "violeta"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "castanho"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "mocasín"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "verde oliva"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "castanho rosado"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "castanho areia"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Ecrãs 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Ecrãs 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Ecrãs 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Ecrãs 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Ecrãs 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Ecrãs 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Ecrãs 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Ecrãs 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Ecrãs 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Ecrãs 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Ecrãs 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Ecrãs 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Ecrãs 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Ecrã 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Ecrãs 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Ecrãs 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Ecrãs 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Ecrãs 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Ecrãs 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Ecrãs 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Ecrã 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Ecrã 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Ecrã 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Ecrã 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Ecrã 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Ecrã 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Ecrã 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Ecrã 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Ecrã 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "off"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Ecrãs 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Ecrãs 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Ecrãs 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "on"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (ou LCD compatível) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (ou LCD compatível) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (ou LCD compatível) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (ou LCD compatível) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H old 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H old 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "LCD Box-Skin interno"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "TFT-LCD interno 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "só Imagens 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "só Imagens 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "só Imagens 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "só Imagens 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "só Imagens de tamanho configurável"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "só Imagem Personalizada Tamanho 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "LCD interno Vu+ Duo2 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 Dias 1 Linha"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 Dias 2 Linhas"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 Dias 1 Linha"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 Dias 2 Linhas"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 dias vista vertical"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 Dias 1 Linha"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 Dias 2 Linhas"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 dias vista vertical"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Temperatura atual (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Temperatura atual (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Atual"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Temperatura atual"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Tudo"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Temperatura+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Temperatura+Co2+Pressão"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Temperatura+Humidade"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Módulo 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Módulos 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Módulos 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Módulos 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Módulos 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Módulos 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Módulos 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Módulos 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Módulos 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Móduloa 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Módulo 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Módulos 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Módulos 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Módulos 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Módulo 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Módulo 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Módulos 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Módulo 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Módulo 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Módulo 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Módulo 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Módulo 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Módulo 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "definido pelo usuário"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Pre"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Pre+Valor"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Botão"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Botão+Valor"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analógico"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analógico+Data"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analógico+Data+Dia da Semana"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analógico+Data+Dia da Semana 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Data"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Data+Hora"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Data+Hora+Dia da Semana"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Data no Desenho Flaps"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Dia da Semana no Desenho Flaps"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Hora"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Hora+Dia da Semana"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Dia da Semana"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "centro"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "esquerda"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "direita"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Extendido"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Extendido (Curto)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Curto"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Curto (Extendido)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Curto+Extendido"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Mês"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Mes+Cabeçalho"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Semana"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Semana+Cabeçalho"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "sem Calendário"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Datas 1 Linha"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Datas 3 Linhas"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Datas 5 Linhas"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Datas 9 Linhas"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Datas compatas en 2 Linhas"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Datas compatas en 3 Linhas"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "sem Datas"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Sublinhado"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Sublinhado 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Quadro"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Datas"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Datas compatas"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Datas compatas sem Icon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Datas sem Icon"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "sem Icons"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "sem Icon, com Número de Destino"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "com Icon"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "com Icono & Número de Destino"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "não"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "mostrar execução"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "mostrar execução+repouso"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Sempre Tudo"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Sempre Novo"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Só os Novos"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Todas as Informações"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Distância apenas"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Distância+Iluminação"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Distância + Fases da Lua"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Iluminação apenas"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Iluminação+Fase da Lua"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Fase da lua apenas"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Canal"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Canal+Título"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+Canal"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+Canal+Título"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "mesma cor"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "sim+25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "sim"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "verticalmente"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "horizontalmente"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "tudo"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Esquina"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Canto+Timeshift"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Timeshift"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "só Barra de Progreso"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "com Minutos Restantes"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "com Minutos Restantes (Tamanho 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "com Minutos Restantes (Tamanho 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "com Percentagem"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "com Percentagem (tamanho 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "con Percentagem (tamanho 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "com Minutos Restantes (acima)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "com Minutos Restantes (acima/Tamanho 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "com Minutos Restantes (acima/Tamanho 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "con Percentagem (acima)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "com Percentagem (acima/Tamanho 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "com Percentagem (acima/Tamanho 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "com Minutos Restantes (abaixo)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "com Minutos Restantes (abaixo/Tamanho 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "com Minutos Restantes (abaixo/Tamanho 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "con Percentagem (abaixo)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "com Percentagem (abaixo/Tamanho 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "com Percentagem (abaixo/Tamanho 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "com o Atual 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "com o Atual 00:00 (Tamanho 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "com o Atual 00:00 (Tamanho 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "com o Atual 00:00 (acima)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "com o Atual 00:00 (acima/Tamanho 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "com o Atual 00:00 (acima/Tamanho 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "com o Atual 00:00 (abaixo)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "com o Atual 00:00 (abaixo/Tamanho 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "com o Atual 00:00 (abaixo/Tamanho 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "com Percentagem de Minutos / Total (acima)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "com Percentagem de Minutos / Total (acima/Tamanho 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "com Percentagem de Minutos / Total (arriba/Tamanho 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "com tempo final absoluto"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "com tempo final absoluto (Tamanho 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "com tempo final absoluto (Tamanho 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "com Total de minutos / Tempo final (superior)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "com Total de minutos / Tempo final (superior/Tamanho 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "com Total de minutos / Tempo final (superior/Tamanho 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Modo Rápido (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normal (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "alfabético"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "aleatório"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "melhor/lento"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "baixo/rápido (só Fotos)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "baixo/rápido (tudo)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + ajuste (alta qualidade, lento)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + ajuste (baixa qualidade, rápido)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "sem cache + sem ajuste"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Sintonizador integrado"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "Sintonizador USB"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Agora/Depois"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normal"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "reduzido"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript sem atualização"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Recarregar"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normal"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - lado a lado"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "modo Cópia alternativo/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "sim + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "sim, longo"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "sim, curto"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Coversearch"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "sempre"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Mídia+Repouso"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Repouso"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - color"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - cor/cinzento"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x Tecla Avanço Rápido"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x Tecla Avanço Rápido Tipo 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Tecla Avanço Rápido Prolongada"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Tecla Avanço Rápido Prolongada Tipo 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Tecla Info"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Tecla MUTE"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Tecla Info Prolongada"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x Tecla Retrocesso Rápido"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x Tecla Retrocesso Rápido Tipo 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Tecla Retrocesso Rápido Prolongada"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Tecla Retrocesso Rápido Longo Tipo 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "sim, extendido"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Consola normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Arquivo de log extenso"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Arquivo de log normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "desligado"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Rádio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Rádio + Mídia"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Rádio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Rádio+Mídia"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (completo)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normal (completo)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "ajustado (preto)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "ajustado (transparente)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "MUTE ou teclas definidas"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "qualquer Chave"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Hora+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Hora+Duração+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Hora+Duração+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "metade esquerda"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "metade direita"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Quadro x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Linha"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "sem Barra"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "sem orla"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Gradiente"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Margens de Sombra"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normal"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Posição abaixo"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Posição esquerda"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Posição direita"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Posição"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Nome"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Desconetado"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Conetado"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Conetado+Desconetado"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "usar só Temporizador"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "usar hora principal"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "sem Timer completo"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "mostrar Temporizador completo"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "uma linha"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "duas linhas"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Memória disponível"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Memória livre"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "ecrã completo"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "sim, excepto gravações"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "ENE"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "ESE"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NE"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNE"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNO"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NO"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SE"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSE"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSO"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SO"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "O"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "ONO"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "OSO"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Carregar Arquivo de Configuração Ativo"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Carregar Padrões / Config vazia"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Salvar Configuração no arquivo...(%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Carregar Arquivo : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Apagar Ficheiro?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "apagado"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "ajuste atual : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "Definições do LCD4linux"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Salvar"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Reiniciar Ecrãs"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Def On >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "não existe Arquivo de Imagem de LCD1"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "não existe Arquivo de Imagem de LCD2"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "não existe Arquivo de Imagem de LCD"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux ativado"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "Tipo LCD 1"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- Rodar LCD 1"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- Cor de Fundo LCD 1"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- Fundo-Imagem LCD 1 [OK]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- Brilho LCD 1"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- Redução Noturna LCD 1"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- Refrescar LCD 1"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "Tipo LCD 2"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- Rodar LCD 2"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- Cor de Fundo LCD 2"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- Fundo-Imagem LCD 2 [OK]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- Brilho LCD 2"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- Redução Noturna LCD 2"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- Refrescar LCD 2"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "Tipo LCD 3"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- Rodar LCD 3"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- Cor de Fundo LCD 3"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- Fundo-Imagem LCD 3 [OK]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- Brilho LCD 3"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- Redução Noturna LCD 3"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- Refrescar LCD 3"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD Tamanho"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Desvio"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD Cor"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD Ativar Modo On"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD Ativar Modo Mídia"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD Ativar Modo Apagado"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [hora no ecrã]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- qual LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Mostrar em Modo"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Tamanho OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Fundo/Transparência"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Gravador Rápido de qualidade baixa"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Texto Emergente"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Clear Key"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Tamanho da Fonte"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Posição"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Alinhamento"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Cor"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Cor de Fundo"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Fonte"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Ecrã Ativo"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Selecionar ecrã a Mudar - LCD"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Selecionar ecrã a Mudar - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Ecrãs usados para mudar"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Tempo para mudar Ecrã 1"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 2"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 3"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 4"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 5"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 6"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 7"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 8"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Tempo de permuta de Ecrã 9"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Tempo para mudar de Imagem"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Imagens aleatórias"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Diretório Recursivo de Imagens"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Qualidade da Imagem para Redimensionar"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Tempo de Atualização Rápida de Imagen [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Tipo de Imagem [só Imagem]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Fundo - Tipo de Imagem"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "O Tempo API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Chave do Tempo API OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Cidade para o Tempo"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Cidade para o Tempo 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Percurso de Icons do Tempo [OK]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Zoom de Icons do Tempo"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Cor de Baixa Temperatura do Tempo"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Cor de Alta Temperatura do Tempo"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Transparências do Tempo"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Unidade de Velocidade do Viento no Tempo"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Linhas de informação do vento do tempo"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Possibilidade de Chuva no Tempo"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Zoom da Chuva"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Cor da Chuva"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- A Chuva usa cor 2 desde"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Cor de Chuva 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Tempo Humidade Cor"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Linhas do Tempo"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Tempo Setas de Tendência"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Informações Extras do Tempo"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Zoom Extra"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Mostrar temperaturas mais frias desde a diferença"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Cor Extra da Cidade"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Cor Extra do Frio"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Intervalo Mínimo"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Intervalo Máximo"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "URL Meteo"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Percurso Icons Lunares [OK]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Imagem de Gravação [OK]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Trocas Tecla dupla"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Tecla para mudar Ecrã"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Tecla para Apagar/Acender Ecrã"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall Percurso da Imagem [OK]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Número de Linhas por Entrada"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall Número de Entradas Listadas"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall Número de Imagems"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall Orientação da Imagem"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "Transparência Imagem FritzCall"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall Busca de Imagens"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall apagar chamadas fora de horas"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Hora Emergente"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall LCD Emergente"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Cor Emergente"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Quadro de Imagem [OK]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Percurso Calendário ics [OK]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "URL Calendário ics"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Calendário planerFS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Calendário Cor Sábado"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Calendário Cor Domingo"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Calendário Linhas Finas"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Calendário Previsualização Eventos Diários"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Calendário Correção Zona Horária"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Calendário Transparência"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Calendário Intervalo"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Cor Sintonizador"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Cor Sintonizador Activo"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Cor Sintonizador Ligado"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Primeiro Busca de Canais"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "Correção da qualidade de Sinal DVB-T"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Fonte Global [OK]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Fonte 1 [OK]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Fonte 2 [OK]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Fonte 3 [OK]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Fonte 4 [OK]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Fonte 5 [OK]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Conetar E-Mail 1"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Servidor E-Mail 1"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "E-Mail 1 [Nome:]Usuário"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Senha E-Mail 1"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Conetar E-Mail 2"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Servidor E-Mail 2"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "E-Mail 2 [Nome:]Usuário\""
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Senha E-Mail 2"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Conetar E-Mail 3"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Servidor E-Mail 3"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "E-Mail 3 [Nome:]Usuário"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Senha E-Mail 3"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Conetar E-Mail 4"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Servidor E-Mail 4"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "E-Mail 4 [Nome:]Usuário"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Senha E-Mail 4"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Conetar E-Mail 5"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Servidor E-Mail 5"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "E-Mail 5 [Nome:]Usuário"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Senha E-Mail 5"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Intervalo E-Mail"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "E-Mail IMAP limitado até aos últimos dias"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Mostrar Caixas Vazias de E-Mail"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Data de Exibir o E-Mail"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "O E-Mail Esconde o Endereço"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 1 [NomeEcrã:]IP/Nome"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 2 [NomeEcrã:]IP/Nome"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 3 [NomeEcrã:]IP/Nome"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 4 [NomeEcrã:]IP/Nome"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Dispositivo Remoto 5 [NomeEcrã:]IP/Nome"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Sondar Dispositivo Remoto todos os Minutos"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Timer da box remota [Nome a exibir:]IP/Nome"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Timer da box remota pesquisa todos os Minutos"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "Intervalo Conversor WWW"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "Uso do Conversor WWW"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "Chave Api WWW de cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "Chave Api WWW de convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "Refrescamento WebIF [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "Tipo de Refrescamento WebIF"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "Atraso de Inicio WebIF"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "IP Proibido WebIF"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "Desenho WebIF"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Guardar como Imagem para WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "Ativar Stream MJPEG LCD 1"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "Porta Stream MJPEG LCD 1"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Stream LCD 1 Brilho Virtual"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "Activar Stream MJPEG LCD 2"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "Porta Stream MJPEG LCD 2"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2 Brilho Virtual"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "Activar Stream MJPEG LCD 3"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "Porta Stream MJPEG LCD 3"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Stream LCD 3 Brilho Virtual"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "Ciclo MJPEG"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Reiniciar com erro"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "Modo de Cabeçalho MJPEG"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "IP Sonos"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Tempo limite de Ping Sonos [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Verificar reprodução Sonos"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Refrescar Sonos [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound tempo limite de Ping [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound verificar reprodução"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Refrescar [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast IP [opcional]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Tempo limite de Ping [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Verificar reprodução"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Refrescar [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Cobrir"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "Largura Personalizada do LCD"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "Altura Personalizada do LCD"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD Personalizado Largura 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD Personalizado Altura 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD Desligado ao desligar"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Hora ! calcular todas as vezes a hora/5*2 en Modo Rápido"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Atraso Ecrã [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Threads por LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Mostrar Crash"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Mostrar Mensagens 'não...'"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Forçar Leitura de Dispositivos de Armazenamento"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Dispositivos de armazenamento: Cor Fundo"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Dispositivos de armazenamento: Cor Barra"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Dispositivos de armazenamento: Cor Cheia"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Verificar rede ativa"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Por contador de planos (se for possível)"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Percurso para Guardar Configurações [OK]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Restaurar Configuração de todas as Definições"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Registo de Depuração > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Luz de Fundo Desligada [desligar ajuste Off=On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Luz de Fundo Ligada"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Luz de Fundo Fim de Semana desconetada [desligar ajuste Off=On]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Luz de Fundo Fim de Semana ligada"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Auto-OFF"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Fundo"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Imagem [OK]"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Tamanho dos Picons"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Ecrã Dividido"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- Ecrã Completo"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Tamanho do Texto"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Transparência"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Percurso Picon [OK]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Percurso Picon 2 [OK]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache Percurso [OK]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Relógio"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "- Tipo"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Relógio Analógico"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Espaçado"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Tamanho"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Margens de Sombra"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Relógio 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Nome do Programa"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- máximo de Linhas"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Duração"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Número do Programa"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Informação do Programa"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Tipo"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Informação Programa 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Informação do Próximo Programa"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Descrição Extendida"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- usar informação quando vazia"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Barra de Progresso"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Cor do Texto"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Margem"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Sombreado"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Unidade min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informações"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Informação do Tuner"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Sensores"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informações 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Barra de Qualidade do Sinal"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Gradiente"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Barra Gama Mínima"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Barra Gama Máxima"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satélite"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Operador"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Sintonizador Usado"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- só o Tuner ativo"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Próximo Evento Programado"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Volume"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "2 x Muda"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Online [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Mostrar Estado"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Descanso [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Nome Online:Endereço"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Endereço IP Externo"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- URL de IP externo"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Dispositivos de Armazenamento"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- Advertência"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- informação extra"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Nome do Dispositivo"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Tipo de Tempo"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "O Tempo 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Estação Metereológica do Tempo"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Estação"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Módulo"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Módulo definido pelo usuário"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Base"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Nome"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Cor 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Cor 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Cor 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Cor 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Cor 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Cor 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo Indicador de CO2"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Comprimento [Barra]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Indicador de Comodidade"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Fases da Lua"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Linhas de Informação"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Setas de Tendência"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Amanhecer"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Mostrar oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Arquivo [OK]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Mostrar ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Mostrar Arquivo de Texto"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Mostrar Arquivo de Texto 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Mostrar Arquivo de Texto 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Mostrar Texto HTTP"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "Conversor WWW-Internet"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- Largura HTTP"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- Altura HTTP"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Cortar desde X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Cortar desde Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Cortar Largura [desligar = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Cortar Altura [desligar = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Mostrar Imagem"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Arquivo ou Percurso [OK]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Tamanho Altura Máxima"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Atualização Rápida"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Mostrar Imagem 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Mostrar Imagem 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Mostrar Imagem 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Linhas"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- E-Mail Konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- Largura máxima"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Timer da box remota"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Tamanho Imagem"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- Posição Imagem"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Alinhamento Imagem"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Disposição"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Cor de Fundo Dia Atual"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Cor da Legenda"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Lista de Datas"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Barra de Icon do Evento"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Ecrã Aparição"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- LCD Aparição"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Mostrar Texto 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Texto"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Mostrar Texto 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Retângulo 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Posição x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Posição y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Tamanho x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Tamanho y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Retângulo 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "A gravar"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- Ecrãs usdados para permuta"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Título"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Informações"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Mostrar Capa"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Buscar Percurso [OK]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Encontrar arquivo de capa [OK]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- Capa por Defeito [OK]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Picon Primeiro"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "Aparado"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Descarregar Capa"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Tipo de Descarga"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "Ecrã LCD"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display-Mode On"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Def Mídia >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "Visor LCD4linux-Modo MediaPlayer"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Def Idle >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display-Modo Idle"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Def Global >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Escolher pasta"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Escolher ficheiro"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Escolher Fonte"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Valor Atual: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3848,95 +4081,95 @@ msgstr ""
 "GUI necesita reiniciar para aplicar as alterações.\n"
 "Deseja reiniciar a GUI agora?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Reiniciar a GUI agora?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Dentro de Casa"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Fora de Casa"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Chuva"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Vento"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Lua Nova"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Quarto Crescente"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Quarto Crescente"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Lua crescente"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Lua Cheia"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Lua minguante"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Quarto Minguante"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Quarto Minguante"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Imagem não disponível"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "sem Timer"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM não está a funcionar"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "sem Chamadas"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d E-Mails %d Novos %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "plugin Netatmo não instalado"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "Mudar o Ecrã LCD4linux"
 
@@ -3954,111 +4187,3 @@ msgstr "Mudar o Ecrã LCD4linux"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Clima Direcção do vento"
-
-#~ msgid "Backup Config"
-#~ msgstr "Guardar Configuração"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Registo de Bloqueio"
-
-#~ msgid "Delete"
-#~ msgstr "Apagar"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Apagar ficheiro de Depuração"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Descarregar Arquivo de Depuração"
-
-#~ msgid "Element"
-#~ msgstr "Elemento"
-
-#~ msgid "Exec"
-#~ msgstr "Exec"
-
-#~ msgid "Filename"
-#~ msgstr "Nome do ficheiro"
-
-#~ msgid "Font"
-#~ msgstr "Fonte"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "É necessário reiniciar a GUI"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Segurança de IP não suportada pelo dispositivo"
-
-#~ msgid "Key"
-#~ msgstr "Chave"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Lista de Dispositivos de Armazenamento"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Inexistente ou arquivo não selecionado, corrigir isto primeiro!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Diretório Parental"
-
-#~ msgid "Picture"
-#~ msgstr "Imagem"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Texto Emergente"
-
-#~ msgid "Restore Config"
-#~ msgstr "Restaurar Configuração"
-
-#~ msgid "Save Config"
-#~ msgstr "Salvar Configuração"
-
-#~ msgid "Screen"
-#~ msgstr "Ecrã"
-
-#~ msgid "Show"
-#~ msgstr "Mostrar"
-
-#~ msgid "Show Externals"
-#~ msgstr "Mostrar externas"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Sintonizador"
-
-#~ msgid "WWW Converter"
-#~ msgstr "Conversor WWW"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "copiar a Espera"
-
-#~ msgid "copy to Media"
-#~ msgstr "copiar para Mídia"
-
-#~ msgid "copy to On"
-#~ msgstr "copiar para Ligado"
-
-#~ msgid "other"
-#~ msgstr "outro"
-
-#~ msgid "set Settings"
-#~ msgstr "ajustar"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "parar Ciclo de Ecrã"

--- a/LCD4linux/po/ru.po
+++ b/LCD4linux/po/ru.po
@@ -2,3839 +2,4072 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:09+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:20+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Пятн"
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
 
-#: plugin.py:263
-msgid "Mon"
-msgstr "Пон"
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
 
-#: plugin.py:263
-msgid "Sat"
-msgstr "Субб"
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Шрифт"
 
-#: plugin.py:263
-msgid "Sun"
-msgstr "Воскр"
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Ключ"
 
-#: plugin.py:263
-msgid "Thur"
-msgstr "Чет"
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Ручей"
 
-#: plugin.py:263
-msgid "Tue"
-msgstr "Вт"
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
 
-#: plugin.py:263
-msgid "Wed"
-msgstr "Ср"
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Картинка"
 
-#: plugin.py:288
-msgid "black"
-msgstr "черный"
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Всплывающий- текст"
 
-#: plugin.py:288
-msgid "white"
-msgstr "белый"
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
 
-#: plugin.py:289
-msgid "gray"
-msgstr "серый"
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Тюнер"
 
-#: plugin.py:289
-msgid "silver"
-msgstr "серебро"
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW Конвертер"
 
-#: plugin.py:289
-msgid "slategray"
-msgstr "сланец серый"
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
 
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "aquamarine"
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Экран"
 
-#: plugin.py:291
-msgid "gold"
-msgstr "золотой"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "greenyellow"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "желтый"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "темнооранжевый"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "dunkelrot"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indianrot"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "оранжевый"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "orangered"
-
-#: plugin.py:292
-msgid "red"
-msgstr "красный"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "tomato"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "темнозеленый"
-
-#: plugin.py:293
-msgid "green"
-msgstr "зеленый"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "lawngreen"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "светло-зеленый"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "лайм"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "синий"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "blauviolett"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "cadetblue"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "cornflowerblue"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "темносиний"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "светло-синий"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "голубой"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "dunkelorchidee"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "deeppink"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "пурпурный"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "фиолетовый"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "коричневый"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "moccasin"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "оливковый"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "rosigbraun"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "sandbraun"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Экран 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Экран 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Экран 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Экран 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Экран 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Экран 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Экран 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Экран 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Экран 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Экран 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Экран 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Экран 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Экран 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Экран 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Экран 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Экран 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Экран 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Экран 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Экран 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Экран 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Экран 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Экран 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Экран 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Экран 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Экран 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Экран 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Экран 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Экран 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Экран 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "выкл"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Экран 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Экран 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Экран 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "вкл"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2час"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3час"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3мин"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40с"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4мин"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50с"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5час"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5с"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10с"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15с"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1мин"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20с"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2мин"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30с"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10мин"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5мин"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20мин"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30мин"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60мин"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (or compatible LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (or compatible LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (or compatible LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (or compatible LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H alt 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H alt 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Internal TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Internal Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "только фото 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "только фото 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "только фото 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "только фото 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "только фото своего размера"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "только фото своего размера 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Internes Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 дня 1 линия"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 дня 2 линии"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 дня 1 линия"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 дня 2 линии"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 дня вертикально"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 дней в 1 линию"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 дней в 2 линии"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 дней вертикально"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Текущяя температура (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Текущяя температура (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Текущий"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Текущяя температура"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Все"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Температура"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Температура+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Температура+Co2+Давление"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Температура+Влажность"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Модуль 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Модуль 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Модуль 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Модуль 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Модуль 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Модуль 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Модуль 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Модуль 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Модуль 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Модуль 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Модуль 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Модуль 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Модуль 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Модуль 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Модуль 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Модуль 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Модуль 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Модуль 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Модуль 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Модуль 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Модуль 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Модуль 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Модуль 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "определяемые пользователем"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Balken"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Balken+Wert"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Кнопка"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Кнопка + значение"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Аналоговый"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Аналоговые+дата"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Аналоговые+дата+будни"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Аналоговые+дата+будни 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Дата"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Дата+Время"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Дата + время + день недели"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Закрылки Дизайн Дата"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Закрылки Дизайн Будний день"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Время"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Время+День"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Будний день"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "центр"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "слева"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "справа"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Расширенное"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Расширенное (Short)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Краткий"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Краткий (Расширенный)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Краткий+Расширенный"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Месяц"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Месяц + заголовок"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Неделя"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Неделя+Заголовок"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "нет календаря"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Даты в 1 линию"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Даты в 3 линии"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Даты в 5 линий"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Даты в 9 линий"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Даты компактно в 2 линии"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Даты компактно в 3 линии"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "нет даты"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Подчеркивание"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Подчеркивание 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Фрейм"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Даты"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Даты компактно"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Даты компактно без иконок"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Даты без иконок"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "нет значка"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "без значка, с целевым числом"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "mit Icon"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "со значком и целевым числом"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + об/мин"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + об/мин/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "rpm"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "нет"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Загрузить@1мин"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Загрузить@5мин"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "показать запущенные"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "показать запущенные+sleep"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Всегда все"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Всегда новые"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Только новости"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Вся информация"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Только расстояние"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Расстояние+Освещение"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Расстояние+фаза луны"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Только подсветка"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Освещение+фаза луны"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Только фаза луны"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Канал"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Канал+Заголовок"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Пикон+Канал"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Пикон+Канал+Название"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Пикон"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "такого же цвета"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "да +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "да"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "вертикально"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "горизонтально"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Глобально"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "все"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Угол"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Угол+сдвиг во времени"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Пикон+сдвиг во времени"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "только прогресс-бар"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "с оставшимися минутами"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "с оставшимися минутами (Размер 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "с оставшимися минутами (Размер 1.5)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "вместе с процентами"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "вместе с процентами (Размер 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "вместе с процентами (Размер 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "с оставшимися минутами (выше"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "с оставшимися минутами (выше/Размер 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "с оставшимися минутами (выше/Размер 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "вместе с процентами (выше)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "вместе с процентами (выше/Размер 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "вместе с процентами (выше/Размер 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "с оставшимися минутами (ниже)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "с оставшимися минутами (ниже/Размер 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "с оставшимися минутами (ниже/Размер 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "вместе с процентами (ниже)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "вместе с процентами (ниже/Размер 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "вместе с процентами (ниже/Размер 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "от текущего"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "от текущего 00:00 (размер 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "от текущего 00:00 (размер 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "от текущего 00:00 (выше)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "with Current 00:00 (above/Size 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "with Current 00:00 (above/Size 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "with Current 00:00 (below)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "with Current 00:00 (below/Size 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "with Current 00:00 (below/Size 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "с процентами минут / Всего (выше)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "с процентами минут / Всего (выше/Размер 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "с процентами минут / Всего (выше/Размер 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "с абсолютным Концом"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "с абсолютным Концом (Размер 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "с абсолютным Концом (Размер 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "с итогом в минутах / Время окончания (выше)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "с итогом в минутах / Время окончания (выше/Размер 1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "с итогом в минутах / Время окончания (выше/Размер 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Быстрый режим (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Нормальный (5с)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "алфавитный"
-
-#: plugin.py:386
-msgid "random"
-msgstr "случайно"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "лучше/медленная"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "низкий/быстрый (Только изображения)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "низкий/быстрый (Все)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "тайник + корректирование (высокое качество, медленный)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "тайник + корректирование (низкое качество, быстрый)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "без кеша + без настройки"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Затыкать Тюнер"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Тюнер"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "E"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Сейчас/дальше"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "нормальный"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "уменьшенный"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "JavaScript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "JavaScript нет обновления"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Перезагрузить"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 нормальный"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - бок о бок"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternative Copy-Mode/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "да + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "да, долго"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "да, коротко"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "км/ч"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "м/с"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Обложка поиск"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / мин"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "всегда"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "On+Media+Standby"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Ожидать"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Медиа"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "Вкл"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit -Цвет"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - серый/цветной"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x  >>"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x >> Тип 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Долгое нажатие >>"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Долгое нажатие >> Тип 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x EPG"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x Немой"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Долгое нажатие EPG"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x <<"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2x << Тип 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Долгое нажатие <<"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Долгое нажатие << Тип 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15мин"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "да, продлен"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Konsole normal"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Logfile extensive"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Logfile normal"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "выключен"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Радио"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Радио+Медиа"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Radio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Радио+Медиа"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (полный)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "нормальный (полный)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "обрезается (черный)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "обрезается (прозрачный)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "Немой или определенные ключи"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "любой ключ"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Инфо"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Время +Информация"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Время +Продолжительность+Информация"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Время+Длинна+Инфо"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "левая половина"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "правая половина"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Фрейм x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "- Линия"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "нет бара"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "без рамки"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Градиент"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Края тени"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Нормальный"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Пикон+позиция ниже"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Пикон+позиция слева"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Пикон+позиция справа"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Позиция"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Имя"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Оффлайн"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Онлайн"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Онлайн+Оффлайн"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "использовать только таймер"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "использовать время"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "нет общего таймера"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "показать общий таймер"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "одна линия"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "две строки"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Доступная память"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Свободная память"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "во весь экран"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "да, за исключением записей"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "E"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "NE"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "NNE"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "NNW"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "NW"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "SE"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "SSE"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "SSW"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "SW"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "W"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "WNW"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "WSW"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Загрузить активный конфиг"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Загрузить умолчанию / пустой конфиг"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Сохранить конфиг в файл... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Загрузить Файл : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Удалить файл?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "удаленный"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "настоящее время установлен : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux Выключатель"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Режим"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Отмена"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Сохранить"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Рестарт дисплея"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Задавать На >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Праздный"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "нет LCD1 картинки-Файл"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "нет LCD2 картинки-Файл"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "нет LCD3 картинки-Файл"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux включен"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Тип"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 чередовать"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 Цвет фона"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 Фон-картинка [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Яркость"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Ночное сокращение"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 Обновить"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Тип"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 Чередовать"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 Цвет фона"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 Фон-Картинка [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Яркость"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Ночное сокращение"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 Обновить"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Тип"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 Чередовать"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 Цвет фона"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 Фон-Картинка [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Яркость"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Ночное сокращение"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 Обновить"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD размер"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Компенсировать"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD цвет"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD Enable On-Mode"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD включить медиа режим"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD Aktiviere Idle-Mode"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [Отображение времени]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- какой LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- Показать в режиме"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- Размер OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Фон/Прозрачность"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- Быстрый Grab низкого качества"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Всплывающий текст"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Очистить ключ"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- Размер шрифта"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- Позиция"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Выравнивание"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Цвет"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Цвет фона"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- Шрифт"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Активный экран"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Экран Выключатель Выбирать - Экран"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Экран Выключатель Выбирать - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Экраны используется для изменения"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Экран 1-Изменить время"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- Экран 2 Изменение времени"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- Экран 3 Изменение времени"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- Экран 4 Изменение времени"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- Экран 5 Изменение времени"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- Экран 6 Изменение времени"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- Экран 7 Изменение времени"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- Экран 8 Изменение времени"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- Экран 9 Изменение времени"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Картина Изменение времени"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Картина Сортировка"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Картина каталог Рекурсивный"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Картина Качество для изменения размера"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Картина Время обновления [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Картина Тип [Только Картина]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Задний план-Картина Тип"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Weather"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Weather API-Key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Weather API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Погода-Город"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Погода-Город 2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Погода-Икона-Дорожка [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Погода-Икона зум"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Низкая температура(погода)-Цвет"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Высокая температура(погода)-Цвет"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Погода Прозрачность"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Погода Ветер скорость единицы измерения"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Линии информации о погоде и ветре"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Возможен дождь"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- Увеличение дождя"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- Цвет дождя"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- Rain use Color 2 from"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- Цвет дождя 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Погода-Линии"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "трендов стрелки погодных"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Погода-Экстра инфо"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Экстра увеличение"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- Показать разницу температур"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Дополнительные цвета городов"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Дополнительные цвета"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 мин Диапазон"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Максимум Диапазон"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "Погода URL"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Месяц-путь к иконкам[ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Запись Картина [ok]"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Double-button switches"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Клавиша изменения экрана"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Key for Screen On/Off"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall Путь изображения [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall Количество строк на вход"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall Количество записей в списке"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall Количество изображений"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall Ориентация изображения"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall Прозрачность изображения"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall Поиск картинок"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall Удалить звонок в нерабочее время"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall Выскакивать-Время"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall Выскакивать LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall Выскакивать окна"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall Рамка Картина [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Календарь ics-путь [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Календарь ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Календарь"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Календарь Суббота Цвет"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Календарь Воскресенье Цвет"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Календарь-толщина линий"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Календарь Дневное событие превью"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Календарь Коррекция часового пояса"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Календарь Прозрачность"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Календарь Интервал опроса"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Цвет тюнера"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Цвет активного тюнера"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Цвет тюнера"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Поиск услуги в первую очередь"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T Сигнал Качество Исправление"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Zeichensatz Global [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Шрифт 1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Шрифт 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Шрифт 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Шрифт 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Шрифт 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Почта 1 подключить"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Почта 1 Сервер"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Почта 1 Имя пользователя"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Почта 1 - пароль"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Почта 2 подключить"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Почта 2 Сервер"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Почта 2 Имя пользователя"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Почта 2 - пароль"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Почта 3 подключить"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Почта 3 Сервер"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Почта 3 Имя пользователя"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Почта 3 - пароль"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Почта 4 подключить"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Почта 4 Сервер"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Почта 4 Имя пользователя"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Почта 4 - пароль"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Почта 5 подключить"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Почта 5 Сервер"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Почта 5 Имя пользователя"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Почта 5 - пароль"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Почта Интервал опроса"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Почта IMAP предел до последних дней"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Почта-Показывать пустые почтовые ящики"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Почта показать Дата"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Почта Спрятать Почтовый адрес"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Удаленный ящик 1 [Показать имя] IP/Имя"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Удаленный ящик 2 [Показать имя]IP/Имя"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Удаленный ящик 3 [Показать имя]IP/Имя"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Удаленный ящик 4 [Показать имя]IP/Имя"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Удаленный ящик 5 [Показать имя]IP/Имя"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Удаленный ящик Опрашивайте каждую минуту"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Удаленный ящик Таймер [Показать имя]IP/Имя"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Удаленный ящик Таймер Опрашивайте каждую минуту"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Converter Poll Interval"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW Конвертер использование"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey из cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey из convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF обновление [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF тип обновления"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF Инициализировать Задерживать"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP Разрешать"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP Отрицать"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF Дизайн"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Сохранить как рисунок для WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG Ручей LCD 1 включить"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Ручей LCD 1 Порт"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG Ручей LCD 1 виртуальная яркость"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG Ручей LCD 2 включить"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Ручей LCD 2 Порт"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Ручей LCD 2 виртуальная яркость"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG Ручей LCD 3 включить"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Ручей LCD 3 Порт"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG Ручей LCD 3 виртуальная яркость"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG Цикл"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Перезагрузить при ошибке"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG Режим заголовка"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Ping Тайм-аут [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos играть Проверять"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Обновить [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Ping Тайм-аут [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound играть Проверять"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Обновить [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Сервер IP [по желанию]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Ping Тайм-аут [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast играть Проверять"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Обновить [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Обложка"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD Своя Ширина"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD Своя высота"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD Своя Ширина 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD Своя высота 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD выключен при выключении"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Выбор времени! calc all Times to Time/5*2 in Fastmode"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Задержка [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Threads pro LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Показать Крушение Угол"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Показать 'нет...' Сообщения"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Хранение-Устройство: Принудит Чтение"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Хранение-Устройство: Цвет Задний план"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Хранение-Устройство: Цвет Бар"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Хранение-Устройство: Цвет Полный"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Проверка сети активна"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Выключатель Кадровый буфер [если возможно]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Конфиг Путь к резервному копированию[ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Конфиг Восстановить все настройки"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Debug-Logging > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Выключение подсветки [Off = On]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Включение подсветки"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Подсвечивать выходные [для отключения установить Off = On]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Hintergrundbeleuchtung Wochenende Ein"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Автоматическое отключение"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Задний план"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "Картина [ok]"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Размер пиконов"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- Разделение экрана"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- На весь экран"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- Размер текста"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- Прозрачность"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Путь к пиконам [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Путь к пиконам 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache путь [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Пикон 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Часы"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Тип"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Аналоговые часы"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- Растояние"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- Размер"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- Теневые грани"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Часы 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Название передачи"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- маскимум линий"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- Длина"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Номер канала"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Инфо о програме"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Тип"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Инфо о програме 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Инфо о следующей программе"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Расширенное описание"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- использовать информацию, когда она пуста"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Прогресс бар"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Цвет Текст"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Граница"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- Затенить"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- единица измерения мин"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Информация"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Инфо о тюнере"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- Сенсор"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Информация 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Уровень сигнала"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- Градиент"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- Бар диапазон мин"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- Бар диапазон макс"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Спутник"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Провайдер"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Используемый тюнер"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- только активный тюнер"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Следующее событие таймера"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Громкость"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Немой"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Аудио/Видео"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Онлайн [Пинг]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- Показать состояние"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- Тайм-аут [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- Ник:адрес"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Внешний IP-адрес"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- внешний IP URL"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Хранение-Устройство"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- бесплатно предупреждение"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- экстра инфо"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- Имя устройства"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Погода"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- Увеличение"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- Тип погоды"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Погода 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Погода-Источник"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Станция"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Модуль"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Модуль определяемые пользователем"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "Основание"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Имя"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Цвет 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Цвет 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Цвет 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Цвет 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Цвет 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Цвет 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Индикатор"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- Длина [Бар]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Комфорт Индикатор"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Фазы Луны"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Информационные строки"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- стрелки тренда"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Восход солнца"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Показать oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- Файл [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Показать ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Показать текст файл"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Показать текст файл 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Показать текст файл 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Показать HTTP текст"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW-Internet Converter"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP Ширина"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP Высота"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- Вырезать из X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- Вырезать из Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- Обрезать по ширине [выкл. = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- Обрезать по высоте [выкл. = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Показать картинку"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- Файл или путь [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- Высота макс"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- Быстрое обновление"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Показать картинку 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Показать картинку 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Показать картинку 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Почта"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- Линий"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- Учетная запись почты"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- ширина макс"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Удаленный ящик"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Удаленный ящик v"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- Размер картинки"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "-Позиция изображения"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- Выравнивание изображения"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Календарь"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP Разрешать"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Файл не выбран или выбран неверный файл, сначала попробуйте правильный файл!"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Режим"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "Безопасность IP не поддерживается Box"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Креш лог"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Показать"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Удалить"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Имя файла"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Восстановить конфигурацию"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Задний план Конфиг"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Удалить Лог-файл"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Скачать Лог-файл"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Сохранить конфигурацию"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "остановить Screencycle"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Глобально"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "Вкл"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Медиа"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Праздный"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "GUI необходимо перезагрузить"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Элемент"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "прочие"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "меню Настройки"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "копировать в На"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "копировать в медиа"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "копировать в фоне"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Выполнение"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Показать Внешние"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Список устройств хранения"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Родительский каталог"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Пятн"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Пон"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "Субб"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Воскр"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Чет"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Вт"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "Ср"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "черный"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "белый"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "серый"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "серебро"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "сланец серый"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "aquamarine"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "золотой"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "greenyellow"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "желтый"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "темнооранжевый"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "dunkelrot"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indianrot"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "оранжевый"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "orangered"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "красный"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "tomato"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "темнозеленый"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "зеленый"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "lawngreen"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "светло-зеленый"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "лайм"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "синий"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "blauviolett"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "cadetblue"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "cornflowerblue"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "темносиний"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "светло-синий"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "голубой"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "dunkelorchidee"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "deeppink"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "пурпурный"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "фиолетовый"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "коричневый"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "moccasin"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "оливковый"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "rosigbraun"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "sandbraun"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Экран 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Экран 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Экран 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Экран 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Экран 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Экран 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Экран 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Экран 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Экран 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Экран 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Экран 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Экран 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Экран 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Экран 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Экран 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Экран 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Экран 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Экран 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Экран 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Экран 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Экран 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Экран 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Экран 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Экран 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Экран 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Экран 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Экран 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Экран 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Экран 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "выкл"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Экран 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Экран 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Экран 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "вкл"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2час"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3час"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3мин"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40с"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4мин"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50с"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5час"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5с"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10с"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15с"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1мин"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20с"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2мин"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30с"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10мин"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5мин"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20мин"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30мин"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60мин"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (or compatible LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (or compatible LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (or compatible LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (или совместимый ЖК-дисплей) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H alt 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H alt 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Internal Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Internal TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "только фото 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "только фото 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "только фото 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "только фото 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "только фото своего размера"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "только фото своего размера 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Internes Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 дня 1 линия"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 дня 2 линии"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 дня 1 линия"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 дня 2 линии"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 дня вертикально"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 дней в 1 линию"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 дней в 2 линии"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 дней вертикально"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Текущяя температура (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Текущяя температура (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Текущий"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Текущяя температура"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Все"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Температура"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Температура+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Температура+Co2+Давление"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Температура+Влажность"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Модуль 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Модуль 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Модуль 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Модуль 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Модуль 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Модуль 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Модуль 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Модуль 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Модуль 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Модуль 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Модуль 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Модуль 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Модуль 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Модуль 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Модуль 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Модуль 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Модуль 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Модуль 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Модуль 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Модуль 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Модуль 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Модуль 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Модуль 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "определяемые пользователем"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Balken"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Balken+Wert"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Кнопка"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Кнопка + значение"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Аналоговый"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Аналоговые+дата"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Аналоговые+дата+будни"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Аналоговые+дата+будни 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Дата"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Дата+Время"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Дата + время + день недели"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Закрылки Дизайн Дата"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Закрылки Дизайн Будний день"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Время"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Время+День"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Будний день"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "центр"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "слева"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "справа"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Расширенное"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Расширенное (Short)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Краткий"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Краткий (Расширенный)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Краткий+Расширенный"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Месяц"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Месяц + заголовок"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Неделя"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Неделя+Заголовок"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "нет календаря"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Даты в 1 линию"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Даты в 3 линии"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Даты в 5 линий"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Даты в 9 линий"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Даты компактно в 2 линии"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Даты компактно в 3 линии"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "нет даты"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Подчеркивание"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Подчеркивание 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Фрейм"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Даты"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Даты компактно"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Даты компактно без иконок"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Даты без иконок"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "нет значка"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "без значка, с целевым числом"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "mit Icon"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "со значком и целевым числом"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + об/мин"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + об/мин/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "rpm/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "нет"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Загрузить@1мин"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Загрузить@5мин"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "показать запущенные"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "показать запущенные+sleep"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Всегда все"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Всегда новые"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Только новости"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Вся информация"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Только расстояние"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Расстояние+Освещение"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Расстояние+фаза луны"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Только подсветка"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Освещение+фаза луны"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Только фаза луны"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Канал"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Канал+Заголовок"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Пикон+Канал"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Пикон+Канал+Название"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Пикон"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "такого же цвета"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "да +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "да"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "вертикально"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "горизонтально"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "все"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Угол"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Угол+сдвиг во времени"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Пикон+сдвиг во времени"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "только прогресс-бар"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "с оставшимися минутами"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "с оставшимися минутами (Размер 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "с оставшимися минутами (Размер 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "вместе с процентами"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "вместе с процентами (Размер 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "вместе с процентами (Размер 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "с оставшимися минутами (выше"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "с оставшимися минутами (выше/Размер 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "с оставшимися минутами (выше/Размер 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "вместе с процентами (выше)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "вместе с процентами (выше/Размер 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "вместе с процентами (выше/Размер 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "с оставшимися минутами (ниже)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "с оставшимися минутами (ниже/Размер 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "с оставшимися минутами (ниже/Размер 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "вместе с процентами (ниже)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "вместе с процентами (ниже/Размер 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "вместе с процентами (ниже/Размер 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "от текущего"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "от текущего 00:00 (размер 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "от текущего 00:00 (размер 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "от текущего 00:00 (выше)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "with Current 00:00 (above/Size 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "with Current 00:00 (above/Size 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "with Current 00:00 (below)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "with Current 00:00 (below/Size 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "with Current 00:00 (below/Size 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "с процентами минут / Всего (выше)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "с процентами минут / Всего (выше/Размер 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "с процентами минут / Всего (выше/Размер 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "с абсолютным Концом"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "с абсолютным Концом (Размер 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "с абсолютным Концом (Размер 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "с итогом в минутах / Время окончания (выше)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "с итогом в минутах / Время окончания (выше/Размер 1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "с итогом в минутах / Время окончания (выше/Размер 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Быстрый режим (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Нормальный (5с)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "алфавитный"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "случайно"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "лучше/медленная"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "низкий/быстрый (Только изображения)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "низкий/быстрый (Все)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "тайник + корректирование (высокое качество, медленный)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "тайник + корректирование (низкое качество, быстрый)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "без кеша + без настройки"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Затыкать Тюнер"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Тюнер"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "E"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Сейчас/дальше"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "нормальный"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "уменьшенный"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "JavaScript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "JavaScript нет обновления"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Перезагрузить"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 нормальный"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - бок о бок"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternative Copy-Mode/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "да + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "да, долго"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "да, коротко"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "км/ч"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "м/с"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Обложка поиск"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / мин"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "всегда"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "On+Media+Standby"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Ожидать"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit -Цвет"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - серый/цветной"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x  >>"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x >> Тип 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Долгое нажатие >>"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Долгое нажатие >> Тип 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x EPG"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x Немой"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Долгое нажатие EPG"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x <<"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2x << Тип 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Долгое нажатие <<"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Долгое нажатие << Тип 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15мин"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "да, продлен"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Konsole normal"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Logfile extensive"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Logfile normal"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "выключен"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Радио"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Радио+Медиа"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Radio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Радио+Медиа"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (полный)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "нормальный (полный)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "обрезается (черный)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "обрезается (прозрачный)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "Немой или определенные ключи"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "любой ключ"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Инфо"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Время +Информация"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Время +Продолжительность+Информация"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Время+Длинна+Инфо"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "левая половина"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "правая половина"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Фрейм x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "- Линия"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "нет бара"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "без рамки"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Градиент"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Края тени"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Нормальный"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Пикон+позиция ниже"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Пикон+позиция слева"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Пикон+позиция справа"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Позиция"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Имя"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Оффлайн"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Онлайн"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Онлайн+Оффлайн"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "использовать только таймер"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "использовать время"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "нет общего таймера"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "показать общий таймер"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "одна линия"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "две строки"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Доступная память"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Свободная память"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "во весь экран"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "да, за исключением записей"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "E"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "NE"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "NNE"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "NNW"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "NW"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "SE"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "SSE"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "SSW"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "SW"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "W"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "WNW"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "WSW"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Загрузить активный конфиг"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Загрузить умолчанию / пустой конфиг"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Сохранить конфиг в файл... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Загрузить Файл : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Удалить файл?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "удаленный"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "настоящее время установлен : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux Выключатель"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Отмена"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Сохранить"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Рестарт дисплея"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Задавать На >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "нет LCD1 картинки-Файл"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "нет LCD2 картинки-Файл"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "нет LCD3 картинки-Файл"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux включен"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Тип"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 чередовать"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 Цвет фона"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 Фон-картинка [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Яркость"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Ночное сокращение"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 Обновить"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Тип"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 Чередовать"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 Цвет фона"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 Фон-Картинка [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Яркость"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Ночное сокращение"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 Обновить"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Тип"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 Чередовать"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 Цвет фона"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 Фон-Картинка [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Яркость"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Ночное сокращение"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 Обновить"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD размер"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Компенсировать"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD цвет"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD Enable On-Mode"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD включить медиа режим"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD Aktiviere Idle-Mode"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [Отображение времени]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- какой LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- Показать в режиме"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- Размер OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Фон/Прозрачность"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- Быстрый Grab низкого качества"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Всплывающий текст"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Очистить ключ"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- Размер шрифта"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- Позиция"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Выравнивание"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Цвет"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Цвет фона"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- Шрифт"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Активный экран"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Экран Выключатель Выбирать - Экран"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Экран Выключатель Выбирать - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Экраны используется для изменения"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Экран 1-Изменить время"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- Экран 2 Изменение времени"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- Экран 3 Изменение времени"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- Экран 4 Изменение времени"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- Экран 5 Изменение времени"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- Экран 6 Изменение времени"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- Экран 7 Изменение времени"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- Экран 8 Изменение времени"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- Экран 9 Изменение времени"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Картина Изменение времени"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Картина Сортировка"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Картина каталог Рекурсивный"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Картина Качество для изменения размера"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Картина Время обновления [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Картина Тип [Только Картина]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Задний план-Картина Тип"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Weather"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Weather API-Key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Weather API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Погода-Город"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Погода-Город 2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Погода-Икона-Дорожка [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Погода-Икона зум"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Низкая температура(погода)-Цвет"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Высокая температура(погода)-Цвет"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Погода Прозрачность"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Погода Ветер скорость единицы измерения"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Линии информации о погоде и ветре"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Возможен дождь"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- Увеличение дождя"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- Цвет дождя"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- Rain use Color 2 from"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- Цвет дождя 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Погода Влажность Цвет"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Погода-Линии"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Погода Трендарроу"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Погода-Экстра инфо"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Экстра увеличение"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- Показать разницу температур"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Дополнительные цвета городов"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Дополнительные цвета"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 мин Диапазон"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Максимум Диапазон"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "Погода URL"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Месяц-путь к иконкам[ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Запись Картина [ok]"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Double-button switches"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Клавиша изменения экрана"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Key for Screen On/Off"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall Путь изображения [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall Количество строк на вход"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall Количество записей в списке"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall Количество изображений"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall Ориентация изображения"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall Прозрачность изображения"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall Поиск картинок"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall Удалить звонок в нерабочее время"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall Выскакивать-Время"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall Выскакивать LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall Выскакивать окна"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall Рамка Картина [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Календарь ics-путь [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Календарь ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Календарь"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Календарь Суббота Цвет"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Календарь Воскресенье Цвет"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Календарь-толщина линий"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Календарь Дневное событие превью"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Календарь Коррекция часового пояса"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Календарь Прозрачность"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Календарь Интервал опроса"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Цвет тюнера"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Цвет активного тюнера"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Цвет тюнера"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Поиск услуги в первую очередь"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T Сигнал Качество Исправление"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Zeichensatz Global [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Шрифт 1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Шрифт 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Шрифт 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Шрифт 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Шрифт 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Почта 1 подключить"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Почта 1 Сервер"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Почта 1 Имя пользователя"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Почта 1 - пароль"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Почта 2 подключить"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Почта 2 Сервер"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Почта 2 Имя пользователя"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Почта 2 - пароль"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Почта 3 подключить"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Почта 3 Сервер"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Почта 3 Имя пользователя"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Почта 3 - пароль"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Почта 4 подключить"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Почта 4 Сервер"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Почта 4 Имя пользователя"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Почта 4 - пароль"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Почта 5 подключить"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Почта 5 Сервер"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Почта 5 Имя пользователя"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Почта 5 - пароль"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Почта Интервал опроса"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Почта IMAP предел до последних дней"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Почта-Показывать пустые почтовые ящики"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Почта показать Дата"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Почта Спрятать Почтовый адрес"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Удаленный ящик 1 [Показать имя] IP/Имя"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Удаленный ящик 2 [Показать имя]IP/Имя"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Удаленный ящик 3 [Показать имя]IP/Имя"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Удаленный ящик 4 [Показать имя]IP/Имя"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Удаленный ящик 5 [Показать имя]IP/Имя"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Удаленный ящик Опрашивайте каждую минуту"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Удаленный ящик Таймер [Показать имя]IP/Имя"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Удаленный ящик Таймер Опрашивайте каждую минуту"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Converter Poll Interval"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW Конвертер использование"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey из cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey из convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF обновление [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF тип обновления"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF Инициализировать Задерживать"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP Отрицать"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF Дизайн"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Сохранить как рисунок для WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG Ручей LCD 1 включить"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Ручей LCD 1 Порт"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG Ручей LCD 1 виртуальная яркость"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG Ручей LCD 2 включить"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Ручей LCD 2 Порт"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Ручей LCD 2 виртуальная яркость"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG Ручей LCD 3 включить"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Ручей LCD 3 Порт"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG Ручей LCD 3 виртуальная яркость"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG Цикл"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Перезагрузить при ошибке"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG Режим заголовка"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Ping Тайм-аут [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos играть Проверять"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Обновить [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Ping Тайм-аут [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound играть Проверять"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Обновить [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Сервер IP [по желанию]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Ping Тайм-аут [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast играть Проверять"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Обновить [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Обложка"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD Своя Ширина"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD Своя высота"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD Своя Ширина 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD Своя высота 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD выключен при выключении"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Выбор времени! calc all Times to Time/5*2 in Fastmode"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Задержка [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Threads pro LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Показать Крушение Угол"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Показать 'нет...' Сообщения"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Хранение-Устройство: Принудит Чтение"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Хранение-Устройство: Цвет Задний план"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Хранение-Устройство: Цвет Бар"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Хранение-Устройство: Цвет Полный"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Проверка сети активна"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Выключатель Кадровый буфер [если возможно]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Конфиг Путь к резервному копированию[ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Конфиг Восстановить все настройки"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Debug-Logging > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Выключение подсветки [Off = On]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Включение подсветки"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Подсвечивать выходные [для отключения установить Off = On]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Hintergrundbeleuchtung Wochenende Ein"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Автоматическое отключение"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Задний план"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "Картина [ok]"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Размер пиконов"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- Разделение экрана"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- На весь экран"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- Размер текста"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- Прозрачность"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Путь к пиконам [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Путь к пиконам 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache путь [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Пикон 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Часы"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Тип"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Аналоговые часы"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- Растояние"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- Размер"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- Теневые грани"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Часы 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Название передачи"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- маскимум линий"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- Длина"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Номер канала"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Инфо о програме"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Тип"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Инфо о програме 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Инфо о следующей программе"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Расширенное описание"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- использовать информацию, когда она пуста"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Прогресс бар"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Цвет Текст"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Граница"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- Затенить"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- единица измерения мин"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Информация"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Инфо о тюнере"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- Сенсор"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Информация 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Уровень сигнала"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- Градиент"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- Бар диапазон мин"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- Бар диапазон макс"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Спутник"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Провайдер"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Используемый тюнер"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- только активный тюнер"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Следующее событие таймера"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Громкость"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Немой"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Аудио/Видео"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Онлайн [Пинг]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- Показать состояние"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- Тайм-аут [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- Ник:адрес"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Внешний IP-адрес"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- внешний IP URL"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Хранение-Устройство"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- бесплатно предупреждение"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- экстра инфо"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- Имя устройства"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- Увеличение"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- Тип погоды"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Погода 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Погода-Источник"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Станция"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Модуль"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Модуль определяемые пользователем"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "Основание"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Имя"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Цвет 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Цвет 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Цвет 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Цвет 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Цвет 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Цвет 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Индикатор"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- Длина [Бар]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Комфорт Индикатор"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Фазы Луны"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Информационные строки"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- стрелки тренда"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Восход солнца"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Показать oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- Файл [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Показать ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Показать текст файл"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Показать текст файл 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Показать текст файл 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Показать HTTP текст"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW-Internet Converter"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP Ширина"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP Высота"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- Вырезать из X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- Вырезать из Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- Обрезать по ширине [выкл. = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- Обрезать по высоте [выкл. = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Показать картинку"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- Файл или путь [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- Высота макс"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- Быстрое обновление"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Показать картинку 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Показать картинку 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Показать картинку 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- Линий"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- Учетная запись почты"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- ширина макс"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Удаленный ящик v"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- Размер картинки"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "-Позиция изображения"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- Выравнивание изображения"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- Макет"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Цвет фона текущего дня"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- Название цвета"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Список дат"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Event Icon Bar"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- Popup Screen"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Показать текст 1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Текст"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Показать текст 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Прямоугольник 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- Позиция по оси x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- Позиция по оси y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- Размер по оси x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- Размер по оси y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Прямоугольник 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Запись"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Заикание TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "Функция используется для изменения экранов"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Заголовок"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Узнайте больше"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Показать обложку"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- Поиск пути [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Найти Обложка Файл [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- По умолчанию обложка [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- Первый пикон"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Обрезанный"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Скачать обложку"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Скачать Тип"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "Google API-Key console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Дисплей"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux режим отображения На"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Задавать СМИ >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux режим отображения Медиа плеер"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Задавать Праздный  >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux режим отображения праздный"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Задавать Глобальный >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Выберите каталог"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Выберите файл"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Выберите шрифт"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - Текущее значение: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3842,95 +4075,95 @@ msgstr ""
 "GUI должен быть перезапущен для активации изменений.\n"
 "Сделать это сейчас?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Перегрузить GUI сейчас?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "В помещении"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Открытый"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Дождь"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Ветер"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Новолуние"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Первая четверть"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Растущий серп"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Растущая Луна"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Полнолуние"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Убывающая Луна"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Убывающая Луна"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Последняя четверть"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Картина недоступен"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "нет таймера"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAMне запущен"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "нет звонки"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Почта  %d Новая  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "netatmo-Plugin не установлен"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Экран Выключатель"
 
@@ -3948,111 +4181,3 @@ msgstr "LCD4linux Экран Выключатель"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Погода Направление ветра"
-
-#~ msgid "Backup Config"
-#~ msgstr "Задний план Конфиг"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Креш лог"
-
-#~ msgid "Delete"
-#~ msgstr "Удалить"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Удалить Лог-файл"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Скачать Лог-файл"
-
-#~ msgid "Element"
-#~ msgstr "Элемент"
-
-#~ msgid "Exec"
-#~ msgstr "Выполнение"
-
-#~ msgid "Filename"
-#~ msgstr "Имя файла"
-
-#~ msgid "Font"
-#~ msgstr "Шрифт"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "GUI необходимо перезагрузить"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "Безопасность IP не поддерживается Box"
-
-#~ msgid "Key"
-#~ msgstr "Ключ"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Список устройств хранения"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Ручей"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Файл не выбран или выбран неверный файл, сначала попробуйте правильный файл!"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Родительский каталог"
-
-#~ msgid "Picture"
-#~ msgstr "Картинка"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Всплывающий- текст"
-
-#~ msgid "Restore Config"
-#~ msgstr "Восстановить конфигурацию"
-
-#~ msgid "Save Config"
-#~ msgstr "Сохранить конфигурацию"
-
-#~ msgid "Screen"
-#~ msgstr "Экран"
-
-#~ msgid "Show"
-#~ msgstr "Показать"
-
-#~ msgid "Show Externals"
-#~ msgstr "Показать Внешние"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Тюнер"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW Конвертер"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "копировать в фоне"
-
-#~ msgid "copy to Media"
-#~ msgstr "копировать в медиа"
-
-#~ msgid "copy to On"
-#~ msgstr "копировать в На"
-
-#~ msgid "other"
-#~ msgstr "прочие"
-
-#~ msgid "set Settings"
-#~ msgstr "меню Настройки"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "остановить Screencycle"

--- a/LCD4linux/po/sk.po
+++ b/LCD4linux/po/sk.po
@@ -2,3840 +2,4073 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:10+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:21+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,-1,-1,-1,-1,747\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "Pi"
-
-#: plugin.py:263
-msgid "Mon"
-msgstr "Po"
-
-#: plugin.py:263
-msgid "Sat"
-msgstr "So"
-
-#: plugin.py:263
-msgid "Sun"
-msgstr "Ne"
-
-#: plugin.py:263
-msgid "Thur"
-msgstr "Št"
-
-#: plugin.py:263
-msgid "Tue"
-msgstr "Ut"
-
-#: plugin.py:263
-msgid "Wed"
-msgstr "St"
-
-#: plugin.py:288
-msgid "black"
-msgstr "čierna"
-
-#: plugin.py:288
-msgid "white"
-msgstr "biela"
-
-#: plugin.py:289
-msgid "gray"
-msgstr "šedá"
-
-#: plugin.py:289
-msgid "silver"
-msgstr "strieborná"
-
-#: plugin.py:289
-msgid "slategray"
-msgstr "bridlicovo sivá"
-
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "akvamarín"
-
-#: plugin.py:291
-msgid "gold"
-msgstr "zlatá"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "zelenožltá"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "žltá"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "tmavooranžová"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "tmavočervená"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "indiánska červená"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "oranžová"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "oranžovočervená"
-
-#: plugin.py:292
-msgid "red"
-msgstr "červená"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "paradajková"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "tmavozelená"
-
-#: plugin.py:293
-msgid "green"
-msgstr "zelená"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "zelený trávnik"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "svetlosvetlozelená"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "limetka"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "modrá"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "modrofialová"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "kadet modrá"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "nevädza modrá"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "tmavomodrá"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "indigo"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "svetlosvetlomodrá"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "svetlomodrá"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "tmavá orchidea"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "tmavoružová"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "purpurová"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "fialová"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "hnedá"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "mokasín"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "olivová"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "ružovohnedá"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "pieskovohnedá"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "Obrazovka 1+2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "Obrazovka 1+2+3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "Obrazovka 1+2+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "Obrazovka 1+2+4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "Obrazovka 1+3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "Obrazovka 1+3+4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "Obrazovka 1+3+5+7+9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "Obrazovka 1+4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "Obrazovka 2+3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "Obrazovka 2+3+4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "Obrazovka 2+4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "Obrazovka 2+4+6+8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "Obrazovka 3+4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "Obrazovka 5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "Obrazovka 5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "Obrazovka 1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "Obrazovka 1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "Obrazovka 1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "Obrazovka 1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "Obrazovka 1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "Obrazovka 1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "Obrazovka 2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "Obrazovka 3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "Obrazovka 4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "Obrazovka 5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "Obrazovka 6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "Obrazovka 7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "Obrazovka 8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "Obrazovka 9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "vypnuté"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "Obrazovka 1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "Obrazovka 1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "Obrazovka 1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "zapnuté"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2h"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3h"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3min"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4min"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5h"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2min"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30s"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10min"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30min"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60min"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby@Pearl 128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "Pearl (alebo kompatibilné LCD) 240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "Pearl (alebo kompatibilné LCD) 320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "Pearl (alebo kompatibilné LCD) 320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (alebo kompatibilné LCD) 480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "Samsung SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "Samsung SPF-75H/76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "Samsung SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "Samsung SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "Samsung SPF-87H alt 800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "Samsung SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "Samsung SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "Samsung SPF-107H alt 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "Samsung SPF-85H/86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "Samsung SPF-85P/86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "Samsung SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "Samsung SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "Samsung SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "Zabudovaný TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "Zabudovaný Box-Skin-LCD"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "len obrázok 1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "len obrázok 320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "len obrázok 800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "len obrázok 800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "len obrázok vlastná veľkosť"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "len obrázok vlastná veľkosť 2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "Zabudovaný Vu+ Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2 dni 1 riadok"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2 dni 2 riadky"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4 dni 1 riadok"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4 dni 2 riadky"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4 dni zvislý pohľad"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5 dní 1 riadok"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5 dní 2 riadky"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5 dní zvislý pohľad"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "Aaktuálna teplota (+C)"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "Aktuálna teplota (-C)"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "Aktuálny"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "Aktuálna teplota"
-
-#: plugin.py:317
-msgid "All"
-msgstr "Všetko"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "Teplota"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "Teplota+Co2"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "Teplota+Co2+Tlak"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "Teplota+Vlhkosť"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "Modul 1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "Modul 1+2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "Modul 1+2+3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "Modul 1+2+4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "Modul 1+3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "Modul 1+3+4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "Modul 1+4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "Modul 1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "Modul 1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "Modul 1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "Modul 2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "Modul 2+3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "Modul 2+3+4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "Modul 2+4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "Modul 2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "Modul 3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "Modul 3+4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "Modul 3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "Modul 4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "Modul 4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "Modul 5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "Modul 5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "Modul 6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "definované užívateľom"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "Stĺpec"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "Stĺpec+hodnota"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "Tlačidlo"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "Tlačidlo+hodnota"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "Analógové"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "Analógové+dátum"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "Analógové+dátum+deň týždňa"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "Analógové+dátum+deň týždňa 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "Dátum"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "Dátum+čas"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "Dátum+čas+deň týždňa"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "Dátum návrhu klapiek"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "Návrh klapiek vo všedný deň"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "Čas"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "Čas+Deň týždňa"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "Deň týždňa"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "vycentrovať"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "ľavý"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "vpravo"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "Rozšírený"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "Rozšírený (menej info)"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "Krátky"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "Krátky(rozširený)"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "Krátky+rozšírený"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "Mesiac"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "Mesiac+hlavička"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "Týždeň"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "Týždeň+Hlavička"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "žiaden kalendár"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "Dátum 1 riadok"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "Dátum 3 riadky"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "Dátum 5 riadkov"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "Dátum 9 riadkov"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "Kompaktné dátumy 2 riadky"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "Kompaktné dátumy 3 riadky"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "žiadne termíny"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "Podčiarknutie"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "Podčiarknutie 2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "Rámček"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "Dátumy"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "Kompaktné dátumy"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "Kompaktné dátumy bez ikon"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "Dátumy bez ikon"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "žiadna ikona"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "žiadna ikona, s cieľovým počtom"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "s ikonou"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "s ikonou & cieľové číslo"
-
-#: plugin.py:329
-msgid "C"
-msgstr "C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C + otáčky"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + otáčky/2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "otáčky"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "otáčky/2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "nie"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "% + BER"
-
-#: plugin.py:330
-msgid "db"
-msgstr "db"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "db + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "db + % + BER"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "db + BER"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + Load@1min"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + Load@5min"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "Load@1min"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "Load@5min"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "zobraz aktívne"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "zobraz aktívne+čakajúce"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "Vždy všetko"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "Vždy nové"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "Len nové"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "Všetky Informácie"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "Len Vzdialenosť"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "Vzdialenosť+Osvetlenie"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "Vzdialenosť+Fáza mesiaca"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "Len Osvetlenie"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "Osvetlenie+Fáza mesačná"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "Len Fáza Mesiaca"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "Kanál"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "Kanál+titulok"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon+kanál"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon+kanál+titulok"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "Picon"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "rovnaká farba"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "áno +25%"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "áno"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "zvislo"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "vodorovne"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "Celkovo"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "všetko"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "Roh"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "Roh + časový posun"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon+Časový posun"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "len stĺpec priebehu"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "a zostávajúce minúty"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "a zostávajúce minúty (veľkosť 1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "a zostávajúce minúty (veľkosť 2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "a percenta"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "a percenta (veľkosť 1.5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "a percenta (veľkosť 2)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "a zostávajúce minúty (nad)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "a zostávajúce minúty (nad/veľkosť 1.5)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "a zostávajúce minúty (nad/veľkosť 2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "s percentami (nad)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "s percentami (nad/veľkosť 1.5)"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "s percentami (nad/veľkosť 2)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "a zostávajúce minúty (pod)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "a zostávajúce minúty (pod/veľkosť 1.5)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "a zostávajúce minúty (pod/veľkosť 2)"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "s percentami (pod)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "s percentami (pod/veľkosť 1.5)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "s percentami (nad/veľkosť 2)"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "s aktuálnym 00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "s aktuálnym 00:00 (veľkosť 1.5)"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "s aktuálnym 00:00 (veľkosť 2)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "s aktuálnym 00:00 (nad)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "s aktuálnym 00:00 (nad/veľkosť 1.5)"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "s aktuálnym 00:00 (nad/veľkosť 2)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "s aktuálnym 00:00 (pod)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "s aktuálnym 00:00 (pod/veľkosť 1.5)"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "s aktuálnym 00:00 (pod/veľkosť 2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "s percentami minút / Celkovo (nad)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "s percentami minút / Celkovo (nad/veľkosť 1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "s percentami minút / Celkovo (nad/veľkosť 2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "s absolútnym časom konca"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "s absolútnym časom konca (veľkosť 1.5)"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "s absolútnym časom konca (veľkosť 2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "s celkovým počtom minút / konečným časom (vyššie)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "s celkovým počtom minút / konečným časom (vyššie / veľkosť 1,5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "s celkovým počtom minút / konečným časom (vyššie / veľkosť 2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "Rýchly mód (2s)"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "Normalne (5s)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "abecedne"
-
-#: plugin.py:386
-msgid "random"
-msgstr "náhodne"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "lepší/pomalší"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "pomaly/rýchlo (len obrázok)"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "pomaly/rýchlo (všetko)"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "cache + prispôsobenie(vysoká kvalita, pomalšie)"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "cache + prispôsobenie(nízka kvalita, rýchlejšie)"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "bez cache + bez nastavovania"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "Zabudovaný tuner"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB Tuner"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "Teraz/Ďalší"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "normálne"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "redukované"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Javascript"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Javascript nie Obnoviť"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "Znovu nahratie"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - normálne"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2 - bok po boku"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "WeatherUnlocked"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "alternatívny Mód kopírovania/DM800hd (24bit)"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "áno + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "áno, dlhé"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "áno, krátke"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "km/h"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "m/s"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "Coversearch"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
+
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "Box-Skin-LCD"
+
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "Písmo"
+
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "Kľúč"
+
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG Stream"
+
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD"
+
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "Obrázok"
+
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "Vyskakovací-text"
+
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
+
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "Ladička"
+
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW konvertor"
+
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
+
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "Obrazovka"
+
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1 / min"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "vždy"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "Zapnuté+Média+Pohotovostný režim"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "Pohotovostný režim"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "Média"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "Zapnuté"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32bit - farba"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8bit - čb/farba"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x rýchlo vred tlačidlo"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x rýchlo vred tlačidlo typ 2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "Dlhé tlačidlo rýchlovpred"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "Dlhé tlačidlo rýchlovpred typ 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 x Info tlačidlo"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x stlmiť zvuk"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "Dlhé tlačidlo info"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 x rýchlospäť tlačidlo"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x Rýchlo späť tlačítko Typ 2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "Dlhé tlačidlo rýchlospäť"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "Dlhé Rýchlo späť tlačítko Typ 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15min"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "áno, rozšírené"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "Bežná konzola"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "Rozsiahly log súbor"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "Normálny log súbor"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "zakázané"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "Rádio"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "Rádio+Média"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "TV+Rádio"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "TV+Rádio+Média"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "TV"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "TV (plný)"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "normálne (plné)"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "zdobené (čierna)"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "zdobené (priehľadné)"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "ZTLM alebo definuj kľúče"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "ľubovoľnú klávesu"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "Čas+Info"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "Čas+Trvanie+Info"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "Mini-EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "Čas+Dĺžka+Info"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "polovica vľavo"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "polovica vpravo"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "Rámček x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "Riadok"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "žiadny bar"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "žiadny Rámček"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "Spád"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "Hrany tieňa"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "Normalne"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+Pozícia pod"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "Picon+Pozícia vľavo"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "Picon+Pozícia vpravo"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "Umiestnenie"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "Meno"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "Vypnuté"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "Aktívný"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "Aktívný+Neaktívny"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "len použitý časovač"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "použiť čas dodania"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "žiaden celkový časovač"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "zobraz celkový časovač"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "jeden riadok"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "dva riadky"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "Dostupná pamäť"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "Voľná pamäť"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "na celú obrazovku"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "TV+OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "áno okrem nahrávok"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "V"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "VSV"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "VJV"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "S"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "SV"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "SSV"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "SSZ"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "SZ"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "J"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "JV"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "JJV"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "JJZ"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "JZ"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "Z"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "ZSZ"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "ZJZ"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%d.%m.%Y - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%d-%b-%Y"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "Nahraj aktívny konfig. súbor"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "Načítať predvolené hodnoty / Prázdna konfigurácia"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "Uložiť konfig do súboru... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "Nahraj súbor : %s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "Zmazať súbor?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "zmazané"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "aktuálne nastavené : %s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux nastavenie"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "Režim"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "Zrušiť"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "Uložiť"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "Reštart zobrazovačov"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "Nastaviť On >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "Nečinný"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "žiadne LCD1 Obrazkové data"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "žiadne LCD2 Obrazkové data"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "žiadne LCD3 Obrazkové data"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "LCD4linux povolené"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1 Typ"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1 otočiť"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1 farba pozadia"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1 obrázok pozadia [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1 Jas"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1 Nočná redukcia"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1 obnova"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2 Typ"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2 otočiť"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2 farba pozadia"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2 obrázok pozadia [ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2 Jas"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2 Nočná redukcia"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2 obnova"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3 Typ"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3 otočiť"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3 farba pozadia"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3 obrázok pozadia [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3 Jas"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3 Nočná redukcia"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3 obnova"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "Box-Skin-LCD rozmery"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD Ofset"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "Box-Skin-LCD Farba"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD povoliť zap. mód"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD povoliť média mód"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD povoliť čakací mód"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [čas zobrazenia]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- ktoré LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- zobraz v móde"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- veľkosť OSD"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- Pozadie/Priehľadnosť"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- rýchly snímok nízkej kvality"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "Vyskakovací text"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- Vymazať kľúč"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- veľkosť písma"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- umiestnenie"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- Zarovnanie"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- Farba"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- Farba pozadia"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- písmo"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "Aktívna obrazovka"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "Výber prepínača obrazovky - Obrazovka"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "Výber prepínača obrazovky - LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "Obrazovky použité na výmenu"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "Obrazovka 1 čas zmeny"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- čas zmeny obrazovky 2"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- čas zmeny obrazovky 3"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- čas zmeny obrazovky 4"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- čas zmeny obrazovky 5"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- čas zmeny obrazovky 6"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- čas zmeny obrazovky 7"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- čas zmeny obrazovky 8"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- čas zmeny obrazovky 9"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "Obrázok čas zmeny"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "Zoradenie obrázkov"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "Obrázok rekurzívny priečinok"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "Kvalita obrázka na zmenu veľkosti"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "Obrázok čas rychlej aktualizácie [s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "Typ obrázka [len obrázok]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "Typ obrázka pozadia"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "Počasie - výber providera"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "Počasie API-key OpenWeatherMap"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "Počasie API-ID Key WeatherUnlocked"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "Počasie MSN (pre Mesto 1)"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "Počasie MSN (pre Mesto 2)"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "Počasie-Ikona-Cesta [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "Počasie-Ikona zväčšenie"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "Počasie farba nízkej  (mínusovej) teploty"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "Počasie farba vysokej (plusovej) teploty"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "Počasie priehľadnosť"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "Počasie jednotky rýchlosti vetra"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "Počasie smer a rýchlosť vetra"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "Počasie pravdepodobnosť dažďa"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- zväčšenie dažďa"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- farba dažďa"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- dážď používa farbu 2 z"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- farba dažďa 2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "Počasie riadky"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "Počasie sípky trendov"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "Počasie rozšírené info"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- Extra zväčšenie"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- zobraz teplotu ochladenia ak je rozdiel"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- Extra farba mesta"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- Extra farba ochladenia"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2 Min rozsah"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2 Max rozsah"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "URL počasia"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "Cesta k ikone mesiaca [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "Obrázok záznamu [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "Zmena dvoj-stlačením tlačidla"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "Kľúč na zmenu obrazovky"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "Klávesa pre zapnutie / vypnutie obrazovky"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall cesta k obrázkom [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall počet riadkov na vstupny údaj"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall počet položiek zoznamu"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall počet obrázkov"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall orientácia obrázka"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall priehľadnosť obrázka"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall vyhľadávanie obrázkov"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall odobrať volania po hodinách"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall čas vyskakovaieho okna"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall vyskakovací LCD"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall farba vyskakovacieho okna"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall obrázok rámčeka [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "Kalendár ics-cesta [ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "Kalendár ics-URL"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "Kalendár plánovač"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "Kalendár farba soboty"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "Kalendár farba nedele"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "Kalendár hrúbka čiary"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "Kalendár denny prehľad"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "Kalendár korekcia časovej zóny"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "Kalendár priehľadnosť"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "Kalendár čas obnovy"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "Ladička Farba"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "Ladička Farba Aktívny"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "Ladička Farba Zapnúť"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "Najprv prehľadať kanál"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T korekcia kvality signálu"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "Písmo celkovo [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "Písmo1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "Písmo 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "Písmo 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "Font 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "Font 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "Pošta 1 pripojenie"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "Pošta 1 server"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "Pošta 1 [Zobrazované meno:]Meno používateľa"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "Pošta 1 heslo"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "Pošta 2 pripojenie"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "Pošta 2 server"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "Pošta 2 [Zobrazované meno:]Meno používateľa"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "Pošta 2 heslo"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "Pošta 3 pripojenie"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "Pošta 3 server"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "Pošta 3 [Zobrazované meno:]Meno používateľa"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "Pošta 3 heslo"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "Pošta 4 pripojenie"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "Pošta 4 server"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "Pošta 4 [Zobrazované meno:]Meno používateľa"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "Pošta 4 heslo"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "Pošta 5 pripojenie"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "Pošta 5 server"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "Pošta 5 [Zobrazované meno:]Meno používateľa"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "Pošta 5 heslo"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "Pošta obnovovací interval"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "Pošta IMAP limit na posledné dni"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "Pošta zobraz prázdne kontá"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "Pošta zobraz dátum"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "Pošta skryť adresy"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "Vzdialený Box 1 [zobrazované meno:]IP/Meno"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Vzdialený Box 2 [zobrazované meno:]IP/Meno"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "Vzdialený Box 3 [zobrazované meno:]IP/Meno"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Vzdialený Box 4 [zobrazované meno:]IP/Meno"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Vzdialený Box 5 [zobrazované meno:]IP/Meno"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "Vzdialený Box obnova v minútach"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "Vzdialený Box 1 [zobrazované meno:]IP/Meno"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "Vzdialený Box obnova v minútach"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW Konvertor čas obnovy"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "Použiť WWW konvertor"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "WWW ApiKey z cloudconvert.org"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "WWW ApiKey z convertapi.com"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF aktualizácia [s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF typ aktualizácie"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF Inicializácia oneskorenie"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP povoľ"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP zakáž"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF vzhľad"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "Uložiť ako obrázok pre WebIF"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG stream pre LCD 1 povoliť"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG Stream LCD 1 porty"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG stream pre LCD 1 Virtuálny jas"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG stream pre LCD 2 povoliť"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG Stream LCD 2 porty"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG stream pre LCD 2 Virtuálny jas"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG stream pre LCD 3 povoliť"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG Stream LCD 3 porty"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG stream pre LCD 2 Virtuálny jas"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG cyklus"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "MJPEG Reštartujte pri chybe"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG režim hlavičky"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "Sonos Časový limit ping [ms]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "Sonos Prehrať šek"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "Sonos Obnoviť [s]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Časový limit ping [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound Prehrať šek"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound Obnoviť [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "MusicCast IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast Server IP [optional]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "MusicCast Časový limit ping [ms]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast Prehrať šek"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast Obnoviť [s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "MusicCast Obal"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD voliteľná šírka"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD voliteľná výška"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD voliteľná šírka 2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD voliteľná výška 2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "LCD Vypnuté pri vypnutí"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "Časovanie ! vypočet všetkých časov na Čas/5*2 v rýchlom móde"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "Oneskorenie zobrazovača [ms]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "Témy pre LCD"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "Zobraz chybové hlásenia"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "Zobraz 'žiadne ....' hlásenia"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "Úložné zariadenia: Vynútiť čítanie"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "Úložné zariadenia: Farba späť"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "Úložné zariadenia: Farebná lišta"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "Úložné zariadenia: Farba plná"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "Kontrola siete aktívna"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "Prepnúť FrameBuffer [ak je to možné]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "Cesta zálohy konfig. [ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "Konfigurácia obnova všetkých nastavení"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "Logovanie > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- Podsvietenie vyp. [ Zap.=Vyp.]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- Podsvietenie zap"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- Podsvietenie cez víkend vyp. [ Zap.=Vyp.]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- Podsvietenie cez víkend zap"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD Automatické vypnutie"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "Pozadie"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- Obrázok [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon veľkosť"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- rozdelená obrazovka"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- celá obrazovka"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- veľkosť textu"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- priehľadnosť"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon cesta [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon cesta 2 [ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon Cache cesta [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "Hodiny"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  Typ"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- Analogové Hodiny"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- rozstup"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- veľkosť"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- hrany tieňa"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "Hodiny 2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "Názov kanálu"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- maximum riadkov"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- dĺžka"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "Číslo kanálu"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "Info o programe"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- Typ"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "Program Info 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "Info o ďalšom programe"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "Rozšírený popis"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- prázdne použite informáciu"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "Priebeh"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- Farebný text"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- Okraj"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- tieňované"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- Jednotka min"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "Informácie"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- Tuner nfo"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- snímače"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- CPU"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "Informácie 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "Stĺpec kvality signálu"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- spád"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- rozsah stĺpca kvality signálu na Min"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- rozsah stĺpca kvality signálu na Max"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "Satelit"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "Poskytovateľ"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "Použitý tuner"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- len aktívny tuner"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "Ďalší časovač udalostí"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "Hlasitosť"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "Stíšiť"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "Audio/Video"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "Stav siete [Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- zobraz stav"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- čas vypršania [ms]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- sieťové meno :Adresa"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "Externá adresa IP"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- externá adresa URL IP"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "Pamäťové-zariadenia"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- bez varovania"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- extra Info"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- meno zariadenia"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "Počasie"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- zväčšenie"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- typ počasia"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "Počasie 2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "Meteo stanica"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- Stanica"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- Modul"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- Definovaný používateľom"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- Základ"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- Meno"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- Farba 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- Farba 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- Farba 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- Farba 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- Farba 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Farba 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2 Indikátor"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- dĺžka [Bar]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo Komfortný Indikátor"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "Fáza mesiaca"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- Informačné linky"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- Šípky trendov"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "Východ slnka"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "Zobraz oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- súbor [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "Zobraz ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "Zobraz textový súbor"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "Zobraz textový súbor 2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "Zobraz textový súbor 3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "Zobraz HTTP Text"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "Konvertor web stránok"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP šírka"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP výška"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- orezanie z X"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- orezanie z Y"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- šírka orezania [vyp. = 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- výška orezania [vyp. = 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "Zobraz obrázok"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- súbor alebo cesta [ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- max výška"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- rýchla aktualizácia"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "Zobraz obrázok 2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "Zobraz obrázok 3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "Zobraz obrázok 4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "Pošta"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- riadky"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- e-mailové konto"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- max šírka"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "Vzdialený Box"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "Vzdialený Box"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- veľkosť obrázka"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- umiestnenie obrázka"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- zarovnanie obrázka"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "Kalendár"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP povoľ"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "Žiadny alebo nesprávny zvolený súbor, skús najprv správny súbor !"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "Režim"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "IP zabezpečenie nie je podporované v box-e"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "Chybový výpis"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "Zobraziť"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "Zmazať"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "Názov súboru"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "Obnova cfg"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "Záloha cfg"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "Zmazanie log súboru"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "Stiahnuť log súbor"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "Ulož cfg"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "zastav výmenu obrazoviek"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "Celkovo"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "Zapnuté"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "Média"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "Nečinný"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "Vyžaduje sa reštart GUI"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "Nastavenia"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "iné"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "aktivuj nastavenia"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "kopírovať do aktívných"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "kopírovať do Média"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "kopírovať do pohotovostných"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "Vykonať"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "Zobraz vonkajšie"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "Zoznam úložných zariadení"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "Nadradený adresár"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "Pi"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "Po"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "So"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "Ne"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "Št"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "Ut"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "St"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "čierna"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "biela"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "šedá"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "strieborná"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "bridlicovo sivá"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "akvamarín"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "zlatá"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "zelenožltá"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "žltá"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "tmavooranžová"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "tmavočervená"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "indiánska červená"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "oranžová"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "oranžovočervená"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "červená"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "paradajková"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "tmavozelená"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "zelená"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "zelený trávnik"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "svetlosvetlozelená"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "limetka"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "modrá"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "modrofialová"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "kadet modrá"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "nevädza modrá"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "tmavomodrá"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "indigo"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "svetlosvetlomodrá"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "svetlomodrá"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "tmavá orchidea"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "tmavoružová"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "purpurová"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "fialová"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "hnedá"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "mokasín"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "olivová"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "ružovohnedá"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "pieskovohnedá"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "Obrazovka 1+2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "Obrazovka 1+2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "Obrazovka 1+2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "Obrazovka 1+2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "Obrazovka 1+3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "Obrazovka 1+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "Obrazovka 1+3+5+7+9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "Obrazovka 1+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "Obrazovka 2+3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "Obrazovka 2+3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "Obrazovka 2+4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "Obrazovka 2+4+6+8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "Obrazovka 3+4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "Obrazovka 5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "Obrazovka 5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "Obrazovka 1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "Obrazovka 1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "Obrazovka 1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "Obrazovka 1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "Obrazovka 1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "Obrazovka 1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "Obrazovka 2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "Obrazovka 3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "Obrazovka 4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "Obrazovka 5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "Obrazovka 6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "Obrazovka 7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "Obrazovka 8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "Obrazovka 9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "vypnuté"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "Obrazovka 1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "Obrazovka 1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "Obrazovka 1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "zapnuté"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2min"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30s"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30min"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60min"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby@Pearl 128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "Pearl (alebo kompatibilné LCD) 240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "Pearl (alebo kompatibilné LCD) 320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "Pearl (alebo kompatibilné LCD) 480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "Pearl (eller kompatibel LCD) 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "Samsung SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "Samsung SPF-75H/76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "Samsung SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "Samsung SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "Samsung SPF-87H alt 800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "Samsung SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "Samsung SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "Samsung SPF-107H alt 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "Samsung SPF-85H/86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "Samsung SPF-85P/86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "Zabudovaný Box-Skin-LCD"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "Zabudovaný TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "Samsung SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "Samsung SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "Samsung SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "len obrázok 1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "len obrázok 320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "len obrázok 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "len obrázok 800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "len obrázok vlastná veľkosť"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "len obrázok vlastná veľkosť 2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "Zabudovaný Vu+ Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2 dni 1 riadok"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2 dni 2 riadky"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4 dni 1 riadok"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4 dni 2 riadky"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4 dni zvislý pohľad"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5 dní 1 riadok"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5 dní 2 riadky"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5 dní zvislý pohľad"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "Aaktuálna teplota (+C)"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "Aktuálna teplota (-C)"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "Aktuálny"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "Aktuálna teplota"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "Všetko"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "Teplota"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "Teplota+Co2"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "Teplota+Co2+Tlak"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "Teplota+Vlhkosť"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "Modul 1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "Modul 1+2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "Modul 1+2+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "Modul 1+2+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "Modul 1+3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "Modul 1+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "Modul 1+4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "Modul 1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "Modul 1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "Modul 1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "Modul 2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "Modul 2+3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "Modul 2+3+4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "Modul 2+4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "Modul 2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "Modul 3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "Modul 3+4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "Modul 3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "Modul 4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "Modul 4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "Modul 5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "Modul 5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "Modul 6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "definované užívateľom"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "Stĺpec"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "Stĺpec+hodnota"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "Tlačidlo"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "Tlačidlo+hodnota"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "Analógové"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "Analógové+dátum"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "Analógové+dátum+deň týždňa"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "Analógové+dátum+deň týždňa 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "Dátum"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "Dátum+čas"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "Dátum+čas+deň týždňa"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "Dátum návrhu klapiek"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "Návrh klapiek vo všedný deň"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "Čas"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "Čas+Deň týždňa"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "Deň týždňa"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "vycentrovať"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "ľavý"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "vpravo"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "Rozšírený"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "Rozšírený (menej info)"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "Krátky"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "Krátky(rozširený)"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "Krátky+rozšírený"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "Mesiac"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "Mesiac+hlavička"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "Týždeň"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "Týždeň+Hlavička"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "žiaden kalendár"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "Dátum 1 riadok"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "Dátum 3 riadky"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "Dátum 5 riadkov"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "Dátum 9 riadkov"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "Kompaktné dátumy 2 riadky"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "Kompaktné dátumy 3 riadky"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "žiadne termíny"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "Podčiarknutie"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "Podčiarknutie 2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "Rámček"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "Dátumy"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "Kompaktné dátumy"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "Kompaktné dátumy bez ikon"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "Dátumy bez ikon"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "žiadna ikona"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "žiadna ikona, s cieľovým počtom"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "s ikonou"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "s ikonou & cieľové číslo"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C + otáčky"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + otáčky/2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "otáčky"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "otáčky/2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "nie"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "% + BER"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "db"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "db + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "db + % + BER"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "db + BER"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + Load@1min"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + Load@5min"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "Load@1min"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "Load@5min"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "zobraz aktívne"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "zobraz aktívne+čakajúce"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "Vždy všetko"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "Vždy nové"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "Len nové"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "Všetky Informácie"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "Len Vzdialenosť"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "Vzdialenosť+Osvetlenie"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "Vzdialenosť+Fáza mesiaca"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "Len Osvetlenie"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "Osvetlenie+Fáza mesačná"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "Len Fáza Mesiaca"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "Kanál"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "Kanál+titulok"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon+kanál"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon+kanál+titulok"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "rovnaká farba"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "áno +25%"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "áno"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "zvislo"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "vodorovne"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "všetko"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "Roh"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "Roh + časový posun"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon+Časový posun"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "len stĺpec priebehu"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "a zostávajúce minúty"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "a zostávajúce minúty (veľkosť 1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "a zostávajúce minúty (veľkosť 2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "a percenta"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "a percenta (veľkosť 1.5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "a percenta (veľkosť 2)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "a zostávajúce minúty (nad)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "a zostávajúce minúty (nad/veľkosť 1.5)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "a zostávajúce minúty (nad/veľkosť 2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "s percentami (nad)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "s percentami (nad/veľkosť 1.5)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "s percentami (nad/veľkosť 2)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "a zostávajúce minúty (pod)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "a zostávajúce minúty (pod/veľkosť 1.5)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "a zostávajúce minúty (pod/veľkosť 2)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "s percentami (pod)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "s percentami (pod/veľkosť 1.5)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "s percentami (nad/veľkosť 2)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "s aktuálnym 00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "s aktuálnym 00:00 (veľkosť 1.5)"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "s aktuálnym 00:00 (veľkosť 2)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "s aktuálnym 00:00 (nad)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "s aktuálnym 00:00 (nad/veľkosť 1.5)"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "s aktuálnym 00:00 (nad/veľkosť 2)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "s aktuálnym 00:00 (pod)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "s aktuálnym 00:00 (pod/veľkosť 1.5)"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "s aktuálnym 00:00 (pod/veľkosť 2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "s percentami minút / Celkovo (nad)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "s percentami minút / Celkovo (nad/veľkosť 1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "s percentami minút / Celkovo (nad/veľkosť 2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "s absolútnym časom konca"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "s absolútnym časom konca (veľkosť 1.5)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "s absolútnym časom konca (veľkosť 2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "s celkovým počtom minút / konečným časom (vyššie)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "s celkovým počtom minút / konečným časom (vyššie / veľkosť 1,5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "s celkovým počtom minút / konečným časom (vyššie / veľkosť 2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "Rýchly mód (2s)"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "Normalne (5s)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "abecedne"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "náhodne"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "lepší/pomalší"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "pomaly/rýchlo (len obrázok)"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "pomaly/rýchlo (všetko)"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "cache + prispôsobenie(vysoká kvalita, pomalšie)"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "cache + prispôsobenie(nízka kvalita, rýchlejšie)"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "bez cache + bez nastavovania"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "Zabudovaný tuner"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB Tuner"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "Teraz/Ďalší"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "normálne"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "redukované"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Javascript"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Javascript nie Obnoviť"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "Znovu nahratie"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - normálne"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2 - bok po boku"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "WeatherUnlocked"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "alternatívny Mód kopírovania/DM800hd (24bit)"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "áno + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "áno, dlhé"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "áno, krátke"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "km/h"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "m/s"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "Coversearch"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1 / min"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "vždy"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "Zapnuté+Média+Pohotovostný režim"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "Pohotovostný režim"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32bit - farba"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8bit - čb/farba"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x rýchlo vred tlačidlo"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x rýchlo vred tlačidlo typ 2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "Dlhé tlačidlo rýchlovpred"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "Dlhé tlačidlo rýchlovpred typ 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 x Info tlačidlo"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x stlmiť zvuk"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "Dlhé tlačidlo info"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 x rýchlospäť tlačidlo"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x Rýchlo späť tlačítko Typ 2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "Dlhé tlačidlo rýchlospäť"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "Dlhé Rýchlo späť tlačítko Typ 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15min"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "áno, rozšírené"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "Bežná konzola"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "Rozsiahly log súbor"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "Normálny log súbor"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "zakázané"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "Rádio"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "Rádio+Média"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "TV+Rádio"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "TV+Rádio+Média"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "TV (plný)"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "normálne (plné)"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "zdobené (čierna)"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "zdobené (priehľadné)"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "ZTLM alebo definuj kľúče"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "ľubovoľnú klávesu"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "Čas+Info"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "Čas+Trvanie+Info"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "Mini-EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "Čas+Dĺžka+Info"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "polovica vľavo"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "polovica vpravo"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "Rámček x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "Riadok"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "žiadny bar"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "žiadny Rámček"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "Spád"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "Hrany tieňa"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "Normalne"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+Pozícia pod"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "Picon+Pozícia vľavo"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "Picon+Pozícia vpravo"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "Umiestnenie"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "Meno"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "Vypnuté"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "Aktívný"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "Aktívný+Neaktívny"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "len použitý časovač"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "použiť čas dodania"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "žiaden celkový časovač"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "zobraz celkový časovač"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "jeden riadok"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "dva riadky"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "Dostupná pamäť"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "Voľná pamäť"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "na celú obrazovku"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "TV+OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "áno okrem nahrávok"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "V"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "VSV"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "VJV"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "S"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "SV"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "SSV"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "SSZ"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "SZ"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "J"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "JV"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "JJV"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "JJZ"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "JZ"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "Z"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "ZSZ"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "ZJZ"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%d.%m.%Y - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%d.%m.%y %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%d-%b-%Y"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "Nahraj aktívny konfig. súbor"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "Načítať predvolené hodnoty / Prázdna konfigurácia"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "Uložiť konfig do súboru... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "Nahraj súbor : %s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "Zmazať súbor?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "zmazané"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "aktuálne nastavené : %s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux nastavenie"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "Zrušiť"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "Uložiť"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "Reštart zobrazovačov"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "Nastaviť On >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "žiadne LCD1 Obrazkové data"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "žiadne LCD2 Obrazkové data"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "žiadne LCD3 Obrazkové data"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "LCD4linux povolené"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1 Typ"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1 otočiť"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1 farba pozadia"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1 obrázok pozadia [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1 Jas"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1 Nočná redukcia"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1 obnova"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2 Typ"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2 otočiť"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2 farba pozadia"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2 obrázok pozadia [ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2 Jas"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2 Nočná redukcia"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2 obnova"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3 Typ"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3 otočiť"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3 farba pozadia"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3 obrázok pozadia [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3 Jas"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3 Nočná redukcia"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3 obnova"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "Box-Skin-LCD rozmery"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD Ofset"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "Box-Skin-LCD Farba"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD povoliť zap. mód"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD povoliť média mód"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD povoliť čakací mód"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [čas zobrazenia]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- ktoré LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- zobraz v móde"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- veľkosť OSD"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- Pozadie/Priehľadnosť"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- rýchly snímok nízkej kvality"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "Vyskakovací text"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- Vymazať kľúč"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- veľkosť písma"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- umiestnenie"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- Zarovnanie"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- Farba"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- Farba pozadia"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- písmo"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "Aktívna obrazovka"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "Výber prepínača obrazovky - Obrazovka"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "Výber prepínača obrazovky - LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "Obrazovky použité na výmenu"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "Obrazovka 1 čas zmeny"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- čas zmeny obrazovky 2"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- čas zmeny obrazovky 3"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- čas zmeny obrazovky 4"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- čas zmeny obrazovky 5"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- čas zmeny obrazovky 6"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- čas zmeny obrazovky 7"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- čas zmeny obrazovky 8"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- čas zmeny obrazovky 9"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "Obrázok čas zmeny"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "Zoradenie obrázkov"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "Obrázok rekurzívny priečinok"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "Kvalita obrázka na zmenu veľkosti"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "Obrázok čas rychlej aktualizácie [s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "Typ obrázka [len obrázok]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "Typ obrázka pozadia"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "Počasie - výber providera"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "Počasie API-key OpenWeatherMap"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "Počasie API-ID Key WeatherUnlocked"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "Počasie MSN (pre Mesto 1)"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "Počasie MSN (pre Mesto 2)"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "Počasie-Ikona-Cesta [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "Počasie-Ikona zväčšenie"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "Počasie farba nízkej  (mínusovej) teploty"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "Počasie farba vysokej (plusovej) teploty"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "Počasie priehľadnosť"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "Počasie jednotky rýchlosti vetra"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "Počasie smer a rýchlosť vetra"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "Počasie pravdepodobnosť dažďa"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- zväčšenie dažďa"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- farba dažďa"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- dážď používa farbu 2 z"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- farba dažďa 2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "Väder Luftfuktighet Färg"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "Počasie riadky"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "Počasie sípky trendov"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "Počasie rozšírené info"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- Extra zväčšenie"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- zobraz teplotu ochladenia ak je rozdiel"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- Extra farba mesta"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- Extra farba ochladenia"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2 Min rozsah"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2 Max rozsah"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "URL počasia"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "Cesta k ikone mesiaca [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "Obrázok záznamu [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "Zmena dvoj-stlačením tlačidla"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "Kľúč na zmenu obrazovky"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "Klávesa pre zapnutie / vypnutie obrazovky"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall cesta k obrázkom [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall počet riadkov na vstupny údaj"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall počet položiek zoznamu"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall počet obrázkov"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall orientácia obrázka"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall priehľadnosť obrázka"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall vyhľadávanie obrázkov"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall odobrať volania po hodinách"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall čas vyskakovaieho okna"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall vyskakovací LCD"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall farba vyskakovacieho okna"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall obrázok rámčeka [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "Kalendár ics-cesta [ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "Kalendár ics-URL"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "Kalendár plánovač"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "Kalendár farba soboty"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "Kalendár farba nedele"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "Kalendár hrúbka čiary"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "Kalendár denny prehľad"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "Kalendár korekcia časovej zóny"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "Kalendár priehľadnosť"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "Kalendár čas obnovy"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "Ladička Farba"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "Ladička Farba Aktívny"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "Ladička Farba Zapnúť"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "Najprv prehľadať kanál"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T korekcia kvality signálu"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "Písmo celkovo [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "Písmo1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "Písmo 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "Písmo 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "Font 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "Font 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "Pošta 1 pripojenie"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "Pošta 1 server"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "Pošta 1 [Zobrazované meno:]Meno používateľa"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "Pošta 1 heslo"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "Pošta 2 pripojenie"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "Pošta 2 server"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "Pošta 2 [Zobrazované meno:]Meno používateľa"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "Pošta 2 heslo"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "Pošta 3 pripojenie"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "Pošta 3 server"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "Pošta 3 [Zobrazované meno:]Meno používateľa"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "Pošta 3 heslo"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "Pošta 4 pripojenie"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "Pošta 4 server"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "Pošta 4 [Zobrazované meno:]Meno používateľa"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "Pošta 4 heslo"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "Pošta 5 pripojenie"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "Pošta 5 server"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "Pošta 5 [Zobrazované meno:]Meno používateľa"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "Pošta 5 heslo"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "Pošta obnovovací interval"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "Pošta IMAP limit na posledné dni"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "Pošta zobraz prázdne kontá"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "Pošta zobraz dátum"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "Pošta skryť adresy"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "Vzdialený Box 1 [zobrazované meno:]IP/Meno"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Vzdialený Box 2 [zobrazované meno:]IP/Meno"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "Vzdialený Box 3 [zobrazované meno:]IP/Meno"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Vzdialený Box 4 [zobrazované meno:]IP/Meno"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Vzdialený Box 5 [zobrazované meno:]IP/Meno"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "Vzdialený Box obnova v minútach"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "Vzdialený Box 1 [zobrazované meno:]IP/Meno"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "Vzdialený Box obnova v minútach"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW Konvertor čas obnovy"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "Použiť WWW konvertor"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "WWW ApiKey z cloudconvert.org"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "WWW ApiKey z convertapi.com"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF aktualizácia [s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF typ aktualizácie"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF Inicializácia oneskorenie"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP zakáž"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF vzhľad"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "Uložiť ako obrázok pre WebIF"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG stream pre LCD 1 povoliť"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG Stream LCD 1 porty"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG stream pre LCD 1 Virtuálny jas"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG stream pre LCD 2 povoliť"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG Stream LCD 2 porty"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG stream pre LCD 2 Virtuálny jas"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG stream pre LCD 3 povoliť"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG Stream LCD 3 porty"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG stream pre LCD 2 Virtuálny jas"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG cyklus"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "MJPEG Reštartujte pri chybe"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG režim hlavičky"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "Sonos Časový limit ping [ms]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "Sonos Prehrať šek"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "Sonos Obnoviť [s]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Časový limit ping [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound Prehrať šek"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound Obnoviť [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "MusicCast IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast Server IP [optional]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "MusicCast Časový limit ping [ms]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast Prehrať šek"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast Obnoviť [s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "MusicCast Obal"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD voliteľná šírka"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD voliteľná výška"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD voliteľná šírka 2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD voliteľná výška 2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "LCD Vypnuté pri vypnutí"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "Časovanie ! vypočet všetkých časov na Čas/5*2 v rýchlom móde"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "Oneskorenie zobrazovača [ms]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "Témy pre LCD"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "Zobraz chybové hlásenia"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "Zobraz 'žiadne ....' hlásenia"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "Úložné zariadenia: Vynútiť čítanie"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "Úložné zariadenia: Farba späť"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "Úložné zariadenia: Farebná lišta"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "Úložné zariadenia: Farba plná"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "Kontrola siete aktívna"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "Prepnúť FrameBuffer [ak je to možné]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "Cesta zálohy konfig. [ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "Konfigurácia obnova všetkých nastavení"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "Logovanie > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- Podsvietenie vyp. [ Zap.=Vyp.]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- Podsvietenie zap"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- Podsvietenie cez víkend vyp. [ Zap.=Vyp.]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- Podsvietenie cez víkend zap"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD Automatické vypnutie"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "Pozadie"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- Obrázok [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon veľkosť"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- rozdelená obrazovka"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- celá obrazovka"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- veľkosť textu"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- priehľadnosť"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon cesta [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon cesta 2 [ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon Cache cesta [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "Hodiny"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  Typ"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- Analogové Hodiny"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- rozstup"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- veľkosť"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- hrany tieňa"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "Hodiny 2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "Názov kanálu"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- maximum riadkov"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- dĺžka"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "Číslo kanálu"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "Info o programe"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- Typ"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "Program Info 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "Info o ďalšom programe"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "Rozšírený popis"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- prázdne použite informáciu"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "Priebeh"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- Farebný text"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- Okraj"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- tieňované"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- Jednotka min"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "Informácie"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- Tuner nfo"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- snímače"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- CPU"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "Informácie 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "Stĺpec kvality signálu"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- spád"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- rozsah stĺpca kvality signálu na Min"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- rozsah stĺpca kvality signálu na Max"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "Satelit"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "Poskytovateľ"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "Použitý tuner"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- len aktívny tuner"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "Ďalší časovač udalostí"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "Hlasitosť"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "Stíšiť"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "Audio/Video"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "Stav siete [Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- zobraz stav"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- čas vypršania [ms]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- sieťové meno :Adresa"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "Externá adresa IP"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- externá adresa URL IP"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "Pamäťové-zariadenia"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- bez varovania"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- extra Info"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- meno zariadenia"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- zväčšenie"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- typ počasia"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "Počasie 2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "Meteo stanica"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- Stanica"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- Modul"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- Definovaný používateľom"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- Základ"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- Meno"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- Farba 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- Farba 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- Farba 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- Farba 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- Farba 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Farba 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2 Indikátor"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- dĺžka [Bar]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo Komfortný Indikátor"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "Fáza mesiaca"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- Informačné linky"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- Šípky trendov"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "Východ slnka"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "Zobraz oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- súbor [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "Zobraz ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "Zobraz textový súbor"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "Zobraz textový súbor 2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "Zobraz textový súbor 3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "Zobraz HTTP Text"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "Konvertor web stránok"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP šírka"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP výška"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- orezanie z X"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- orezanie z Y"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- šírka orezania [vyp. = 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- výška orezania [vyp. = 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "Zobraz obrázok"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- súbor alebo cesta [ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- max výška"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- rýchla aktualizácia"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "Zobraz obrázok 2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "Zobraz obrázok 3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "Zobraz obrázok 4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- riadky"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- e-mailové konto"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- max šírka"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "Vzdialený Box"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- veľkosť obrázka"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- umiestnenie obrázka"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- zarovnanie obrázka"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- rozmiestnenie"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- Farba pozadia aktuálneho dňa"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- farba titulku"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "Zoznam dátumov"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "Stĺpec ikon udalosti"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- vyskakovacia obrazovka"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- vyskakovacie LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "Zobraziť text  1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- Text"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "Zobraziť text 2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "Obdĺžnik 1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- pozícia x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- pozícia y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- veľkosť x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- veľkosť y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "Obdĺžnik 2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "Záznam"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "Zobraz - zrkadlenie TV"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- použité obrazovky na výmenu"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "Titulok"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "Informácie"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "Zobraz obálku"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- prehľadávaná cesta [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- Nájdite súbor obalu  [ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- predvolená obálka [ok]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- najprv Picon"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- Orezané"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- Stiahnite si obálku"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- Typ sťahovania"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Kľúč Google API console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "LCD Displej"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Režim zobrazenia je Mode on"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "Nastaviť Media >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Režim zobrazenia MediaPlayer"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "Nastaviť Idle >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Režim zobrazenia Idle"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "Nastaviť Global >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "Zvoľ priečinok"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "Zvoľ súbor"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "Zvoľ písmo"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s -Súčasná hodnota: %s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3843,95 +4076,95 @@ msgstr ""
 "Je potrebné reštartovať GUI aby sa aplikovali zmeny.\n"
 "Chceš restartovať GUI teraz?"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "Reštartovať GUI teraz?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "Vnútorné"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "Vonkajšie"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "Dážď"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "Vietor"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "Nový mesiac"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "Prvá štvrtina"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "Dorastajúci kosáčik"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "Dorastajúci mesiac"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "Spln mesiaca"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "Ubúdajúci mesiac"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "Ubúdajúci kosáčik"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "Posledná štvrtina"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "Obrázok nie je k dispozícii"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "žiaden časovač"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM nebeží"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "žiadne volania"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d Správ  %d Nové  %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "nenainštalovaný Netatmo-Plugin"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux povolený"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4Linux povolený"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "Prepínač obrazovky LCD4linux"
 
@@ -3949,111 +4182,3 @@ msgstr "Prepínač obrazovky LCD4linux"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "Počasie Smer vetra"
-
-#~ msgid "Backup Config"
-#~ msgstr "Záloha cfg"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "Box-Skin-LCD"
-
-#~ msgid "Crashlog"
-#~ msgstr "Chybový výpis"
-
-#~ msgid "Delete"
-#~ msgstr "Zmazať"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "Zmazanie log súboru"
-
-#~ msgid "Download Logfile"
-#~ msgstr "Stiahnuť log súbor"
-
-#~ msgid "Element"
-#~ msgstr "Nastavenia"
-
-#~ msgid "Exec"
-#~ msgstr "Vykonať"
-
-#~ msgid "Filename"
-#~ msgstr "Názov súboru"
-
-#~ msgid "Font"
-#~ msgstr "Písmo"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "Vyžaduje sa reštart GUI"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "IP zabezpečenie nie je podporované v box-e"
-
-#~ msgid "Key"
-#~ msgstr "Kľúč"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "Zoznam úložných zariadení"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG Stream"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "Žiadny alebo nesprávny zvolený súbor, skús najprv správny súbor !"
-
-#~ msgid "OSD"
-#~ msgstr "OSD"
-
-#~ msgid "Parent Directory"
-#~ msgstr "Nadradený adresár"
-
-#~ msgid "Picture"
-#~ msgstr "Obrázok"
-
-#~ msgid "Popup-Text"
-#~ msgstr "Vyskakovací-text"
-
-#~ msgid "Restore Config"
-#~ msgstr "Obnova cfg"
-
-#~ msgid "Save Config"
-#~ msgstr "Ulož cfg"
-
-#~ msgid "Screen"
-#~ msgstr "Obrazovka"
-
-#~ msgid "Show"
-#~ msgstr "Zobraziť"
-
-#~ msgid "Show Externals"
-#~ msgstr "Zobraz vonkajšie"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "Ladička"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW konvertor"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "kopírovať do pohotovostných"
-
-#~ msgid "copy to Media"
-#~ msgstr "kopírovať do Média"
-
-#~ msgid "copy to On"
-#~ msgstr "kopírovať do aktívných"
-
-#~ msgid "other"
-#~ msgstr "iné"
-
-#~ msgid "set Settings"
-#~ msgstr "aktivuj nastavenia"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "zastav výmenu obrazoviek"

--- a/LCD4linux/po/tr.po
+++ b/LCD4linux/po/tr.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:10+0100\n"
+"PO-Revision-Date: 2024-03-12 18:23+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: plugin.py:263
 msgid "Fri"
@@ -637,7 +637,7 @@ msgstr ""
 
 #: plugin.py:315
 msgid "Current Temperature (-C)"
-msgstr "şuanki sıcaklık (-C)"
+msgstr "Mevcut Sıcaklık (-C)"
 
 #: plugin.py:315 plugin.py:316
 msgid "Current"
@@ -645,7 +645,7 @@ msgstr ""
 
 #: plugin.py:316
 msgid "Current Temperature"
-msgstr "şuanki sıcaklık"
+msgstr "Mevcut Sıcaklık"
 
 #: plugin.py:317
 msgid "All"
@@ -1514,7 +1514,7 @@ msgstr "EPG"
 
 #: plugin.py:413
 msgid "Now/Next"
-msgstr "şimdiki/sonraki"
+msgstr "Şimdi/Önümüzdeki"
 
 #: plugin.py:427
 msgid "normal"
@@ -1832,15 +1832,15 @@ msgstr ""
 
 #: plugin.py:896 plugin.py:1387 plugin.py:1945
 msgid "Offline"
-msgstr "çevrimdışı"
+msgstr "Çevrimdışı"
 
 #: plugin.py:896 plugin.py:1387 plugin.py:1945
 msgid "Online"
-msgstr "çevrimiçi"
+msgstr "Çevrimiçi"
 
 #: plugin.py:896 plugin.py:1387 plugin.py:1945
 msgid "Online+Offline"
-msgstr "çevrimiçi+çevrimdışı"
+msgstr "Çevrimiçi+Çevrimdışı"
 
 #: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
 #: plugin.py:1982
@@ -2014,7 +2014,7 @@ msgstr ""
 
 #: plugin.py:5534
 msgid "Mode"
-msgstr "mod"
+msgstr "Mod"
 
 #: plugin.py:5544
 msgid "Cancel"
@@ -3536,7 +3536,7 @@ msgstr ""
 
 #: plugin.py:6418 plugin.py:7151 plugin.py:7600
 msgid "Show oscam.lcd"
-msgstr "oscam.lcd 'yi göster"
+msgstr "oscam.lcd'yi göster"
 
 #: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
 #: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
@@ -3546,7 +3546,7 @@ msgstr ""
 
 #: plugin.py:6428
 msgid "Show ecm.info"
-msgstr "ecm.info 'yu göster"
+msgstr "ecm.info adresini göster"
 
 #: plugin.py:6437 plugin.py:7092 plugin.py:7609
 msgid "Show Textfile"
@@ -3853,7 +3853,7 @@ msgstr ""
 
 #: plugin.py:8198
 msgid "Restart GUI now?"
-msgstr "şimdi sistemi yeniden başlat ?"
+msgstr "GUI'yi şimdi yeniden başlatalım mı?"
 
 #: plugin.py:8780
 msgid "Indoor"

--- a/LCD4linux/po/zh_CN.po
+++ b/LCD4linux/po/zh_CN.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-27 17:58+0100\n"
-"PO-Revision-Date: 2023-02-27 18:11+0100\n"
+"POT-Creation-Date: 2024-03-12 18:03+0100\n"
+"PO-Revision-Date: 2024-03-12 18:24+0100\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: 孤独之剑 <haotzyy1970@163.com>\n"
 "Language: zh_CN\n"
@@ -12,3832 +12,4065 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generated: TM2TURK by thawtes\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-SourceCharset: UTF-8\n"
 
-#: plugin.py:263
-msgid "Fri"
-msgstr "周五"
-
-#: plugin.py:263
-msgid "Mon"
-msgstr "周一"
-
-#: plugin.py:263
-msgid "Sat"
-msgstr "周六"
-
-#: plugin.py:263
-msgid "Sun"
-msgstr "周日"
-
-#: plugin.py:263
-msgid "Thur"
-msgstr "周四"
-
-#: plugin.py:263
-msgid "Tue"
-msgstr "周二"
-
-#: plugin.py:263
-msgid "Wed"
-msgstr "周三"
-
-#: plugin.py:288
-msgid "black"
-msgstr "黑色"
-
-#: plugin.py:288
-msgid "white"
-msgstr "白色"
-
-#: plugin.py:289
-msgid "gray"
-msgstr "灰色"
-
-#: plugin.py:289
-msgid "silver"
-msgstr "银色"
-
-#: plugin.py:289
-msgid "slategray"
-msgstr "青灰色"
-
-#: plugin.py:290
-msgid "aquamarine"
-msgstr "藍綠色"
-
-#: plugin.py:291
-msgid "gold"
-msgstr "金色"
-
-#: plugin.py:291
-msgid "greenyellow"
-msgstr "黄绿色"
-
-#: plugin.py:291
-msgid "yellow"
-msgstr "黄色"
-
-#: plugin.py:292
-msgid "darkorange"
-msgstr "深橙色"
-
-#: plugin.py:292
-msgid "darkred"
-msgstr "深红"
-
-#: plugin.py:292
-msgid "indianred"
-msgstr "印度红"
-
-#: plugin.py:292
-msgid "orange"
-msgstr "橙色"
-
-#: plugin.py:292
-msgid "orangered"
-msgstr "橘红色"
-
-#: plugin.py:292
-msgid "red"
-msgstr "红色"
-
-#: plugin.py:292
-msgid "tomato"
-msgstr "番茄"
-
-#: plugin.py:293
-msgid "darkgreen"
-msgstr "深绿色"
-
-#: plugin.py:293
-msgid "green"
-msgstr "绿色"
-
-#: plugin.py:293
-msgid "lawngreen"
-msgstr "草坪绿"
-
-#: plugin.py:293
-msgid "lightgreen"
-msgstr "浅绿色"
-
-#: plugin.py:293
-msgid "lime"
-msgstr "幸福绿"
-
-#: plugin.py:294
-msgid "blue"
-msgstr "蓝色"
-
-#: plugin.py:294
-msgid "blueviolet"
-msgstr "紫罗兰色"
-
-#: plugin.py:294
-msgid "cadetblue"
-msgstr "灰蓝色"
-
-#: plugin.py:294
-msgid "cornflowerblue"
-msgstr "浅蓝色"
-
-#: plugin.py:294
-msgid "darkblue"
-msgstr "深蓝色"
-
-#: plugin.py:294
-msgid "indigo"
-msgstr "靛藍"
-
-#: plugin.py:294
-msgid "lightblue"
-msgstr "浅蓝"
-
-#: plugin.py:295
-msgid "cyan"
-msgstr "青色"
-
-#: plugin.py:295
-msgid "darkorchid"
-msgstr "深紫色"
-
-#: plugin.py:295
-msgid "deeppink"
-msgstr "深粉红色"
-
-#: plugin.py:295
-msgid "magenta"
-msgstr "紫紅色"
-
-#: plugin.py:295
-msgid "violet"
-msgstr "紫罗兰色"
-
-#: plugin.py:296
-msgid "brown"
-msgstr "棕色"
-
-#: plugin.py:296
-msgid "moccasin"
-msgstr "鹿皮黄色"
-
-#: plugin.py:296
-msgid "olive"
-msgstr "橄榄"
-
-#: plugin.py:296
-msgid "rosybrown"
-msgstr "玫瑰棕色"
-
-#: plugin.py:296
-msgid "sandybrown"
-msgstr "沙棕色"
-
-#: plugin.py:298
-msgid "Screen 1+2"
-msgstr "屏幕1 + 2"
-
-#: plugin.py:298
-msgid "Screen 1+2+3"
-msgstr "屏幕1 + 2 + 3"
-
-#: plugin.py:298
-msgid "Screen 1+2+3+4"
-msgstr "屏幕1 + 2 + 3 + 4"
-
-#: plugin.py:298
-msgid "Screen 1+2+4"
-msgstr "屏幕1 + 2 + 4"
-
-#: plugin.py:298
-msgid "Screen 1+3"
-msgstr "屏幕1 + 3"
-
-#: plugin.py:298
-msgid "Screen 1+3+4"
-msgstr "屏幕1 + 3 + 4"
-
-#: plugin.py:298
-msgid "Screen 1+3+5+7+9"
-msgstr "屏幕1 + 3 + 5 + 7 + 9"
-
-#: plugin.py:298
-msgid "Screen 1+4"
-msgstr "屏幕1 + 4"
-
-#: plugin.py:298
-msgid "Screen 2+3"
-msgstr "屏幕2 + 3"
-
-#: plugin.py:298
-msgid "Screen 2+3+4"
-msgstr "屏幕2 + 3 + 4"
-
-#: plugin.py:298
-msgid "Screen 2+4"
-msgstr "屏幕2 + 4"
-
-#: plugin.py:298
-msgid "Screen 2+4+6+8"
-msgstr "屏幕2 + 4 + 6 + 8"
-
-#: plugin.py:298
-msgid "Screen 3+4"
-msgstr "屏幕3 + 4"
-
-#: plugin.py:298
-msgid "Screen 5-8"
-msgstr "屏幕5-8"
-
-#: plugin.py:298
-msgid "Screen 5-9"
-msgstr "屏幕5-9"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-5"
-msgstr "屏幕1-5"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-6"
-msgstr "屏幕1-6"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-7"
-msgstr "屏幕1-7"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-8"
-msgstr "屏幕1-8"
-
-#: plugin.py:298 plugin.py:299
-msgid "Screen 1-9"
-msgstr "屏幕1-9"
-
-#: plugin.py:298 plugin.py:299 plugin.py:300
-msgid "Screen 1"
-msgstr "屏幕1"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 2"
-msgstr "屏幕2"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 3"
-msgstr "屏幕3"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 4"
-msgstr "屏幕4"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 5"
-msgstr "屏幕5"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 6"
-msgstr "屏幕6"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 7"
-msgstr "屏幕7"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 8"
-msgstr "屏幕8"
-
-#: plugin.py:298 plugin.py:300
-msgid "Screen 9"
-msgstr "屏幕9"
-
-#: plugin.py:298 plugin.py:301 plugin.py:334 plugin.py:336 plugin.py:376
-#: plugin.py:385 plugin.py:386 plugin.py:400 plugin.py:459 plugin.py:482
-#: plugin.py:483 plugin.py:508 plugin.py:509 plugin.py:614 plugin.py:631
-#: plugin.py:640 plugin.py:654 plugin.py:663 plugin.py:673 plugin.py:745
-#: plugin.py:914 plugin.py:1050 plugin.py:1125 plugin.py:1133 plugin.py:1144
-#: plugin.py:1155 plugin.py:1165 plugin.py:1175 plugin.py:1185 plugin.py:1193
-#: plugin.py:1258 plugin.py:1266 plugin.py:1277 plugin.py:1405 plugin.py:1589
-#: plugin.py:1682 plugin.py:1693 plugin.py:1703 plugin.py:1713 plugin.py:1737
-#: plugin.py:1745 plugin.py:1759 plugin.py:1768 plugin.py:1778 plugin.py:1818
-#: plugin.py:1826 plugin.py:1838 plugin.py:1846 plugin.py:1857 plugin.py:1963
-#: plugin.py:2052 plugin.py:2124 plugin.py:2135 plugin.py:2146 plugin.py:2156
-#: plugin.py:2166 plugin.py:2176 plugin.py:2184 plugin.py:2242 plugin.py:2256
-#: plugin.py:2265 plugin.py:2275 plugin.py:2315 plugin.py:2323
-msgid "off"
-msgstr "关闭"
-
-#: plugin.py:299
-msgid "Screen 1-2"
-msgstr "屏幕1-2"
-
-#: plugin.py:299
-msgid "Screen 1-3"
-msgstr "屏幕1-3"
-
-#: plugin.py:299
-msgid "Screen 1-4"
-msgstr "屏幕1-4"
-
-#: plugin.py:301 plugin.py:1838
-msgid "on"
-msgstr "启用"
-
-#: plugin.py:302
-msgid "2h"
-msgstr "2小时"
-
-#: plugin.py:302
-msgid "3h"
-msgstr "3小时"
-
-#: plugin.py:302
-msgid "3min"
-msgstr "3分钟"
-
-#: plugin.py:302
-msgid "40s"
-msgstr "40s"
-
-#: plugin.py:302
-msgid "4min"
-msgstr "4分钟"
-
-#: plugin.py:302
-msgid "50s"
-msgstr "50s"
-
-#: plugin.py:302
-msgid "5h"
-msgstr "5小时"
-
-#: plugin.py:302
-msgid "5s"
-msgstr "5秒"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "10s"
-msgstr "10秒"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "15s"
-msgstr "15秒"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "1min"
-msgstr "1分钟"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "20s"
-msgstr "20s"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "2min"
-msgstr "2分钟"
-
-#: plugin.py:302 plugin.py:466 plugin.py:471 plugin.py:476
-msgid "30s"
-msgstr "30秒"
-
-#: plugin.py:302 plugin.py:530
-msgid "10min"
-msgstr "10分钟"
-
-#: plugin.py:302 plugin.py:530
-msgid "5min"
-msgstr "5分钟"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579
-msgid "20min"
-msgstr "20分钟"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "30min"
-msgstr "30分钟"
-
-#: plugin.py:302 plugin.py:530 plugin.py:579 plugin.py:1196
-msgid "60min"
-msgstr "60分钟"
-
-#: plugin.py:303
-msgid "LCD 1+2"
-msgstr "LCD 1+2"
-
-#: plugin.py:303
-msgid "LCD 1+2+3"
-msgstr "LCD 1+2+3"
-
-#: plugin.py:303
-msgid "LCD 1+3"
-msgstr "LCD 1+3"
-
-#: plugin.py:303
-msgid "LCD 2+3"
-msgstr "LCD 2+3"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: plugin.py:303 plugin.py:304
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: plugin.py:304
-msgid "LCD 1-3"
-msgstr "LCD 1-3"
-
-#: plugin.py:305
-msgid "Corby@Pearl 128x128"
-msgstr "Corby @珍珠128x128"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 240x320"
-msgstr "珍珠（或相容的LCD）240x320"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x240"
-msgstr "珍珠（或相容的LCD）320x240"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 320x480"
-msgstr "珍珠（或相容的LCD）320x480"
-
-#: plugin.py:305
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "珍珠（或相容的LCD）480x320"
-
-#: plugin.py:306
-msgid "Samsung SPF-72H 800x480"
-msgstr "三星SPF-72H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-75H/76H 800x480"
-msgstr "三星SPF-75H / 76H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-83H 800x600"
-msgstr "三星SPF-83H 800x600"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H 800x480"
-msgstr "三星SPF-87H 800x480"
-
-#: plugin.py:306
-msgid "Samsung SPF-87H old 800x480"
-msgstr "三星SPF-87H旧800x480"
-
-#: plugin.py:307
-msgid "Samsung SPF-105P 1024x600"
-msgstr "三星SPF-105P 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H 1024x600"
-msgstr "三星SPF-107H 1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-107H old 1024x600"
-msgstr "三星SPF-107H旧的1024x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85H/86H 800x600"
-msgstr "三星SPF-85H / 86H 800x600"
-
-#: plugin.py:307
-msgid "Samsung SPF-85P/86P 800x600"
-msgstr "三星SPF-85P / 86P 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-1000P 1024x600"
-msgstr "三星SPF-1000P 1024x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-700T 800x600"
-msgstr "三星SPF-700T 800x600"
-
-#: plugin.py:308
-msgid "Samsung SPF-800P 800x480"
-msgstr "三星SPF-800P 800x480"
-
-#: plugin.py:309
-msgid "Internal TFT-LCD 400x240"
-msgstr "内置TFT-LCD 400x240"
-
-#: plugin.py:310
-msgid "Internal Box-Skin-LCD"
-msgstr "内盒式皮肤液晶显示器"
-
-#: plugin.py:311
-msgid "only Picture 1024x600"
-msgstr "仅图片1024x600"
-
-#: plugin.py:311
-msgid "only Picture 320x240"
-msgstr "仅图片320x240"
-
-#: plugin.py:311
-msgid "only Picture 800x480"
-msgstr "仅图片800x480"
-
-#: plugin.py:311
-msgid "only Picture 800x600"
-msgstr "仅图片800x600"
-
-#: plugin.py:311
-msgid "only Picture Custom Size"
-msgstr "仅图片自定义尺寸"
-
-#: plugin.py:311
-msgid "only Picture Custom Size 2"
-msgstr "仅图片自定义尺寸2"
-
-#: plugin.py:313
-msgid "Internal Vu+ Duo2 LCD 400x240"
-msgstr "内置Vu + Duo2 LCD 400x240"
-
-#: plugin.py:314
-msgid "128x32"
-msgstr "128x32"
-
-#: plugin.py:314
-msgid "128x64"
-msgstr "128x64"
-
-#: plugin.py:314
-msgid "132x64"
-msgstr "132x64"
-
-#: plugin.py:314
-msgid "220x176"
-msgstr "220x176"
-
-#: plugin.py:314
-msgid "255x64"
-msgstr "255x64"
-
-#: plugin.py:314
-msgid "400x240"
-msgstr "400x240"
-
-#: plugin.py:314
-msgid "480x320"
-msgstr "480x320"
-
-#: plugin.py:314
-msgid "720x405"
-msgstr "720x405"
-
-#: plugin.py:314
-msgid "800x480"
-msgstr "800x480"
-
-#: plugin.py:314
-msgid "96x64"
-msgstr "96x64"
-
-#: plugin.py:315
-msgid "2 Days 1 Line"
-msgstr "2天1行"
-
-#: plugin.py:315
-msgid "2 Days 2 Line"
-msgstr "2天2行"
-
-#: plugin.py:315
-msgid "4 Days 1 Line"
-msgstr "4天1行"
-
-#: plugin.py:315
-msgid "4 Days 2 Lines"
-msgstr "4天2行"
-
-#: plugin.py:315
-msgid "4 Days Vertical View"
-msgstr "4天垂直视图"
-
-#: plugin.py:315
-msgid "5 Days 1 Line"
-msgstr "5天1行"
-
-#: plugin.py:315
-msgid "5 Days 2 Lines"
-msgstr "5天2行"
-
-#: plugin.py:315
-msgid "5 Days Vertical View"
-msgstr "5天垂直视图"
-
-#: plugin.py:315
-msgid "Current Temperature (+C)"
-msgstr "当前温度（+C）"
-
-#: plugin.py:315
-msgid "Current Temperature (-C)"
-msgstr "当前温度（-C）"
-
-#: plugin.py:315 plugin.py:316
-msgid "Current"
-msgstr "当前"
-
-#: plugin.py:316
-msgid "Current Temperature"
-msgstr "当前温度"
-
-#: plugin.py:317
-msgid "All"
-msgstr "全部"
-
-#: plugin.py:317
-msgid "Temperature"
-msgstr "温度"
-
-#: plugin.py:317
-msgid "Temperature+Co2"
-msgstr "温度+二氧化碳"
-
-#: plugin.py:317
-msgid "Temperature+Co2+Pressure"
-msgstr "温度+ CO2 +压力"
-
-#: plugin.py:317
-msgid "Temperature+Humidity"
-msgstr "温度+湿度"
-
-#: plugin.py:318
-msgid "Module 1"
-msgstr "模块1"
-
-#: plugin.py:318
-msgid "Module 1+2"
-msgstr "模块1 + 2"
-
-#: plugin.py:318
-msgid "Module 1+2+3"
-msgstr "模块1 + 2 + 3"
-
-#: plugin.py:318
-msgid "Module 1+2+4"
-msgstr "模块1 + 2 + 4"
-
-#: plugin.py:318
-msgid "Module 1+3"
-msgstr "模块1 + 3"
-
-#: plugin.py:318
-msgid "Module 1+3+4"
-msgstr "模块1 + 3 + 4"
-
-#: plugin.py:318
-msgid "Module 1+4"
-msgstr "模块1 + 4"
-
-#: plugin.py:318
-msgid "Module 1-4"
-msgstr "模块1-4"
-
-#: plugin.py:318
-msgid "Module 1-5"
-msgstr "模块1-5"
-
-#: plugin.py:318
-msgid "Module 1-6"
-msgstr "模块1-6"
-
-#: plugin.py:318
-msgid "Module 2"
-msgstr "模块2"
-
-#: plugin.py:318
-msgid "Module 2+3"
-msgstr "模块2 + 3"
-
-#: plugin.py:318
-msgid "Module 2+3+4"
-msgstr "模块2 + 3 + 4"
-
-#: plugin.py:318
-msgid "Module 2+4"
-msgstr "模块2 + 4"
-
-#: plugin.py:318
-msgid "Module 2-6"
-msgstr "模块2-6"
-
-#: plugin.py:318
-msgid "Module 3"
-msgstr "模块3"
-
-#: plugin.py:318
-msgid "Module 3+4"
-msgstr "模块3 + 4"
-
-#: plugin.py:318
-msgid "Module 3-6"
-msgstr "模块3-6"
-
-#: plugin.py:318
-msgid "Module 4"
-msgstr "模块4"
-
-#: plugin.py:318
-msgid "Module 4-6"
-msgstr "模块4-6"
-
-#: plugin.py:318
-msgid "Module 5"
-msgstr "模块5"
-
-#: plugin.py:318
-msgid "Module 5-6"
-msgstr "模块5-6"
-
-#: plugin.py:318
-msgid "Module 6"
-msgstr "模块6"
-
-#: plugin.py:318
-msgid "userdefined"
-msgstr "用户自定义"
-
-#: plugin.py:320
-msgid "Bar"
-msgstr "条形图"
-
-#: plugin.py:320
-msgid "Bar+Value"
-msgstr "条形+数值"
-
-#: plugin.py:320
-msgid "Knob"
-msgstr "旋钮"
-
-#: plugin.py:320
-msgid "Knob+Value"
-msgstr "旋钮+值"
-
-#: plugin.py:321
-msgid "Analog"
-msgstr "模拟"
-
-#: plugin.py:321
-msgid "Analog+Date"
-msgstr "模拟量+日期"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday"
-msgstr "模拟+日期+周"
-
-#: plugin.py:321
-msgid "Analog+Date+Weekday 2"
-msgstr "模拟+日期+周 2"
-
-#: plugin.py:321
-msgid "Date"
-msgstr "日期"
-
-#: plugin.py:321
-msgid "Date+Time"
-msgstr "日期+时间"
-
-#: plugin.py:321
-msgid "Date+Time+Weekday"
-msgstr "日期+时间+工作日"
-
-#: plugin.py:321
-msgid "Flaps Design Date"
-msgstr "襟翼设计日期"
-
-#: plugin.py:321
-msgid "Flaps Design Weekday"
-msgstr "襟翼设计工作日"
-
-#: plugin.py:321
-msgid "Time"
-msgstr "时间"
-
-#: plugin.py:321
-msgid "Time+Weekday"
-msgstr "时间+工作日"
-
-#: plugin.py:321
-msgid "Weekday"
-msgstr "周日"
-
-#: plugin.py:322 plugin.py:335
-msgid "30%"
-msgstr "30%"
-
-#: plugin.py:322 plugin.py:335
-msgid "35%"
-msgstr "35%"
-
-#: plugin.py:322 plugin.py:335
-msgid "40%"
-msgstr "40%"
-
-#: plugin.py:322 plugin.py:335
-msgid "45%"
-msgstr "45%"
-
-#: plugin.py:322 plugin.py:335
-msgid "50%"
-msgstr "50%"
-
-#: plugin.py:322 plugin.py:335
-msgid "55%"
-msgstr "55%"
-
-#: plugin.py:322 plugin.py:335
-msgid "60%"
-msgstr "60%"
-
-#: plugin.py:322 plugin.py:335
-msgid "65%"
-msgstr "65%"
-
-#: plugin.py:322 plugin.py:335
-msgid "70%"
-msgstr "70%"
-
-#: plugin.py:322 plugin.py:335
-msgid "75%"
-msgstr "75%"
-
-#: plugin.py:322 plugin.py:335
-msgid "80%"
-msgstr "80%"
-
-#: plugin.py:322 plugin.py:335
-msgid "85%"
-msgstr "85%"
-
-#: plugin.py:322 plugin.py:335
-msgid "90%"
-msgstr "90%"
-
-#: plugin.py:322 plugin.py:335
-msgid "95%"
-msgstr "95%"
-
-#: plugin.py:322 plugin.py:335
-msgid "97%"
-msgstr "97%"
-
-#: plugin.py:322 plugin.py:335
-msgid "98%"
-msgstr "98%"
-
-#: plugin.py:322 plugin.py:336
-msgid "10%"
-msgstr "10%"
-
-#: plugin.py:322 plugin.py:336
-msgid "15%"
-msgstr "15%"
-
-#: plugin.py:322 plugin.py:336
-msgid "2%"
-msgstr "2%"
-
-#: plugin.py:322 plugin.py:336
-msgid "20%"
-msgstr "20%"
-
-#: plugin.py:322 plugin.py:336
-msgid "25%"
-msgstr "25%"
-
-#: plugin.py:322 plugin.py:336
-msgid "3%"
-msgstr "3%"
-
-#: plugin.py:322 plugin.py:336
-msgid "5%"
-msgstr "5%"
-
-#: plugin.py:322 plugin.py:629
-msgid "center"
-msgstr "居中"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "left"
-msgstr "左边"
-
-#: plugin.py:322 plugin.py:629 plugin.py:1122 plugin.py:1130 plugin.py:1734
-#: plugin.py:2121
-msgid "right"
-msgstr "右边"
-
-#: plugin.py:323
-msgid "Extended"
-msgstr "扩展"
-
-#: plugin.py:323
-msgid "Extended (Short)"
-msgstr "扩展（短）"
-
-#: plugin.py:323
-msgid "Short"
-msgstr "短"
-
-#: plugin.py:323
-msgid "Short (Extended)"
-msgstr "短（扩展）"
-
-#: plugin.py:323
-msgid "Short+Extended"
-msgstr "短+扩展"
-
-#: plugin.py:324
-msgid "Month"
-msgstr "月"
-
-#: plugin.py:324
-msgid "Month+Header"
-msgstr "月+标题"
-
-#: plugin.py:324
-msgid "Week"
-msgstr "周"
-
-#: plugin.py:324
-msgid "Week+Header"
-msgstr "周+标题"
-
-#: plugin.py:324
-msgid "no Calendar"
-msgstr "没有日历"
-
-#: plugin.py:325
-msgid "Dates 1 Line"
-msgstr "日期1行"
-
-#: plugin.py:325
-msgid "Dates 3 Lines"
-msgstr "日期3行"
-
-#: plugin.py:325
-msgid "Dates 5 Lines"
-msgstr "日期5行"
-
-#: plugin.py:325
-msgid "Dates 9 Lines"
-msgstr "日期9行"
-
-#: plugin.py:325
-msgid "Dates compact 2 Lines"
-msgstr "日期紧凑2行"
-
-#: plugin.py:325
-msgid "Dates compact 3 Lines"
-msgstr "日期紧凑3行"
-
-#: plugin.py:325 plugin.py:14353
-msgid "no Dates"
-msgstr "没有日期"
-
-#: plugin.py:326
-msgid "Underline"
-msgstr "下划线"
-
-#: plugin.py:326
-msgid "Underline 2"
-msgstr "下划线2"
-
-#: plugin.py:326 plugin.py:806 plugin.py:1365
-msgid "Frame"
-msgstr "框架"
-
-#: plugin.py:327
-msgid "Dates"
-msgstr "日期"
-
-#: plugin.py:327
-msgid "Dates compact"
-msgstr "日期紧凑"
-
-#: plugin.py:327
-msgid "Dates compact no Icon"
-msgstr "日期紧凑无图标"
-
-#: plugin.py:327
-msgid "Dates no Icon"
-msgstr "日期无图标"
-
-#: plugin.py:328
-msgid "no Icon"
-msgstr "无图标"
-
-#: plugin.py:328
-msgid "no Icon, with Targetnumber"
-msgstr "没有图标,有目标编号"
-
-#: plugin.py:328
-msgid "with Icon"
-msgstr "带图标"
-
-#: plugin.py:328
-msgid "with Icon & Targetnumber"
-msgstr "带有图标和目标编号"
-
-#: plugin.py:329
-msgid "C"
-msgstr "°C"
-
-#: plugin.py:329
-msgid "C + rpm"
-msgstr "C +转速"
-
-#: plugin.py:329
-msgid "C + rpm/2"
-msgstr "C + 转速 / 2"
-
-#: plugin.py:329
-msgid "rpm"
-msgstr "每分钟转数"
-
-#: plugin.py:329
-msgid "rpm/2"
-msgstr "转速/ 2"
-
-#: plugin.py:329 plugin.py:330 plugin.py:331 plugin.py:341 plugin.py:412
-#: plugin.py:415 plugin.py:444 plugin.py:446 plugin.py:451 plugin.py:558
-#: plugin.py:560 plugin.py:563 plugin.py:580 plugin.py:690 plugin.py:981
-#: plugin.py:1520 plugin.py:1727 plugin.py:2002
-msgid "no"
-msgstr "否"
-
-#: plugin.py:330
-msgid "% + BER"
-msgstr "％+误码率"
-
-#: plugin.py:330
-msgid "db"
-msgstr "分贝"
-
-#: plugin.py:330
-msgid "db + %"
-msgstr "分贝 + %"
-
-#: plugin.py:330
-msgid "db + % + BER"
-msgstr "分贝+％+误码率"
-
-#: plugin.py:330
-msgid "db + BER"
-msgstr "分贝+误码率"
-
-#: plugin.py:330 plugin.py:331
-msgid "%"
-msgstr "%"
-
-#: plugin.py:331
-msgid "% + Load@1min"
-msgstr "% + 负载@1分钟"
-
-#: plugin.py:331
-msgid "% + Load@5min"
-msgstr "% + 负载@ 5分钟"
-
-#: plugin.py:331
-msgid "Load@1min"
-msgstr "负荷@ 1分钟"
-
-#: plugin.py:331
-msgid "Load@5min"
-msgstr "负荷@ 5分钟"
-
-#: plugin.py:332
-msgid "show run"
-msgstr "显示运行"
-
-#: plugin.py:332
-msgid "show run+sleep"
-msgstr "显示运行+睡眠"
-
-#: plugin.py:333
-msgid "Always All"
-msgstr "总是"
-
-#: plugin.py:333
-msgid "Always New"
-msgstr "总是新的"
-
-#: plugin.py:333
-msgid "Only New"
-msgstr "只有新"
-
-#: plugin.py:334
-msgid "All Informations"
-msgstr "所有信息"
-
-#: plugin.py:334
-msgid "Distance only"
-msgstr "仅距离"
-
-#: plugin.py:334
-msgid "Distance+Illumination"
-msgstr "距离+照度"
-
-#: plugin.py:334
-msgid "Distance+Moonphase"
-msgstr "距离+月相"
-
-#: plugin.py:334
-msgid "Illumination only"
-msgstr "仅照明"
-
-#: plugin.py:334
-msgid "Illumination+Moonphase"
-msgstr "照明+月相"
-
-#: plugin.py:334
-msgid "Moonphase only"
-msgstr "仅月相"
-
-#: plugin.py:335
-msgid "100%"
-msgstr "100%"
-
-#: plugin.py:337
-msgid "1-2"
-msgstr "1-2"
-
-#: plugin.py:337
-msgid "1-3"
-msgstr "1-3"
-
-#: plugin.py:337
-msgid "1-4"
-msgstr "1-4"
-
-#: plugin.py:337
-msgid "1-5"
-msgstr "1-5"
-
-#: plugin.py:337 plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "1"
-msgstr "1"
-
-#: plugin.py:338
-msgid "IMAP"
-msgstr "IMAP"
-
-#: plugin.py:338
-msgid "IMAP-SSL"
-msgstr "IMAP-SSL"
-
-#: plugin.py:338
-msgid "Pop3"
-msgstr "Pop3"
-
-#: plugin.py:338
-msgid "Pop3-SSL"
-msgstr "Pop3-SSL"
-
-#: plugin.py:339
-msgid "Channel"
-msgstr "频道"
-
-#: plugin.py:339
-msgid "Channel+Title"
-msgstr "频道+标题"
-
-#: plugin.py:339
-msgid "Picon+Channel"
-msgstr "Picon +频道"
-
-#: plugin.py:339
-msgid "Picon+Channel+Title"
-msgstr "Picon +频道+标题"
-
-#: plugin.py:339 plugin.py:345 plugin.py:817 plugin.py:828 plugin.py:5969
-msgid "Picon"
-msgstr "皮康"
-
-#: plugin.py:340
-msgid "same color"
-msgstr "相同颜色"
-
-#: plugin.py:341
-msgid "yes +25%"
-msgstr "是+ 25％"
-
-#: plugin.py:341 plugin.py:444 plugin.py:446 plugin.py:558 plugin.py:560
-#: plugin.py:580 plugin.py:690 plugin.py:1727
-msgid "yes"
-msgstr "是"
-
-#: plugin.py:342
-msgid "vertically"
-msgstr "垂直"
-
-#: plugin.py:342 plugin.py:875 plugin.py:1463 plugin.py:1909
-msgid "horizontally"
-msgstr "水平"
-
-#: plugin.py:343
-msgid "4"
-msgstr "4"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:459 plugin.py:465
-#: plugin.py:470 plugin.py:475
-msgid "2"
-msgstr "2"
-
-#: plugin.py:343 plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470
-#: plugin.py:475
-msgid "3"
-msgstr "3"
-
-#: plugin.py:343 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "5"
-msgstr "5"
-
-#: plugin.py:343 plugin.py:5573 plugin.py:5716 plugin.py:7861 plugin.py:7877
-msgid "Global"
-msgstr "全局"
-
-#: plugin.py:344
-msgid "14"
-msgstr "14"
-
-#: plugin.py:344
-msgid "7"
-msgstr "7"
-
-#: plugin.py:344
-msgid "all"
-msgstr "全部"
-
-#: plugin.py:344 plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "30"
-msgstr "30"
-
-#: plugin.py:345
-msgid "Corner"
-msgstr "转角"
-
-#: plugin.py:345
-msgid "Corner+Timeshift"
-msgstr "转角+时移"
-
-#: plugin.py:345
-msgid "Picon+Timeshift"
-msgstr "Picon +时移"
-
-#: plugin.py:346
-msgid "only Progress Bar"
-msgstr "仅进度栏"
-
-#: plugin.py:347
-msgid "with Remaining Minutes"
-msgstr "剩余分钟"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 1.5)"
-msgstr "剩余分钟 (尺寸1.5)"
-
-#: plugin.py:347
-msgid "with Remaining Minutes (Size 2)"
-msgstr "剩余分钟 (大于2)"
-
-#: plugin.py:348
-msgid "with Percent"
-msgstr "带百分比"
-
-#: plugin.py:348
-msgid "with Percent (Size 1.5)"
-msgstr "带百分比 (尺寸1,5)"
-
-#: plugin.py:348
-msgid "with Percent (Size 2)"
-msgstr "与百分比（尺寸2）"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above)"
-msgstr "剩余分钟 (大于)"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 1.5)"
-msgstr "剩余分钟数（大于/尺寸1.5）"
-
-#: plugin.py:349
-msgid "with Remaining Minutes (above/Size 2)"
-msgstr "剩余分钟 (大于/尺寸2)"
-
-#: plugin.py:350
-msgid "with Percent (above)"
-msgstr "与百分比（大于）"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 1.5)"
-msgstr "百分比（大于/尺寸1.5）"
-
-#: plugin.py:350
-msgid "with Percent (above/Size 2)"
-msgstr "百分比（大于/尺寸2）"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below)"
-msgstr "剩下的几分钟 (低于)"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 1.5)"
-msgstr "剩余分钟数（低于/尺寸1.5）"
-
-#: plugin.py:351
-msgid "with Remaining Minutes (below/Size 2)"
-msgstr "剩余分钟数（低于/尺寸2）"
-
-#: plugin.py:352
-msgid "with Percent (below)"
-msgstr "百分比 (低于)"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 1.5)"
-msgstr "百分比（低于/尺寸1.5）"
-
-#: plugin.py:352
-msgid "with Percent (below/Size 2)"
-msgstr "百分比（低于/尺寸2）"
-
-#: plugin.py:353
-msgid "with Current 00:00"
-msgstr "当前00:00"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 1.5)"
-msgstr "当前00:00（尺寸1.5）"
-
-#: plugin.py:353
-msgid "with Current 00:00 (Size 2)"
-msgstr "当前00:00（尺寸2）"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above)"
-msgstr "当前00:00（以上）"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 1.5)"
-msgstr "当前00:00（高于/尺寸1.5）"
-
-#: plugin.py:354
-msgid "with Current 00:00 (above/Size 2)"
-msgstr "当前00:00（尺寸2以上）"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below)"
-msgstr "当前00:00（低于）"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 1.5)"
-msgstr "当前00:00（低于/尺寸1.5）"
-
-#: plugin.py:355
-msgid "with Current 00:00 (below/Size 2)"
-msgstr "当前00:00（下方/尺寸2）"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above)"
-msgstr "分钟/总计百分比 (大于/尺寸2)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 1.5)"
-msgstr "分钟/总计百分比 (大于/尺寸1.5)"
-
-#: plugin.py:356
-msgid "with Percent Minutes / Total (above/Size 2)"
-msgstr "分钟/总计百分比 (大于/尺寸2)"
-
-#: plugin.py:357
-msgid "with absolute Endtime"
-msgstr "绝对结束时间"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 1.5)"
-msgstr "绝对结束时间（尺寸1.5）"
-
-#: plugin.py:357
-msgid "with absolute Endtime (Size 2)"
-msgstr "带绝对结束时间 (尺寸2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above)"
-msgstr "分钟/总计百分比 (大于/尺寸2)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 1.5)"
-msgstr "分钟/总计百分比 (大于/尺寸1.5)"
-
-#: plugin.py:358
-msgid "with Minutes Total / Endtime (above/Size 2)"
-msgstr "分钟/总计百分比 (大于/尺寸2)"
-
-#: plugin.py:370
-msgid "Fastmode (2s)"
-msgstr "快速模式（2秒）"
-
-#: plugin.py:370
-msgid "Normal (5s)"
-msgstr "正常 (5秒)"
-
-#: plugin.py:386
-msgid "alphabetic"
-msgstr "按字母顺序排列"
-
-#: plugin.py:386
-msgid "random"
-msgstr "随机"
-
-#: plugin.py:387
-msgid "better/slow"
-msgstr "较好/缓慢"
-
-#: plugin.py:387
-msgid "low/fast (Picture only)"
-msgstr "低/快（仅图片）"
-
-#: plugin.py:387
-msgid "low/fast (all)"
-msgstr "低/快（全部）"
-
-#: plugin.py:389
-msgid "0.5"
-msgstr "0.5"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "10"
-msgstr "10"
-
-#: plugin.py:389 plugin.py:465 plugin.py:470 plugin.py:475
-msgid "20"
-msgstr "20"
-
-#: plugin.py:392
-msgid "JPG"
-msgstr "JPG"
-
-#: plugin.py:392
-msgid "PNG"
-msgstr "PNG"
-
-#: plugin.py:393
-msgid "cache + adjustment (high quality, slow)"
-msgstr "缓存+调整（高质量，慢）"
-
-#: plugin.py:393
-msgid "cache + adjustment (low quality, fast)"
-msgstr "缓存+调整（低质量，快）"
-
-#: plugin.py:393
-msgid "no cache + no adjustment"
-msgstr "没有缓存+没有调整"
-
-#: plugin.py:412
-msgid "Plug Tuner"
-msgstr "插头调谐器"
-
-#: plugin.py:412
-msgid "USB Tuner"
-msgstr "USB调谐器"
-
-#: plugin.py:413
-msgid "EPG"
-msgstr "EPG"
-
-#: plugin.py:413
-msgid "Now/Next"
-msgstr "现在/下一个"
-
-#: plugin.py:427
-msgid "normal"
-msgstr "正常"
-
-#: plugin.py:427
-msgid "reduced"
-msgstr "减少"
-
-#: plugin.py:431
-msgid "Javascript"
-msgstr "Java脚本"
-
-#: plugin.py:431
-msgid "Javascript no Refresh"
-msgstr "Java脚本无刷新"
-
-#: plugin.py:431
-msgid "Reload"
-msgstr "加载"
-
-#: plugin.py:435
-msgid "1 - normal"
-msgstr "1 - 正常"
-
-#: plugin.py:435
-msgid "2 - side by side"
-msgstr "2-并排"
-
-#: plugin.py:436
-msgid "MSN"
-msgstr "MSN"
-
-#: plugin.py:436
-msgid "OpenWeatherMap"
-msgstr "打开天气图"
-
-#: plugin.py:436
-msgid "WeatherUnlocked"
-msgstr "天气解锁"
-
-#: plugin.py:444 plugin.py:580
-msgid "alternative Copy-Mode/DM800hd (24bit)"
-msgstr "备用复制模式/ DM800hd（24位）"
-
-#: plugin.py:446
-msgid "yes + %"
-msgstr "是 + %"
-
-#: plugin.py:451
-msgid "yes, long"
-msgstr "是,很长"
-
-#: plugin.py:451
-msgid "yes, short"
-msgstr "是,简短"
-
-#: plugin.py:458
-msgid "km/h"
-msgstr "公里/小时"
-
-#: plugin.py:458
-msgid "m/s"
-msgstr "米/秒"
-
-#: plugin.py:465 plugin.py:470 plugin.py:475
-msgid "60"
-msgstr "60"
-
-#: plugin.py:477
-msgid "Coversearch"
-msgstr "封面搜索"
-
-#: plugin.py:477
+#: ..\WebConfigSite.py:28
+msgid "BlueSound"
+msgstr "BlueSound"
+
+#: ..\WebConfigSite.py:28
+msgid "Box-Skin-LCD"
+msgstr "盒式液晶显示器"
+
+#: ..\WebConfigSite.py:28
+msgid "Font"
+msgstr "字体"
+
+#: ..\WebConfigSite.py:28
+msgid "Key"
+msgstr "按键"
+
+#: ..\WebConfigSite.py:28
+msgid "MJPEG Stream"
+msgstr "MJPEG流"
+
+#: ..\WebConfigSite.py:28
+msgid "OSD"
+msgstr "OSD菜单"
+
+#: ..\WebConfigSite.py:28
+msgid "Picture"
+msgstr "图片"
+
+#: ..\WebConfigSite.py:28
+msgid "Popup-Text"
+msgstr "弹出式文本"
+
+#: ..\WebConfigSite.py:28
+msgid "Sonos"
+msgstr "Sonos"
+
+#: ..\WebConfigSite.py:28
+msgid "Tuner"
+msgstr "调谐器"
+
+#: ..\WebConfigSite.py:28
+msgid "WWW Converter"
+msgstr "WWW转换器"
+
+#: ..\WebConfigSite.py:28
+msgid "WebIF"
+msgstr "WebIF"
+
+#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+msgid "Screen"
+msgstr "屏幕"
+
+#: ..\WebConfigSite.py:28 ..\plugin.py:486
 msgid "MusicCast"
 msgstr "音乐广播"
 
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "0"
-msgstr "0"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "180"
-msgstr "180"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "270"
-msgstr "270"
-
-#: plugin.py:484 plugin.py:485 plugin.py:486
-msgid "90"
-msgstr "90"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495
-msgid "1 / min"
-msgstr "1/分钟"
-
-#: plugin.py:493 plugin.py:494 plugin.py:495 plugin.py:618
-msgid "always"
-msgstr "总是"
-
-#: plugin.py:496
-msgid "On+Media+Standby"
-msgstr "启用+多媒体+唤醒"
-
-#: plugin.py:496
-msgid "Standby"
-msgstr "待机"
-
-#: plugin.py:496 plugin.py:621 plugin.py:5567 plugin.py:6685 plugin.py:7867
-#: plugin.py:7871 plugin.py:8073
-msgid "Media"
-msgstr "媒体"
-
-#: plugin.py:496 plugin.py:5564 plugin.py:5957 plugin.py:7862 plugin.py:7866
-msgid "On"
-msgstr "打开"
-
-#: plugin.py:498
-msgid "32bit - color"
-msgstr "32位-颜色"
-
-#: plugin.py:498
-msgid "8bit - grayscale/color"
-msgstr "8位-灰度/彩色"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey"
-msgstr "2 x快进键"
-
-#: plugin.py:508
-msgid "2 x FastForwardKey Type 2"
-msgstr "2 x快进键类型2"
-
-#: plugin.py:508
-msgid "Long FastForwardKey"
-msgstr "长按快进键"
-
-#: plugin.py:508
-msgid "Long FastForwardKey Type 2"
-msgstr "长按快进键 类型 2"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x InfoKey"
-msgstr "2 X信息键"
-
-#: plugin.py:508 plugin.py:509
-msgid "2 x Mute"
-msgstr "2 x静音"
-
-#: plugin.py:508 plugin.py:509
-msgid "Long InfoKey"
-msgstr "长按信息键"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey"
-msgstr "2 X快速后退键"
-
-#: plugin.py:509
-msgid "2 x FastBackwardKey Type 2"
-msgstr "2 x快退键类型2"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey"
-msgstr "长按快速后退键"
-
-#: plugin.py:509
-msgid "Long FastBackwardKey Type 2"
-msgstr "长按快速后退键 类型 2"
-
-#: plugin.py:530 plugin.py:579
-msgid "15min"
-msgstr "15分钟"
-
-#: plugin.py:558
-msgid "yes, extended"
-msgstr "是,扩展"
-
-#: plugin.py:614
-msgid "Console normal"
-msgstr "控制台正常"
-
-#: plugin.py:614
-msgid "Logfile extensive"
-msgstr "日志文件扩展"
-
-#: plugin.py:614
-msgid "Logfile normal"
-msgstr "日志文件正常"
-
-#: plugin.py:618
-msgid "disabled"
-msgstr "已禁用"
-
-#: plugin.py:621
-msgid "Radio"
-msgstr "无线电"
-
-#: plugin.py:621
-msgid "Radio+Media"
-msgstr "广播+媒体"
-
-#: plugin.py:621
-msgid "TV+Radio"
-msgstr "电视/电台"
-
-#: plugin.py:621
-msgid "TV+Radio+Media"
-msgstr "电视+广播+媒体"
-
-#: plugin.py:621 plugin.py:1250
-msgid "TV"
-msgstr "电视"
-
-#: plugin.py:622
-msgid "TV (full)"
-msgstr "电视（完整）"
-
-#: plugin.py:622
-msgid "normal (full)"
-msgstr "正常（满）"
-
-#: plugin.py:622
-msgid "trimmed (black)"
-msgstr "修剪（黑色）"
-
-#: plugin.py:622
-msgid "trimmed (transparent)"
-msgstr "修剪（透明）"
-
-#: plugin.py:625
-msgid "MUTE or defined Keys"
-msgstr "静音或定义键"
-
-#: plugin.py:625
-msgid "any Key"
-msgstr "任意键"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Info"
-msgstr "信息"
-
-#: plugin.py:762 plugin.py:774 plugin.py:786 plugin.py:1333 plugin.py:1345
-msgid "Time+Info"
-msgstr "时间+信息"
-
-#: plugin.py:762 plugin.py:774 plugin.py:1333
-msgid "Time+Duration+Info"
-msgstr "时间+持续时间+信息"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Mini-EPG"
-msgstr "迷你EPG"
-
-#: plugin.py:786 plugin.py:1345
-msgid "Time+Length+Info"
-msgstr "时间+长度+信息"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half left"
-msgstr "半面向左转"
-
-#: plugin.py:801 plugin.py:1361
-msgid "half right"
-msgstr "半面向右转"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Frame x2"
-msgstr "框架 x2"
-
-#: plugin.py:806 plugin.py:1365
-msgid "Line"
-msgstr "行"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Bar"
-msgstr "没有进度条"
-
-#: plugin.py:806 plugin.py:1365
-msgid "no Frame"
-msgstr "无框架"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Gradient"
-msgstr "渐变色"
-
-#: plugin.py:808 plugin.py:1367
-msgid "Shadow Edges"
-msgstr "阴影边缘"
-
-#: plugin.py:808 plugin.py:1367 plugin.py:1728
-msgid "Normal"
-msgstr "正常"
-
-#: plugin.py:817
-msgid "Picon+Position below"
-msgstr "Picon+下方位置"
-
-#: plugin.py:817
-msgid "Picon+Position left"
-msgstr "皮康+左位置"
-
-#: plugin.py:817
-msgid "Picon+Position right"
-msgstr "皮康+位置右"
-
-#: plugin.py:817
-msgid "Position"
-msgstr "位置"
-
-#: plugin.py:817 plugin.py:828
-msgid "Name"
-msgstr "名称"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Offline"
-msgstr "离线"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online"
-msgstr "在线"
-
-#: plugin.py:896 plugin.py:1387 plugin.py:1945
-msgid "Online+Offline"
-msgstr "在线+离线"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "only use Timer"
-msgstr "仅使用定时器"
-
-#: plugin.py:940 plugin.py:1004 plugin.py:1424 plugin.py:1543 plugin.py:1894
-#: plugin.py:1982
-msgid "use lead-time"
-msgstr "使用提前期"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "no total Timer"
-msgstr "没有总计时器"
-
-#: plugin.py:941 plugin.py:1005 plugin.py:1425 plugin.py:1544 plugin.py:1895
-#: plugin.py:1983
-msgid "show total Timer"
-msgstr "显示总计时器"
-
-#: plugin.py:959 plugin.py:1498
-msgid "one line"
-msgstr "一行"
-
-#: plugin.py:959 plugin.py:1498
-msgid "two lines"
-msgstr "两行"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory available"
-msgstr "可用内存"
-
-#: plugin.py:981 plugin.py:1520 plugin.py:2002
-msgid "Memory free"
-msgstr "内存释放"
-
-#: plugin.py:1197
-msgid "cloudconvert.org"
-msgstr "cloudconvert.org"
-
-#: plugin.py:1197
-msgid "convertapi.com"
-msgstr "convertapi.com"
-
-#: plugin.py:1218 plugin.py:1227 plugin.py:1236 plugin.py:1245 plugin.py:1660
-#: plugin.py:1669 plugin.py:2205 plugin.py:2214 plugin.py:2223 plugin.py:2232
-msgid "full Screen"
-msgstr "全屏"
-
-#: plugin.py:1250
-msgid "TV+OSD"
-msgstr "电视+ OSD"
-
-#: plugin.py:1727
-msgid "yes except records"
-msgstr "是,除了录制"
-
-#: plugin.py:1728
-msgid "Google API"
-msgstr "Google API"
-
-#: plugin.py:2639
-msgid "E"
-msgstr "Ε"
-
-#: plugin.py:2639
-msgid "ENE"
-msgstr "东北偏东"
-
-#: plugin.py:2639
-msgid "ESE"
-msgstr "东南偏东"
-
-#: plugin.py:2639
-msgid "N"
-msgstr "N"
-
-#: plugin.py:2639
-msgid "NE"
-msgstr "东北方"
-
-#: plugin.py:2639
-msgid "NNE"
-msgstr "东北偏北"
-
-#: plugin.py:2639
-msgid "NNW"
-msgstr "西北偏北"
-
-#: plugin.py:2639
-msgid "NW"
-msgstr "西北"
-
-#: plugin.py:2639
-msgid "S"
-msgstr "南"
-
-#: plugin.py:2639
-msgid "SE"
-msgstr "东南"
-
-#: plugin.py:2639
-msgid "SSE"
-msgstr "东南偏南"
-
-#: plugin.py:2639
-msgid "SSW"
-msgstr "西南偏南"
-
-#: plugin.py:2639
-msgid "SW"
-msgstr "西南"
-
-#: plugin.py:2639
-msgid "W"
-msgstr "西"
-
-#: plugin.py:2639
-msgid "WNW"
-msgstr "西北偏西"
-
-#: plugin.py:2639
-msgid "WSW"
-msgstr "西南偏西"
-
-#: plugin.py:4588
-msgid "%d.%m.%Y - %H:%M"
-msgstr "%Y.%m.%d - %H:%M"
-
-#: plugin.py:4589
-msgid "%d.%m.%y %H:%M:%S"
-msgstr "%y.%m.%d %H:%M:%S"
-
-#: plugin.py:5153
-msgid "%d-%b-%Y"
-msgstr "%Y-%b-%d"
-
-#: plugin.py:5285
-msgid "Load Active Config-File"
-msgstr "加载活动配置文件"
-
-#: plugin.py:5286
-msgid "Load Defaults / Empty Config"
-msgstr "加载默认值/清空配置"
-
-#: plugin.py:5287
-msgid "Save Config to File... (%s)"
-msgstr "将配置保存到文件... (%s)"
-
-#: plugin.py:5291 plugin.py:5328
-msgid "Load File : %s"
-msgstr "加载文件：%s"
-
-#: plugin.py:5300
-msgid "Delete File?"
-msgstr "是否删除文件?"
-
-#: plugin.py:5337
-msgid "deleted"
-msgstr "已删除"
-
-#: plugin.py:5362
-msgid "currently set : %s"
-msgstr "当前设置：%s"
-
-#: plugin.py:5475 plugin.py:7878
-msgid "LCD4linux Settings"
-msgstr "LCD4linux设置"
-
-#: plugin.py:5534
-msgid "Mode"
-msgstr "模式"
-
-#: plugin.py:5544
-msgid "Cancel"
-msgstr "取消"
-
-#: plugin.py:5545
-msgid "Save"
-msgstr "保存"
-
-#: plugin.py:5546
-msgid "Restart Displays"
-msgstr "重新启动显示"
-
-#: plugin.py:5547 plugin.py:7879
-msgid "Set On >>"
-msgstr "启用 >>"
-
-#: plugin.py:5570 plugin.py:5591 plugin.py:7307 plugin.py:7872 plugin.py:7876
-#: plugin.py:8071
-msgid "Idle"
-msgstr "空闲"
-
-#: plugin.py:5630
-msgid "no LCD1 Picture-File"
-msgstr "没有LCD1图片文件"
-
-#: plugin.py:5655
-msgid "no LCD2 Picture-File"
-msgstr "没有LCD2图片文件"
-
-#: plugin.py:5681
-msgid "no LCD3 Picture-File"
-msgstr "没有LCD3图片文件"
-
-#: plugin.py:5718
-msgid "LCD4linux enabled"
-msgstr "已启用LCD4linux"
-
-#: plugin.py:5719
-msgid "LCD 1 Type"
-msgstr "LCD 1型"
-
-#: plugin.py:5720
-msgid "- LCD 1 Rotate"
-msgstr "- LCD 1旋转"
-
-#: plugin.py:5721 plugin.py:6687 plugin.py:7315
-msgid "- LCD 1 Background Color"
-msgstr "- LCD 1背景色"
-
-#: plugin.py:5722 plugin.py:6688 plugin.py:7316
-msgid "- LCD 1 Background-Picture [ok]>"
-msgstr "- LCD 1背景图片 [ok]>"
-
-#: plugin.py:5723 plugin.py:6689 plugin.py:7317
-msgid "- LCD 1 Brightness"
-msgstr "- LCD 1亮度"
-
-#: plugin.py:5724 plugin.py:6690 plugin.py:7318
-msgid "- LCD 1 Night Reduction"
-msgstr "- LCD 1夜间还原"
-
-#: plugin.py:5725
-msgid "- LCD 1 Refresh"
-msgstr "- LCD 1刷新"
-
-#: plugin.py:5726
-msgid "LCD 2 Type"
-msgstr "LCD 2型"
-
-#: plugin.py:5728
-msgid "- LCD 2 Rotate"
-msgstr "- LCD 2旋转"
-
-#: plugin.py:5729 plugin.py:6691 plugin.py:7319
-msgid "- LCD 2 Background Color"
-msgstr "- LCD 2背景色"
-
-#: plugin.py:5730 plugin.py:6692 plugin.py:7320
-msgid "- LCD 2 Background-Picture [ok]>"
-msgstr "- LCD 2背景图片[ok]>"
-
-#: plugin.py:5731 plugin.py:6693 plugin.py:7321
-msgid "- LCD 2 Brightness"
-msgstr "- LCD 2亮度"
-
-#: plugin.py:5732 plugin.py:6694 plugin.py:7322
-msgid "- LCD 2 Night Reduction"
-msgstr "- LCD 2夜间还原"
-
-#: plugin.py:5733
-msgid "- LCD 2 Refresh"
-msgstr "- LCD 2刷新"
-
-#: plugin.py:5734
-msgid "LCD 3 Type"
-msgstr "LCD 3型"
-
-#: plugin.py:5736
-msgid "- LCD 3 Rotate"
-msgstr "- LCD 3旋转"
-
-#: plugin.py:5737 plugin.py:6695 plugin.py:7323
-msgid "- LCD 3 Background Color"
-msgstr "- LCD 3背景色"
-
-#: plugin.py:5738 plugin.py:6696 plugin.py:7324
-msgid "- LCD 3 Background-Picture [ok]>"
-msgstr "- LCD 3背景图片 [ok]>"
-
-#: plugin.py:5739 plugin.py:6697 plugin.py:7325
-msgid "- LCD 3 Brightness"
-msgstr "- LCD 3亮度"
-
-#: plugin.py:5740 plugin.py:6698 plugin.py:7326
-msgid "- LCD 3 Night Reduction"
-msgstr "- LCD 3夜间还原"
-
-#: plugin.py:5741
-msgid "- LCD 3 Refresh"
-msgstr "- LCD 3刷新"
-
-#: plugin.py:5743
-msgid "Box-Skin-LCD Dimension"
-msgstr "盒式LCD尺寸"
-
-#: plugin.py:5744
-msgid "Box-Skin-LCD Offset"
-msgstr "Box-Skin-LCD偏移"
-
-#: plugin.py:5745
-msgid "Box-Skin-LCD Color"
-msgstr "盒式液晶显示器颜色"
-
-#: plugin.py:5746
-msgid "Box-Skin-LCD Enable On-Mode"
-msgstr "Box-Skin-LCD启用开启模式"
-
-#: plugin.py:5747
-msgid "Box-Skin-LCD Enable Media-Mode"
-msgstr "Box-Skin-LCD启用媒体模式"
-
-#: plugin.py:5748
-msgid "Box-Skin-LCD Enable Idle-Mode"
-msgstr "Box-Skin-LCD启用空闲模式"
-
-#: plugin.py:5749
-msgid "OSD [display time]"
-msgstr "OSD [显示时间]"
-
-#: plugin.py:5752 plugin.py:5759 plugin.py:5966 plugin.py:5971 plugin.py:5984
-#: plugin.py:5996 plugin.py:6011 plugin.py:6026 plugin.py:6038 plugin.py:6048
-#: plugin.py:6061 plugin.py:6074 plugin.py:6087 plugin.py:6101 plugin.py:6116
-#: plugin.py:6130 plugin.py:6144 plugin.py:6156 plugin.py:6168 plugin.py:6180
-#: plugin.py:6190 plugin.py:6204 plugin.py:6214 plugin.py:6221 plugin.py:6232
-#: plugin.py:6242 plugin.py:6260 plugin.py:6272 plugin.py:6290 plugin.py:6298
-#: plugin.py:6309 plugin.py:6320 plugin.py:6329 plugin.py:6352 plugin.py:6375
-#: plugin.py:6385 plugin.py:6395 plugin.py:6408 plugin.py:6420 plugin.py:6430
-#: plugin.py:6439 plugin.py:6450 plugin.py:6461 plugin.py:6472 plugin.py:6483
-#: plugin.py:6496 plugin.py:6506 plugin.py:6516 plugin.py:6526 plugin.py:6536
-#: plugin.py:6551 plugin.py:6566 plugin.py:6579 plugin.py:6593 plugin.py:6608
-#: plugin.py:6621 plugin.py:6631 plugin.py:6643 plugin.py:6655 plugin.py:6664
-#: plugin.py:6673 plugin.py:6682 plugin.py:6703 plugin.py:6708 plugin.py:6720
-#: plugin.py:6732 plugin.py:6746 plugin.py:6758 plugin.py:6771 plugin.py:6784
-#: plugin.py:6799 plugin.py:6809 plugin.py:6816 plugin.py:6831 plugin.py:6846
-#: plugin.py:6859 plugin.py:6872 plugin.py:6882 plugin.py:6896 plugin.py:6907
-#: plugin.py:6917 plugin.py:6935 plugin.py:6946 plugin.py:6964 plugin.py:6972
-#: plugin.py:6983 plugin.py:6994 plugin.py:7003 plugin.py:7026 plugin.py:7049
-#: plugin.py:7059 plugin.py:7069 plugin.py:7082 plugin.py:7094 plugin.py:7105
-#: plugin.py:7116 plugin.py:7126 plugin.py:7136 plugin.py:7153 plugin.py:7162
-#: plugin.py:7177 plugin.py:7192 plugin.py:7205 plugin.py:7219 plugin.py:7234
-#: plugin.py:7247 plugin.py:7257 plugin.py:7269 plugin.py:7281 plugin.py:7290
-#: plugin.py:7299 plugin.py:7330 plugin.py:7345 plugin.py:7360 plugin.py:7375
-#: plugin.py:7389 plugin.py:7402 plugin.py:7415 plugin.py:7425 plugin.py:7443
-#: plugin.py:7454 plugin.py:7472 plugin.py:7480 plugin.py:7491 plugin.py:7502
-#: plugin.py:7511 plugin.py:7534 plugin.py:7557 plugin.py:7567 plugin.py:7577
-#: plugin.py:7590 plugin.py:7602 plugin.py:7611 plugin.py:7622 plugin.py:7633
-#: plugin.py:7644 plugin.py:7655 plugin.py:7668 plugin.py:7678 plugin.py:7688
-#: plugin.py:7698 plugin.py:7708 plugin.py:7723 plugin.py:7738 plugin.py:7751
-#: plugin.py:7765 plugin.py:7780 plugin.py:7793 plugin.py:7803 plugin.py:7815
-#: plugin.py:7827 plugin.py:7836 plugin.py:7845
-msgid "- which LCD"
-msgstr "- 创建LCD"
-
-#: plugin.py:5753
-msgid "- Show in Mode"
-msgstr "- 以模式显示"
-
-#: plugin.py:5754
-msgid "- OSD Size"
-msgstr "- OSD尺寸"
-
-#: plugin.py:5755
-msgid "- Background/Transparency"
-msgstr "- 背景/透明度"
-
-#: plugin.py:5756
-msgid "- Fast Grab lower quality"
-msgstr "- 快速抓取低质量"
-
-#: plugin.py:5757
-msgid "Popup Text"
-msgstr "弹出式文本"
-
-#: plugin.py:5760
-msgid "- Clear Key"
-msgstr "- 清除键"
-
-#: plugin.py:5761 plugin.py:6027 plugin.py:6039 plugin.py:6050 plugin.py:6063
-#: plugin.py:6076 plugin.py:6089 plugin.py:6157 plugin.py:6169 plugin.py:6181
-#: plugin.py:6191 plugin.py:6215 plugin.py:6222 plugin.py:6233 plugin.py:6243
-#: plugin.py:6261 plugin.py:6273 plugin.py:6291 plugin.py:6331 plugin.py:6354
-#: plugin.py:6397 plugin.py:6409 plugin.py:6422 plugin.py:6431 plugin.py:6441
-#: plugin.py:6452 plugin.py:6463 plugin.py:6474 plugin.py:6537 plugin.py:6552
-#: plugin.py:6567 plugin.py:6580 plugin.py:6633 plugin.py:6645 plugin.py:6709
-#: plugin.py:6721 plugin.py:6734 plugin.py:6747 plugin.py:6760 plugin.py:6773
-#: plugin.py:6810 plugin.py:6873 plugin.py:6883 plugin.py:6897 plugin.py:6908
-#: plugin.py:6918 plugin.py:6936 plugin.py:6947 plugin.py:6965 plugin.py:7005
-#: plugin.py:7028 plugin.py:7071 plugin.py:7083 plugin.py:7096 plugin.py:7107
-#: plugin.py:7154 plugin.py:7163 plugin.py:7178 plugin.py:7193 plugin.py:7206
-#: plugin.py:7259 plugin.py:7271 plugin.py:7376 plugin.py:7416 plugin.py:7426
-#: plugin.py:7444 plugin.py:7455 plugin.py:7473 plugin.py:7513 plugin.py:7536
-#: plugin.py:7579 plugin.py:7591 plugin.py:7603 plugin.py:7613 plugin.py:7624
-#: plugin.py:7635 plugin.py:7646 plugin.py:7709 plugin.py:7724 plugin.py:7739
-#: plugin.py:7752 plugin.py:7805 plugin.py:7817
-msgid "- Font Size"
-msgstr "- 字体大小"
-
-#: plugin.py:5762 plugin.py:5973 plugin.py:5986 plugin.py:6003 plugin.py:6018
-#: plugin.py:6029 plugin.py:6040 plugin.py:6052 plugin.py:6065 plugin.py:6078
-#: plugin.py:6091 plugin.py:6105 plugin.py:6121 plugin.py:6135 plugin.py:6146
-#: plugin.py:6158 plugin.py:6170 plugin.py:6182 plugin.py:6195 plugin.py:6206
-#: plugin.py:6216 plugin.py:6223 plugin.py:6234 plugin.py:6244 plugin.py:6262
-#: plugin.py:6274 plugin.py:6292 plugin.py:6299 plugin.py:6310 plugin.py:6321
-#: plugin.py:6330 plugin.py:6353 plugin.py:6376 plugin.py:6386 plugin.py:6398
-#: plugin.py:6410 plugin.py:6423 plugin.py:6432 plugin.py:6442 plugin.py:6453
-#: plugin.py:6464 plugin.py:6475 plugin.py:6485 plugin.py:6500 plugin.py:6510
-#: plugin.py:6520 plugin.py:6530 plugin.py:6538 plugin.py:6553 plugin.py:6571
-#: plugin.py:6581 plugin.py:6594 plugin.py:6610 plugin.py:6623 plugin.py:6634
-#: plugin.py:6646 plugin.py:6677 plugin.py:6711 plugin.py:6723 plugin.py:6736
-#: plugin.py:6749 plugin.py:6762 plugin.py:6775 plugin.py:6788 plugin.py:6801
-#: plugin.py:6811 plugin.py:6823 plugin.py:6838 plugin.py:6850 plugin.py:6863
-#: plugin.py:6874 plugin.py:6887 plugin.py:6898 plugin.py:6909 plugin.py:6919
-#: plugin.py:6937 plugin.py:6948 plugin.py:6966 plugin.py:6973 plugin.py:6984
-#: plugin.py:6995 plugin.py:7004 plugin.py:7027 plugin.py:7050 plugin.py:7060
-#: plugin.py:7072 plugin.py:7084 plugin.py:7097 plugin.py:7108 plugin.py:7120
-#: plugin.py:7130 plugin.py:7139 plugin.py:7155 plugin.py:7164 plugin.py:7179
-#: plugin.py:7197 plugin.py:7207 plugin.py:7220 plugin.py:7236 plugin.py:7249
-#: plugin.py:7260 plugin.py:7272 plugin.py:7303 plugin.py:7352 plugin.py:7367
-#: plugin.py:7380 plugin.py:7393 plugin.py:7406 plugin.py:7417 plugin.py:7427
-#: plugin.py:7445 plugin.py:7456 plugin.py:7474 plugin.py:7481 plugin.py:7492
-#: plugin.py:7503 plugin.py:7512 plugin.py:7535 plugin.py:7558 plugin.py:7568
-#: plugin.py:7580 plugin.py:7592 plugin.py:7604 plugin.py:7614 plugin.py:7625
-#: plugin.py:7636 plugin.py:7647 plugin.py:7657 plugin.py:7672 plugin.py:7682
-#: plugin.py:7692 plugin.py:7702 plugin.py:7710 plugin.py:7725 plugin.py:7743
-#: plugin.py:7753 plugin.py:7766 plugin.py:7782 plugin.py:7795 plugin.py:7806
-#: plugin.py:7818 plugin.py:7849
-msgid "- Position"
-msgstr "- 位置"
-
-#: plugin.py:5763 plugin.py:5974 plugin.py:5987 plugin.py:6004 plugin.py:6019
-#: plugin.py:6030 plugin.py:6041 plugin.py:6053 plugin.py:6066 plugin.py:6079
-#: plugin.py:6092 plugin.py:6106 plugin.py:6122 plugin.py:6136 plugin.py:6147
-#: plugin.py:6159 plugin.py:6171 plugin.py:6183 plugin.py:6196 plugin.py:6207
-#: plugin.py:6217 plugin.py:6225 plugin.py:6235 plugin.py:6245 plugin.py:6263
-#: plugin.py:6275 plugin.py:6293 plugin.py:6301 plugin.py:6312 plugin.py:6323
-#: plugin.py:6332 plugin.py:6355 plugin.py:6378 plugin.py:6388 plugin.py:6399
-#: plugin.py:6411 plugin.py:6424 plugin.py:6433 plugin.py:6443 plugin.py:6454
-#: plugin.py:6465 plugin.py:6476 plugin.py:6486 plugin.py:6501 plugin.py:6511
-#: plugin.py:6521 plugin.py:6531 plugin.py:6539 plugin.py:6554 plugin.py:6572
-#: plugin.py:6582 plugin.py:6596 plugin.py:6611 plugin.py:6624 plugin.py:6635
-#: plugin.py:6647 plugin.py:6678 plugin.py:6712 plugin.py:6724 plugin.py:6737
-#: plugin.py:6750 plugin.py:6763 plugin.py:6776 plugin.py:6789 plugin.py:6802
-#: plugin.py:6812 plugin.py:6824 plugin.py:6839 plugin.py:6851 plugin.py:6864
-#: plugin.py:6875 plugin.py:6888 plugin.py:6900 plugin.py:6910 plugin.py:6920
-#: plugin.py:6938 plugin.py:6949 plugin.py:6967 plugin.py:6975 plugin.py:6986
-#: plugin.py:6997 plugin.py:7006 plugin.py:7029 plugin.py:7052 plugin.py:7062
-#: plugin.py:7073 plugin.py:7085 plugin.py:7098 plugin.py:7109 plugin.py:7121
-#: plugin.py:7131 plugin.py:7140 plugin.py:7156 plugin.py:7165 plugin.py:7180
-#: plugin.py:7198 plugin.py:7208 plugin.py:7222 plugin.py:7237 plugin.py:7250
-#: plugin.py:7261 plugin.py:7273 plugin.py:7304 plugin.py:7353 plugin.py:7368
-#: plugin.py:7381 plugin.py:7394 plugin.py:7407 plugin.py:7418 plugin.py:7428
-#: plugin.py:7446 plugin.py:7457 plugin.py:7475 plugin.py:7483 plugin.py:7494
-#: plugin.py:7505 plugin.py:7514 plugin.py:7537 plugin.py:7560 plugin.py:7570
-#: plugin.py:7581 plugin.py:7593 plugin.py:7605 plugin.py:7615 plugin.py:7626
-#: plugin.py:7637 plugin.py:7648 plugin.py:7658 plugin.py:7673 plugin.py:7683
-#: plugin.py:7693 plugin.py:7703 plugin.py:7711 plugin.py:7726 plugin.py:7744
-#: plugin.py:7754 plugin.py:7768 plugin.py:7783 plugin.py:7796 plugin.py:7807
-#: plugin.py:7819 plugin.py:7850
-msgid "- Alignment"
-msgstr "- 对齐"
-
-#: plugin.py:5764 plugin.py:5839 plugin.py:5841 plugin.py:5843 plugin.py:5845
-#: plugin.py:5847 plugin.py:5967 plugin.py:6006 plugin.py:6021 plugin.py:6033
-#: plugin.py:6042 plugin.py:6056 plugin.py:6069 plugin.py:6082 plugin.py:6095
-#: plugin.py:6108 plugin.py:6125 plugin.py:6139 plugin.py:6150 plugin.py:6161
-#: plugin.py:6173 plugin.py:6199 plugin.py:6210 plugin.py:6227 plugin.py:6237
-#: plugin.py:6247 plugin.py:6265 plugin.py:6277 plugin.py:6304 plugin.py:6315
-#: plugin.py:6326 plugin.py:6341 plugin.py:6364 plugin.py:6403 plugin.py:6413
-#: plugin.py:6426 plugin.py:6435 plugin.py:6444 plugin.py:6455 plugin.py:6466
-#: plugin.py:6477 plugin.py:6541 plugin.py:6583 plugin.py:6601 plugin.py:6616
-#: plugin.py:6637 plugin.py:6649 plugin.py:6660 plugin.py:6669 plugin.py:6704
-#: plugin.py:6715 plugin.py:6727 plugin.py:6740 plugin.py:6753 plugin.py:6766
-#: plugin.py:6779 plugin.py:6791 plugin.py:6805 plugin.py:6826 plugin.py:6841
-#: plugin.py:6854 plugin.py:6867 plugin.py:6891 plugin.py:6902 plugin.py:6912
-#: plugin.py:6922 plugin.py:6940 plugin.py:6951 plugin.py:6978 plugin.py:6989
-#: plugin.py:7000 plugin.py:7015 plugin.py:7038 plugin.py:7077 plugin.py:7087
-#: plugin.py:7099 plugin.py:7110 plugin.py:7158 plugin.py:7167 plugin.py:7209
-#: plugin.py:7227 plugin.py:7242 plugin.py:7263 plugin.py:7275 plugin.py:7286
-#: plugin.py:7295 plugin.py:7331 plugin.py:7355 plugin.py:7370 plugin.py:7384
-#: plugin.py:7397 plugin.py:7410 plugin.py:7430 plugin.py:7448 plugin.py:7459
-#: plugin.py:7486 plugin.py:7497 plugin.py:7508 plugin.py:7523 plugin.py:7546
-#: plugin.py:7585 plugin.py:7595 plugin.py:7607 plugin.py:7616 plugin.py:7627
-#: plugin.py:7638 plugin.py:7649 plugin.py:7713 plugin.py:7755 plugin.py:7773
-#: plugin.py:7788 plugin.py:7809 plugin.py:7821 plugin.py:7832 plugin.py:7841
-msgid "- Color"
-msgstr "- 颜色"
-
-#: plugin.py:5765 plugin.py:6043 plugin.py:6266 plugin.py:6414 plugin.py:6427
-#: plugin.py:6436 plugin.py:6445 plugin.py:6456 plugin.py:6467 plugin.py:6478
-#: plugin.py:6542 plugin.py:6584 plugin.py:6638 plugin.py:6650 plugin.py:6661
-#: plugin.py:6670 plugin.py:6941 plugin.py:7088 plugin.py:7100 plugin.py:7111
-#: plugin.py:7159 plugin.py:7168 plugin.py:7210 plugin.py:7264 plugin.py:7276
-#: plugin.py:7287 plugin.py:7296 plugin.py:7449 plugin.py:7596 plugin.py:7608
-#: plugin.py:7617 plugin.py:7628 plugin.py:7639 plugin.py:7650 plugin.py:7714
-#: plugin.py:7756 plugin.py:7810 plugin.py:7822 plugin.py:7833 plugin.py:7842
-msgid "- Background Color"
-msgstr "- 背景色"
-
-#: plugin.py:5766 plugin.py:6008 plugin.py:6023 plugin.py:6035 plugin.py:6045
-#: plugin.py:6058 plugin.py:6071 plugin.py:6084 plugin.py:6097 plugin.py:6113
-#: plugin.py:6127 plugin.py:6141 plugin.py:6165 plugin.py:6177 plugin.py:6187
-#: plugin.py:6201 plugin.py:6229 plugin.py:6239 plugin.py:6249 plugin.py:6268
-#: plugin.py:6279 plugin.py:6306 plugin.py:6317 plugin.py:6349 plugin.py:6372
-#: plugin.py:6405 plugin.py:6417 plugin.py:6447 plugin.py:6458 plugin.py:6469
-#: plugin.py:6480 plugin.py:6548 plugin.py:6563 plugin.py:6576 plugin.py:6590
-#: plugin.py:6605 plugin.py:6618 plugin.py:6640 plugin.py:6652 plugin.py:6717
-#: plugin.py:6729 plugin.py:6742 plugin.py:6755 plugin.py:6768 plugin.py:6781
-#: plugin.py:6796 plugin.py:6828 plugin.py:6843 plugin.py:6856 plugin.py:6869
-#: plugin.py:6879 plugin.py:6893 plugin.py:6904 plugin.py:6914 plugin.py:6924
-#: plugin.py:6943 plugin.py:6953 plugin.py:6980 plugin.py:6991 plugin.py:7023
-#: plugin.py:7046 plugin.py:7079 plugin.py:7091 plugin.py:7102 plugin.py:7113
-#: plugin.py:7174 plugin.py:7189 plugin.py:7202 plugin.py:7216 plugin.py:7231
-#: plugin.py:7244 plugin.py:7266 plugin.py:7278 plugin.py:7357 plugin.py:7372
-#: plugin.py:7386 plugin.py:7399 plugin.py:7412 plugin.py:7422 plugin.py:7432
-#: plugin.py:7451 plugin.py:7461 plugin.py:7488 plugin.py:7499 plugin.py:7531
-#: plugin.py:7554 plugin.py:7587 plugin.py:7599 plugin.py:7619 plugin.py:7630
-#: plugin.py:7641 plugin.py:7652 plugin.py:7720 plugin.py:7735 plugin.py:7748
-#: plugin.py:7762 plugin.py:7777 plugin.py:7790 plugin.py:7812 plugin.py:7824
-msgid "- Font"
-msgstr "- 字体"
-
-#: plugin.py:5769
-msgid "Active Screen"
-msgstr "活动画面"
-
-#: plugin.py:5770
-msgid "Screen Switch Select - Screen"
-msgstr "屏幕开关选择-屏幕"
-
-#: plugin.py:5771
-msgid "Screen Switch Select - LCD"
-msgstr "屏幕开关选择-LCD"
-
-#: plugin.py:5772
-msgid "Screens used for Changing"
-msgstr "用于更换的屏幕"
-
-#: plugin.py:5773 plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr "屏幕1更改时间"
-
-#: plugin.py:5775 plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr "- 屏幕2更改时间"
-
-#: plugin.py:5776 plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr "- 屏幕3更改时间"
-
-#: plugin.py:5777 plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr "- 屏幕4更改时间"
-
-#: plugin.py:5778 plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr "- 屏幕5更改时间"
-
-#: plugin.py:5779 plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr "- 屏幕6更改时间"
-
-#: plugin.py:5780 plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr "- 屏幕7更改时间"
-
-#: plugin.py:5781 plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr "- 屏幕8更改时间"
-
-#: plugin.py:5782 plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr "- 屏幕9更改时间"
-
-#: plugin.py:5783
-msgid "Picture Changing Time"
-msgstr "图片更改时间"
-
-#: plugin.py:5784
-msgid "Picture Sort"
-msgstr "图片排序"
-
-#: plugin.py:5785
-msgid "Picture Directory Recursive"
-msgstr "图片目录递归"
-
-#: plugin.py:5786
-msgid "Picture Quality for Resizing"
-msgstr "调整画质的图像质量"
-
-#: plugin.py:5788
-msgid "Picture Quick Update Time [s]"
-msgstr "图片快速更新时间[s]"
-
-#: plugin.py:5790
-msgid "Picture Type [only Picture]"
-msgstr "图片类型[仅图片]"
-
-#: plugin.py:5791
-msgid "Background-Picture Type"
-msgstr "背景图片类型"
-
-#: plugin.py:5792
-msgid "Weather API"
-msgstr "天气 API"
-
-#: plugin.py:5793
-msgid "Weather API-Key OpenWeatherMap"
-msgstr "天气API键打开天气图"
-
-#: plugin.py:5794
-msgid "Weather API-ID Key WeatherUnlocked"
-msgstr "天气API-ID密钥天气解锁"
-
-#: plugin.py:5795
-msgid "Weather City"
-msgstr "天气城市"
-
-#: plugin.py:5796
-msgid "Weather City 2"
-msgstr "天气城市2"
-
-#: plugin.py:5797
-msgid "Weather-Icon-Path [ok]>"
-msgstr "天气图标路径 [ok]>"
-
-#: plugin.py:5798
-msgid "Weather-Icon Zoom"
-msgstr "天气图标放大"
-
-#: plugin.py:5799
-msgid "Weather Low Temperature Color"
-msgstr "天气低温色"
-
-#: plugin.py:5800
-msgid "Weather High Temperature Color"
-msgstr "天气高温色"
-
-#: plugin.py:5801
-msgid "Weather Transparency"
-msgstr "天气透明度"
-
-#: plugin.py:5802
-msgid "Weather Wind speed unit"
-msgstr "天气风速单位"
-
-#: plugin.py:5803
-msgid "Weather Wind Info Lines"
-msgstr "天气线"
-
-#: plugin.py:5804
-msgid "Weather Rain Chance"
-msgstr "天气雨"
-
-#: plugin.py:5806
-msgid "- Rain Zoom"
-msgstr "- 雨缩放"
-
-#: plugin.py:5807
-msgid "- Rain Color"
-msgstr "- 雨色"
-
-#: plugin.py:5808
-msgid "- Rain use Color 2 from"
-msgstr "- 从雨中使用颜色2"
-
-#: plugin.py:5809
-msgid "- Rain Color 2"
-msgstr "- 雨色2"
-
-#: plugin.py:5810
-msgid "Weather Lines"
-msgstr "天气线"
-
-#: plugin.py:5811
-msgid "Weather Trendarrows"
-msgstr "天气趋势箭头"
-
-#: plugin.py:5812
-msgid "Weather Extra Infos"
-msgstr "天气额外信息"
-
-#: plugin.py:5814
-msgid "- Extra Zoom"
-msgstr "- 额外缩放"
-
-#: plugin.py:5815
-msgid "- Show chill temperature from difference"
-msgstr "- 显示温差"
-
-#: plugin.py:5816
-msgid "- Extra Color City"
-msgstr "- 城市的附加颜色"
-
-#: plugin.py:5817
-msgid "- Extra Color Chill"
-msgstr "- 额外颜色冷色"
-
-#: plugin.py:5818
-msgid "Netatmo CO2 Min Range"
-msgstr "Netatmo CO2最小范围"
-
-#: plugin.py:5819
-msgid "Netatmo CO2 Max Range"
-msgstr "Netatmo CO2最大范围"
-
-#: plugin.py:5820
-msgid "Meteo URL"
-msgstr "气象网址"
-
-#: plugin.py:5821
-msgid "Moon-Icon-Path [ok]>"
-msgstr "月亮图标路径 [ok]>"
-
-#: plugin.py:5822
-msgid "Recording Picture [ok]>"
-msgstr "录制图片 [ok]>"
-
-#: plugin.py:5823
-msgid "Double-button switches"
-msgstr "双按钮开关"
-
-#: plugin.py:5824
-msgid "Key for Screen Change"
-msgstr "屏幕切换键"
-
-#: plugin.py:5825
-msgid "Key for Screen On/Off"
-msgstr "屏幕开/关键"
-
-#: plugin.py:5826
-msgid "FritzCall Picture Path [ok]>"
-msgstr "FritzCall图片路径 [ok]>"
-
-#: plugin.py:5827
-msgid "FritzCall Number of Lines per Entry"
-msgstr "FritzCall每个条目的行数"
-
-#: plugin.py:5828
-msgid "FritzCall Number of List Entries"
-msgstr "FritzCall列表条目数"
-
-#: plugin.py:5829
-msgid "FritzCall Number of Pictures"
-msgstr "FritzCall图片数"
-
-#: plugin.py:5830
-msgid "FritzCall Picture Orientation"
-msgstr "FritzCall图像定向"
-
-#: plugin.py:5831
-msgid "FritzCall Picture Transparency"
-msgstr "FritzCall图片透明度"
-
-#: plugin.py:5832
-msgid "FritzCall Pictures Search"
-msgstr "FritzCall图片搜索"
-
-#: plugin.py:5833
-msgid "FritzCall remove Calls after hours"
-msgstr "FritzCall在(小时)后取消呼叫"
-
-#: plugin.py:5834
-msgid "FritzCall Popup-Time"
-msgstr "FritzCall弹出时间"
-
-#: plugin.py:5835
-msgid "FritzCall Popup LCD"
-msgstr "FritzCall弹出式液晶屏"
-
-#: plugin.py:5836
-msgid "FritzCall Popup Color"
-msgstr "FritzCall弹出窗口的颜色"
-
-#: plugin.py:5837
-msgid "FritzCall Frame Picture [ok]>"
-msgstr "FritzCall相框图片 [ok]>"
-
-#: plugin.py:5838
-msgid "Calendar ics-Path [ok]>"
-msgstr "日历象形图路径[ok]>"
-
-#: plugin.py:5840 plugin.py:5842 plugin.py:5844
-msgid "Calendar ics-URL"
-msgstr "日历象形图互联网地址"
-
-#: plugin.py:5846
-msgid "Calendar planerFS"
-msgstr "日历调度程序FS"
-
-#: plugin.py:5848
-msgid "Calendar Saturday Color"
-msgstr "日历中的星期六颜色"
-
-#: plugin.py:5849
-msgid "Calendar Sunday Color"
-msgstr "日历中的星期日颜色"
-
-#: plugin.py:5850
-msgid "Calendar Line Thickness"
-msgstr "日历线条粗细"
-
-#: plugin.py:5851
-msgid "Calendar Day Event Preview"
-msgstr "日历日活动预览"
-
-#: plugin.py:5852
-msgid "Calendar Timezone Correction"
-msgstr "日历时区修正"
-
-#: plugin.py:5853
-msgid "Calendar Transparency"
-msgstr "日历透明度"
-
-#: plugin.py:5854
-msgid "Calendar Poll Interval"
-msgstr "日历轮询间隔"
-
-#: plugin.py:5855
-msgid "Tuner Color"
-msgstr "调谐器颜色"
-
-#: plugin.py:5856
-msgid "Tuner Color Active"
-msgstr "调谐器颜色有效"
-
-#: plugin.py:5857
-msgid "Tuner Color On"
-msgstr "调谐器颜色开启"
-
-#: plugin.py:5858
-msgid "Service search first"
-msgstr "服务搜索优先"
-
-#: plugin.py:5859
-msgid "DVB-T Signal-Quality Correction"
-msgstr "DVB-T信号质量校正"
-
-#: plugin.py:5860
-msgid "Font global [ok]>"
-msgstr "字体全局 [ok]>"
-
-#: plugin.py:5861
-msgid "Font 1 [ok]>"
-msgstr "字体1 [ok]>"
-
-#: plugin.py:5862
-msgid "Font 2 [ok]>"
-msgstr "字体 2 [ok]>"
-
-#: plugin.py:5863
-msgid "Font 3 [ok]>"
-msgstr "字体 3 [ok]>"
-
-#: plugin.py:5864
-msgid "Font 4 [ok]>"
-msgstr "字体 4 [ok]>"
-
-#: plugin.py:5865
-msgid "Font 5 [ok]>"
-msgstr "字体 5 [ok]>"
-
-#: plugin.py:5866
-msgid "Mail 1 Connect"
-msgstr "邮件1连接"
-
-#: plugin.py:5867
-msgid "Mail 1 Server"
-msgstr "邮件1服务器"
-
-#: plugin.py:5868
-msgid "Mail 1 [Displayname:]Username"
-msgstr "邮件1 [显示名称:]用户名"
-
-#: plugin.py:5869
-msgid "Mail 1 Password"
-msgstr "邮件1密码"
-
-#: plugin.py:5870
-msgid "Mail 2 Connect"
-msgstr "邮件2连接"
-
-#: plugin.py:5871
-msgid "Mail 2 Server"
-msgstr "邮件2服务器"
-
-#: plugin.py:5872
-msgid "Mail 2 [Displayname:]Username"
-msgstr "邮件2 [显示名称:]用户名"
-
-#: plugin.py:5873
-msgid "Mail 2 Password"
-msgstr "邮件2密码"
-
-#: plugin.py:5874
-msgid "Mail 3 Connect"
-msgstr "邮件3连接"
-
-#: plugin.py:5875
-msgid "Mail 3 Server"
-msgstr "邮件3服务器"
-
-#: plugin.py:5876
-msgid "Mail 3 [Displayname:]Username"
-msgstr "邮件3 [显示名称:]用户名"
-
-#: plugin.py:5877
-msgid "Mail 3 Password"
-msgstr "邮件3密码"
-
-#: plugin.py:5878
-msgid "Mail 4 Connect"
-msgstr "邮件4连接"
-
-#: plugin.py:5879
-msgid "Mail 4 Server"
-msgstr "邮件4服务器"
-
-#: plugin.py:5880
-msgid "Mail 4 [Displayname:]Username"
-msgstr "邮件4 [显示名称:]用户名"
-
-#: plugin.py:5881
-msgid "Mail 4 Password"
-msgstr "邮件4密码"
-
-#: plugin.py:5882
-msgid "Mail 5 Connect"
-msgstr "邮件5连接"
-
-#: plugin.py:5883
-msgid "Mail 5 Server"
-msgstr "邮件5服务器"
-
-#: plugin.py:5884
-msgid "Mail 5 [Displayname:]Username"
-msgstr "邮件5 [显示名称:]用户名"
-
-#: plugin.py:5885
-msgid "Mail 5 Password"
-msgstr "邮件5密码"
-
-#: plugin.py:5886
-msgid "Mail Poll Interval"
-msgstr "邮件轮询间隔"
-
-#: plugin.py:5887
-msgid "Mail IMAP limit to last days"
-msgstr "邮寄IMAP限制到最后几天"
-
-#: plugin.py:5888
-msgid "Mail Show Empty Mailboxes"
-msgstr "邮件显示空邮箱"
-
-#: plugin.py:5889
-msgid "Mail Show Date"
-msgstr "邮件显示日期"
-
-#: plugin.py:5890
-msgid "Mail Hide Mailadress"
-msgstr "邮件隐藏邮件地址"
-
-#: plugin.py:5891
-msgid "Remote Box 1 [Displayname:]IP/Name"
-msgstr "远程文件夹1 [显示名称:] IP /名称"
-
-#: plugin.py:5892
-msgid "Remote Box 2 [Displayname:]IP/Name"
-msgstr "Remote Box 2 [显示名称:] IP /名称"
-
-#: plugin.py:5893
-msgid "Remote Box 3 [Displayname:]IP/Name"
-msgstr "遥控器3 [显示名称:] IP /名称"
-
-#: plugin.py:5894
-msgid "Remote Box 4 [Displayname:]IP/Name"
-msgstr "Remote Box 4 [显示名称:] IP /名称"
-
-#: plugin.py:5895
-msgid "Remote Box 5 [Displayname:]IP/Name"
-msgstr "Remote Box 5 [显示名称:] IP /名称"
-
-#: plugin.py:5896
-msgid "Remote Box Poll every Minutes"
-msgstr "每分钟进行一次远程箱投票"
-
-#: plugin.py:5897
-msgid "Remote Box Timer [Displayname:]IP/Name"
-msgstr "远程盒定时器[显示名称:] IP /名称"
-
-#: plugin.py:5898
-msgid "Remote Box Timer Poll every Minutes"
-msgstr "每隔一分钟的远程Box Timer轮询"
-
-#: plugin.py:5899
-msgid "WWW Converter Poll Interval"
-msgstr "WWW转换器轮询间隔"
-
-#: plugin.py:5900
-msgid "WWW Converter Usage"
-msgstr "WWW转换器使用"
-
-#: plugin.py:5901
-msgid "WWW ApiKey from cloudconvert.org"
-msgstr "来自cloudconvert.org的WWW ApiKey"
-
-#: plugin.py:5902
-msgid "WWW ApiKey from convertapi.com"
-msgstr "来自convertapi.com的WWW ApiKey"
-
-#: plugin.py:5903
-msgid "WebIF Refresh [s]"
-msgstr "WebIF刷新[s]"
-
-#: plugin.py:5904
-msgid "WebIF Refresh Type"
-msgstr "WebIF刷新类型"
-
-#: plugin.py:5905
-msgid "WebIF Init Delay"
-msgstr "WebIF初始化延迟"
-
-#: plugin.py:5906
-msgid "WebIF IP Allow"
-msgstr "WebIF IP允许"
-
-#: plugin.py:5907
-msgid "WebIF IP Deny"
-msgstr "WebIF IP拒绝"
-
-#: plugin.py:5908
-msgid "WebIF Design"
-msgstr "WebIF设计"
-
-#: plugin.py:5909
-msgid "Save as Picture for WebIF"
-msgstr "另存为WebIF图片"
-
-#: plugin.py:5910
-msgid "MJPEG Stream LCD 1 enable"
-msgstr "MJPEG流LCD 1启用"
-
-#: plugin.py:5911
-msgid "MJPEG Stream LCD 1 Port"
-msgstr "MJPEG流LCD 1端口"
-
-#: plugin.py:5912
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "MJPEG流LCD 1虚拟亮度"
-
-#: plugin.py:5913
-msgid "MJPEG Stream LCD 2 enable"
-msgstr "MJPEG流LCD 2启用"
-
-#: plugin.py:5914
-msgid "MJPEG Stream LCD 2 Port"
-msgstr "MJPEG流LCD 2端口"
-
-#: plugin.py:5915
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "MJPEG Stream LCD 2虚拟亮度"
-
-#: plugin.py:5916
-msgid "MJPEG Stream LCD 3 enable"
-msgstr "MJPEG流LCD 3启用"
-
-#: plugin.py:5917
-msgid "MJPEG Stream LCD 3 Port"
-msgstr "MJPEG流LCD 3端口"
-
-#: plugin.py:5918
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "MJPEG流LCD 3虚拟亮度"
-
-#: plugin.py:5920
-msgid "MJPEG Cycle"
-msgstr "MJPEG循环"
-
-#: plugin.py:5921
-msgid "MJPEG Restart on Error"
-msgstr "出错时MJPEG重新启动"
-
-#: plugin.py:5922
-msgid "MJPEG Header Mode"
-msgstr "MJPEG标题模式"
-
-#: plugin.py:5923
-msgid "Sonos IP"
-msgstr "Sonos IP地址"
-
-#: plugin.py:5924
-msgid "Sonos Ping Timeout [ms]"
-msgstr "休眠Ping超时[毫秒]"
-
-#: plugin.py:5925
-msgid "Sonos Play Check"
-msgstr "休眠播放检查"
-
-#: plugin.py:5926
-msgid "Sonos Refresh [s]"
-msgstr "休眠更新间隔[秒]"
-
-#: plugin.py:5927
-msgid "BlueSound IP"
-msgstr "BlueSound IP"
-
-#: plugin.py:5928
-msgid "BlueSound Ping Timeout [ms]"
-msgstr "BlueSound Ping 超时 [ms]"
-
-#: plugin.py:5929
-msgid "BlueSound Play Check"
-msgstr "BlueSound 玩检查"
-
-#: plugin.py:5930
-msgid "BlueSound Refresh [s]"
-msgstr "BlueSound刷新 [s]"
-
-#: plugin.py:5931
-msgid "MusicCast IP"
-msgstr "音乐广播IP"
-
-#: plugin.py:5932
-msgid "MusicCast Server IP [optional]"
-msgstr "MusicCast服务器IP [可选]"
-
-#: plugin.py:5933
-msgid "MusicCast Ping Timeout [ms]"
-msgstr "音乐播放Ping超时 [毫秒]"
-
-#: plugin.py:5934
-msgid "MusicCast Play Check"
-msgstr "MusicCast播放检查"
-
-#: plugin.py:5935
-msgid "MusicCast Refresh [s]"
-msgstr "MusicCast刷新[s]"
-
-#: plugin.py:5936
-msgid "MusicCast Cover"
-msgstr "音乐广告封面"
-
-#: plugin.py:5937
-msgid "LCD Custom Width"
-msgstr "LCD自定义宽度"
-
-#: plugin.py:5938
-msgid "LCD Custom Height"
-msgstr "LCD自定义高度"
-
-#: plugin.py:5939
-msgid "LCD Custom Width 2"
-msgstr "LCD自定义宽度2"
-
-#: plugin.py:5940
-msgid "LCD Custom Height 2"
-msgstr "LCD自定义高度2"
-
-#: plugin.py:5941
-msgid "LCD Off when shutdown"
-msgstr "关机时液晶屏关闭"
-
-#: plugin.py:5942
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
-msgstr "时机！在快速模式下计算所有时间到时间/ 5 * 2"
-
-#: plugin.py:5943
-msgid "Display Delay [ms]"
-msgstr "显示延迟[毫秒]"
-
-#: plugin.py:5944
-msgid "Threads per LCD"
-msgstr "每个LCD的线程数"
-
-#: plugin.py:5945
-msgid "Show Crash Corner"
-msgstr "显示崩溃角"
-
-#: plugin.py:5946
-msgid "Show 'no ....' Messages"
-msgstr "显示“否 ....”消息"
-
-#: plugin.py:5947
-msgid "Storage-Devices: Force Read"
-msgstr "存储设备：强制读取"
-
-#: plugin.py:5948
-msgid "Storage-Devices: Color Back"
-msgstr "存储设备：彩色背"
-
-#: plugin.py:5949
-msgid "Storage-Devices: Color Bar"
-msgstr "存储设备：颜色栏"
-
-#: plugin.py:5950
-msgid "Storage-Devices: Color Full"
-msgstr "存储设备：全彩色"
-
-#: plugin.py:5951
-msgid "Network Check active"
-msgstr "网络检查处于活动状态"
-
-#: plugin.py:5952
-msgid "Switch FrameBuffer [if possible]"
-msgstr "切换帧缓冲区 [如果可能]"
-
-#: plugin.py:5953
-msgid "Config Backup Path [ok]>"
-msgstr "配置备份路径[ok]>"
-
-#: plugin.py:5954
-msgid "Config Restore All Settings"
-msgstr "配置还原所有设置"
-
-#: plugin.py:5955
-msgid "Debug-Logging > /tmp/L4log.txt"
-msgstr "调试日志 > /tmp/L4log.txt"
-
-#: plugin.py:5959 plugin.py:7310
-msgid "- Backlight Off [disable set Off=On]"
-msgstr "- 背光关闭[禁用设置关闭=打开]"
-
-#: plugin.py:5960 plugin.py:7311
-msgid "- Backlight On"
-msgstr "- 背光开启"
-
-#: plugin.py:5961 plugin.py:7312
-msgid "- Backlight Weekend Off [disable set Off=On]"
-msgstr "- 周末背光关闭 [禁用设置关闭=打开]"
-
-#: plugin.py:5962 plugin.py:7313
-msgid "- Backlight Weekend On"
-msgstr "- 背光周末开启"
-
-#: plugin.py:5963 plugin.py:6699 plugin.py:7314
-msgid "- LCD Auto-OFF"
-msgstr "- LCD自动关闭"
-
-#: plugin.py:5964 plugin.py:6701 plugin.py:7328
-msgid "Background"
-msgstr "背景"
-
-#: plugin.py:5968 plugin.py:6705 plugin.py:7332
-msgid "- Picture [ok]>"
-msgstr "- 图片 [ok]>"
-
-#: plugin.py:5972 plugin.py:5985
-msgid "- Picon Size"
-msgstr "- Picon大小"
-
-#: plugin.py:5975 plugin.py:5988 plugin.py:6005 plugin.py:6020 plugin.py:6032
-#: plugin.py:6055 plugin.py:6068 plugin.py:6081 plugin.py:6094 plugin.py:6123
-#: plugin.py:6137 plugin.py:6149 plugin.py:6160 plugin.py:6172 plugin.py:6184
-#: plugin.py:6198 plugin.py:6209 plugin.py:6218 plugin.py:6226 plugin.py:6236
-#: plugin.py:6246 plugin.py:6264 plugin.py:6276 plugin.py:6294 plugin.py:6302
-#: plugin.py:6313 plugin.py:6324 plugin.py:6333 plugin.py:6356 plugin.py:6380
-#: plugin.py:6390 plugin.py:6402 plugin.py:6412 plugin.py:6425 plugin.py:6434
-#: plugin.py:6540 plugin.py:6574 plugin.py:6597 plugin.py:6612 plugin.py:6625
-#: plugin.py:6636 plugin.py:6648 plugin.py:6679 plugin.py:6714 plugin.py:6726
-#: plugin.py:6739 plugin.py:6752 plugin.py:6765 plugin.py:6778 plugin.py:6804
-#: plugin.py:6813 plugin.py:6825 plugin.py:6840 plugin.py:6852 plugin.py:6865
-#: plugin.py:6876 plugin.py:6890 plugin.py:6901 plugin.py:6911 plugin.py:6921
-#: plugin.py:6939 plugin.py:6950 plugin.py:6968 plugin.py:6976 plugin.py:6987
-#: plugin.py:6998 plugin.py:7007 plugin.py:7030 plugin.py:7054 plugin.py:7064
-#: plugin.py:7076 plugin.py:7086 plugin.py:7157 plugin.py:7166 plugin.py:7200
-#: plugin.py:7223 plugin.py:7238 plugin.py:7251 plugin.py:7262 plugin.py:7274
-#: plugin.py:7305 plugin.py:7354 plugin.py:7369 plugin.py:7383 plugin.py:7395
-#: plugin.py:7408 plugin.py:7419 plugin.py:7429 plugin.py:7447 plugin.py:7458
-#: plugin.py:7476 plugin.py:7484 plugin.py:7495 plugin.py:7506 plugin.py:7515
-#: plugin.py:7538 plugin.py:7562 plugin.py:7572 plugin.py:7584 plugin.py:7594
-#: plugin.py:7606 plugin.py:7712 plugin.py:7746 plugin.py:7769 plugin.py:7784
-#: plugin.py:7797 plugin.py:7808 plugin.py:7820 plugin.py:7851
-msgid "- Split Screen"
-msgstr "- 分屏"
-
-#: plugin.py:5976 plugin.py:5989
-msgid "- Full Screen"
-msgstr "- 全屏显示"
-
-#: plugin.py:5977 plugin.py:5990
-msgid "- Text Size"
-msgstr "- 文本大小"
-
-#: plugin.py:5978 plugin.py:6503 plugin.py:6513 plugin.py:6523 plugin.py:6533
-#: plugin.py:7123 plugin.py:7133 plugin.py:7146 plugin.py:7675 plugin.py:7685
-#: plugin.py:7695 plugin.py:7705
-msgid "- Transparency"
-msgstr "- 透明度"
-
-#: plugin.py:5979 plugin.py:5991 plugin.py:6163 plugin.py:6175
-msgid "- Picon Path [ok]>"
-msgstr "- Picon路径 [ok]>"
-
-#: plugin.py:5980 plugin.py:5992
-msgid "- Picon Path 2 [ok]>"
-msgstr "- Picon路径2[ok]>"
-
-#: plugin.py:5981 plugin.py:5993
-msgid "- Picon Cache Path [ok]>"
-msgstr "- Picon缓存路径 [ok]>"
-
-#: plugin.py:5982
-msgid "Picon 2"
-msgstr "Picon 2"
-
-#: plugin.py:5994 plugin.py:6814 plugin.py:7343
-msgid "Clock"
-msgstr "时钟"
-
-#: plugin.py:5997 plugin.py:6012 plugin.py:6674 plugin.py:7300 plugin.py:7846
-msgid "-  Type"
-msgstr "-  类型"
-
-#: plugin.py:5999 plugin.py:6014 plugin.py:6819 plugin.py:6834 plugin.py:7348
-#: plugin.py:7363
-msgid "- Analog Clock"
-msgstr "- 模拟时钟"
-
-#: plugin.py:6001 plugin.py:6016 plugin.py:6821 plugin.py:6836 plugin.py:7350
-#: plugin.py:7365
-msgid "- Spacing"
-msgstr "- 间距"
-
-#: plugin.py:6002 plugin.py:6017 plugin.py:6104 plugin.py:6120 plugin.py:6134
-#: plugin.py:6145 plugin.py:6205 plugin.py:6377 plugin.py:6387 plugin.py:6396
-#: plugin.py:6484 plugin.py:6498 plugin.py:6508 plugin.py:6518 plugin.py:6528
-#: plugin.py:6609 plugin.py:6622 plugin.py:6675 plugin.py:6787 plugin.py:6800
-#: plugin.py:6822 plugin.py:6837 plugin.py:6849 plugin.py:6862 plugin.py:7051
-#: plugin.py:7061 plugin.py:7070 plugin.py:7118 plugin.py:7128 plugin.py:7137
-#: plugin.py:7235 plugin.py:7248 plugin.py:7301 plugin.py:7351 plugin.py:7366
-#: plugin.py:7392 plugin.py:7405 plugin.py:7559 plugin.py:7569 plugin.py:7578
-#: plugin.py:7656 plugin.py:7670 plugin.py:7680 plugin.py:7690 plugin.py:7700
-#: plugin.py:7781 plugin.py:7794 plugin.py:7847
-msgid "- Size"
-msgstr "- 大小"
-
-#: plugin.py:6007 plugin.py:6022 plugin.py:6034 plugin.py:6044 plugin.py:6057
-#: plugin.py:6070 plugin.py:6083 plugin.py:6096 plugin.py:6126 plugin.py:6140
-#: plugin.py:6164 plugin.py:6176 plugin.py:6200 plugin.py:6228 plugin.py:6238
-#: plugin.py:6248 plugin.py:6267 plugin.py:6278 plugin.py:6305 plugin.py:6316
-#: plugin.py:6348 plugin.py:6371 plugin.py:6404 plugin.py:6416 plugin.py:6446
-#: plugin.py:6457 plugin.py:6468 plugin.py:6479 plugin.py:6547 plugin.py:6562
-#: plugin.py:6575 plugin.py:6589 plugin.py:6604 plugin.py:6617 plugin.py:6639
-#: plugin.py:6651 plugin.py:6716 plugin.py:6728 plugin.py:6741 plugin.py:6754
-#: plugin.py:6767 plugin.py:6780 plugin.py:6827 plugin.py:6842 plugin.py:6855
-#: plugin.py:6868 plugin.py:6892 plugin.py:6903 plugin.py:6913 plugin.py:6923
-#: plugin.py:6942 plugin.py:6952 plugin.py:6979 plugin.py:6990 plugin.py:7022
-#: plugin.py:7045 plugin.py:7078 plugin.py:7090 plugin.py:7101 plugin.py:7112
-#: plugin.py:7173 plugin.py:7188 plugin.py:7201 plugin.py:7215 plugin.py:7230
-#: plugin.py:7243 plugin.py:7265 plugin.py:7277 plugin.py:7356 plugin.py:7371
-#: plugin.py:7385 plugin.py:7398 plugin.py:7411 plugin.py:7431 plugin.py:7450
-#: plugin.py:7460 plugin.py:7487 plugin.py:7498 plugin.py:7530 plugin.py:7553
-#: plugin.py:7586 plugin.py:7598 plugin.py:7618 plugin.py:7629 plugin.py:7640
-#: plugin.py:7651 plugin.py:7719 plugin.py:7734 plugin.py:7747 plugin.py:7761
-#: plugin.py:7776 plugin.py:7789 plugin.py:7811 plugin.py:7823
-msgid "- Shadow Edges"
-msgstr "- 阴影边缘"
-
-#: plugin.py:6009 plugin.py:6829 plugin.py:7358
-msgid "Clock 2"
-msgstr "时钟2"
-
-#: plugin.py:6024 plugin.py:6744
-msgid "Program Name"
-msgstr "程序名称"
-
-#: plugin.py:6028 plugin.py:6051 plugin.py:6064 plugin.py:6077 plugin.py:6090
-#: plugin.py:6124 plugin.py:6138 plugin.py:6192 plugin.py:6568 plugin.py:6613
-#: plugin.py:6710 plugin.py:6722 plugin.py:6735 plugin.py:6748 plugin.py:6761
-#: plugin.py:6774 plugin.py:6853 plugin.py:6866 plugin.py:6884 plugin.py:7194
-#: plugin.py:7239 plugin.py:7377 plugin.py:7396 plugin.py:7409 plugin.py:7740
-#: plugin.py:7785
-msgid "- maximum Lines"
-msgstr "- 最大行数"
-
-#: plugin.py:6031 plugin.py:6054 plugin.py:6067 plugin.py:6080 plugin.py:6093
-#: plugin.py:6107 plugin.py:6148 plugin.py:6197 plugin.py:6208 plugin.py:6573
-#: plugin.py:6713 plugin.py:6725 plugin.py:6738 plugin.py:6751 plugin.py:6764
-#: plugin.py:6777 plugin.py:6790 plugin.py:6803 plugin.py:6889 plugin.py:7199
-#: plugin.py:7382 plugin.py:7745
-msgid "- Length"
-msgstr "- 长度"
-
-#: plugin.py:6036
-msgid "Program Number"
-msgstr "程序号码示例"
-
-#: plugin.py:6046 plugin.py:6756
-msgid "Program Info"
-msgstr "程序信息"
-
-#: plugin.py:6049 plugin.py:6062 plugin.py:6075 plugin.py:6088 plugin.py:6102
-#: plugin.py:6103 plugin.py:6162 plugin.py:6174 plugin.py:6185 plugin.py:6193
-#: plugin.py:6194 plugin.py:6224 plugin.py:6250 plugin.py:6280 plugin.py:6295
-#: plugin.py:6339 plugin.py:6340 plugin.py:6362 plugin.py:6363 plugin.py:6382
-#: plugin.py:6392 plugin.py:6415 plugin.py:6545 plugin.py:6561 plugin.py:6569
-#: plugin.py:6570 plugin.py:6585 plugin.py:6598 plugin.py:6599 plugin.py:6615
-#: plugin.py:6626 plugin.py:6683 plugin.py:6733 plugin.py:6759 plugin.py:6772
-#: plugin.py:6785 plugin.py:6786 plugin.py:6817 plugin.py:6832 plugin.py:6877
-#: plugin.py:6885 plugin.py:6886 plugin.py:6899 plugin.py:6925 plugin.py:6954
-#: plugin.py:6969 plugin.py:7013 plugin.py:7014 plugin.py:7036 plugin.py:7037
-#: plugin.py:7056 plugin.py:7066 plugin.py:7089 plugin.py:7171 plugin.py:7187
-#: plugin.py:7195 plugin.py:7196 plugin.py:7211 plugin.py:7224 plugin.py:7225
-#: plugin.py:7241 plugin.py:7252 plugin.py:7346 plugin.py:7361 plugin.py:7378
-#: plugin.py:7379 plugin.py:7420 plugin.py:7433 plugin.py:7462 plugin.py:7477
-#: plugin.py:7521 plugin.py:7522 plugin.py:7544 plugin.py:7545 plugin.py:7564
-#: plugin.py:7574 plugin.py:7597 plugin.py:7717 plugin.py:7733 plugin.py:7741
-#: plugin.py:7742 plugin.py:7757 plugin.py:7770 plugin.py:7771 plugin.py:7787
-#: plugin.py:7798
-msgid "- Type"
-msgstr "- 类型"
-
-#: plugin.py:6059
-msgid "Program Info 2"
-msgstr "程序信息 2"
-
-#: plugin.py:6072 plugin.py:6769
-msgid "Next Program Info"
-msgstr "下一个程序信息"
-
-#: plugin.py:6085 plugin.py:6730
-msgid "Extended Description"
-msgstr "扩展描述"
-
-#: plugin.py:6098 plugin.py:6743
-msgid "- use Info when empty"
-msgstr "- 空时使用信息"
-
-#: plugin.py:6099 plugin.py:6782
-msgid "Progress Bar"
-msgstr "进度条"
-
-#: plugin.py:6109 plugin.py:6792
-msgid "- Color Text"
-msgstr "- 文本颜色"
-
-#: plugin.py:6110 plugin.py:6793
-msgid "- Border"
-msgstr "- 边界"
-
-#: plugin.py:6111 plugin.py:6211 plugin.py:6794 plugin.py:6806
-msgid "- Shaded"
-msgstr "- 阴影"
-
-#: plugin.py:6112 plugin.py:6795
-msgid "- Unit min"
-msgstr "- 单位最小值"
-
-#: plugin.py:6114 plugin.py:6844 plugin.py:7387
-msgid "Informations"
-msgstr "信息"
-
-#: plugin.py:6117 plugin.py:6131
-msgid "- Tunerinfo"
-msgstr "- 调谐器信息"
-
-#: plugin.py:6118 plugin.py:6132 plugin.py:6847 plugin.py:6860 plugin.py:7390
-#: plugin.py:7403
-msgid "- Sensors"
-msgstr "- 传感器"
-
-#: plugin.py:6119 plugin.py:6133 plugin.py:6848 plugin.py:6861 plugin.py:7391
-#: plugin.py:7404
-msgid "- CPU"
-msgstr "- 处理器"
-
-#: plugin.py:6128 plugin.py:6857 plugin.py:7400
-msgid "Informations 2"
-msgstr "信息 2"
-
-#: plugin.py:6142
-msgid "Signal Quality Bar"
-msgstr "信号质量条"
-
-#: plugin.py:6151
-msgid "- Gradient"
-msgstr "- 渐变色"
-
-#: plugin.py:6152
-msgid "- Bar Range Min"
-msgstr "- 最小范围"
-
-#: plugin.py:6153
-msgid "- Bar Range Max"
-msgstr "- 最大范围"
-
-#: plugin.py:6154
-msgid "Satellite"
-msgstr "卫星"
-
-#: plugin.py:6166
-msgid "Provider"
-msgstr "供应商"
-
-#: plugin.py:6178 plugin.py:6870 plugin.py:7413
-msgid "Used Tuner"
-msgstr "使用调谐器"
-
-#: plugin.py:6186 plugin.py:6878 plugin.py:7421
-msgid "- only active Tuner"
-msgstr "- 仅活动调谐器"
-
-#: plugin.py:6188 plugin.py:6880 plugin.py:7373
-msgid "Next Timer Event"
-msgstr "下次计时器事件"
-
-#: plugin.py:6202 plugin.py:6797
-msgid "Volume"
-msgstr "体积"
-
-#: plugin.py:6212 plugin.py:6807
-msgid "Mute"
-msgstr "静音"
-
-#: plugin.py:6219 plugin.py:6894
-msgid "Audio/Video"
-msgstr "音频/视频"
-
-#: plugin.py:6230 plugin.py:6905
-msgid "Bitrate"
-msgstr "比特率"
-
-#: plugin.py:6240 plugin.py:6915 plugin.py:7423
-msgid "Online [Ping]"
-msgstr "在线[Ping]"
-
-#: plugin.py:6251 plugin.py:6926 plugin.py:7434
-msgid "- Show State"
-msgstr "- 显示状态"
-
-#: plugin.py:6252 plugin.py:6927 plugin.py:7435
-msgid "- Timeout [ms]"
-msgstr "- 超时[毫秒]"
-
-#: plugin.py:6253 plugin.py:6254 plugin.py:6255 plugin.py:6256 plugin.py:6257
-#: plugin.py:6928 plugin.py:6929 plugin.py:6930 plugin.py:6931 plugin.py:6932
-#: plugin.py:7436 plugin.py:7437 plugin.py:7438 plugin.py:7439 plugin.py:7440
-msgid "- Online Name:Address"
-msgstr "- 在线名称:地址"
-
-#: plugin.py:6258 plugin.py:6933 plugin.py:7441
-msgid "External IP Address"
-msgstr "外部 IP 地址"
-
-#: plugin.py:6269
-msgid "- external IP URL"
-msgstr "- 外部 IP 网址"
-
-#: plugin.py:6270 plugin.py:6944 plugin.py:7452
-msgid "Storage-Devices"
-msgstr "存储设备"
-
-#: plugin.py:6281 plugin.py:6955 plugin.py:7463
-msgid "- free Warning"
-msgstr "- 免费警告"
-
-#: plugin.py:6282 plugin.py:6956 plugin.py:7464
-msgid "- extra Info"
-msgstr "- 额外信息"
-
-#: plugin.py:6283 plugin.py:6284 plugin.py:6285 plugin.py:6286 plugin.py:6287
-#: plugin.py:6957 plugin.py:6958 plugin.py:6959 plugin.py:6960 plugin.py:6961
-#: plugin.py:7465 plugin.py:7466 plugin.py:7467 plugin.py:7468 plugin.py:7469
-msgid "- Device Name"
-msgstr "- 设备名称"
-
-#: plugin.py:6288 plugin.py:6962 plugin.py:7470
-msgid "HDD"
-msgstr "HDD"
-
-#: plugin.py:6296 plugin.py:6970 plugin.py:7478
+#: ..\WebConfigSite.py:28 ..\plugin.py:6222 ..\plugin.py:6896 ..\plugin.py:7404
 msgid "Weather"
 msgstr "天气"
 
-#: plugin.py:6300 plugin.py:6311 plugin.py:6322 plugin.py:6595 plugin.py:6974
-#: plugin.py:6985 plugin.py:6996 plugin.py:7221 plugin.py:7482 plugin.py:7493
-#: plugin.py:7504 plugin.py:7767
-msgid "- Zoom"
-msgstr "- 缩小 -"
-
-#: plugin.py:6303 plugin.py:6314 plugin.py:6325 plugin.py:6977 plugin.py:6988
-#: plugin.py:6999 plugin.py:7485 plugin.py:7496 plugin.py:7507
-msgid "- Weather Type"
-msgstr "- 天气类型"
-
-#: plugin.py:6307 plugin.py:6981 plugin.py:7489
-msgid "Weather 2"
-msgstr "天气2"
-
-#: plugin.py:6318 plugin.py:6992 plugin.py:7500
-msgid "Meteo-Weather Station"
-msgstr "气象站"
-
-#: plugin.py:6327 plugin.py:7001 plugin.py:7509
+#: ..\WebConfigSite.py:28 ..\plugin.py:6253 ..\plugin.py:6927 ..\plugin.py:7435
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: plugin.py:6334 plugin.py:6357 plugin.py:6381 plugin.py:6391 plugin.py:7008
-#: plugin.py:7031 plugin.py:7055 plugin.py:7065 plugin.py:7516 plugin.py:7539
-#: plugin.py:7563 plugin.py:7573
-msgid "- Station"
-msgstr "- 站"
-
-#: plugin.py:6335 plugin.py:6358 plugin.py:7009 plugin.py:7032 plugin.py:7517
-#: plugin.py:7540
-msgid "- Module"
-msgstr "- 模块"
-
-#: plugin.py:6336 plugin.py:6359 plugin.py:7010 plugin.py:7033 plugin.py:7518
-#: plugin.py:7541
-msgid "- Module userdefined"
-msgstr "- 未指定模块"
-
-#: plugin.py:6337 plugin.py:6360 plugin.py:7011 plugin.py:7034 plugin.py:7519
-#: plugin.py:7542
-msgid "- Base"
-msgstr "- 基本"
-
-#: plugin.py:6338 plugin.py:6361 plugin.py:7012 plugin.py:7035 plugin.py:7520
-#: plugin.py:7543
-msgid "- Name"
-msgstr "- 名称"
-
-#: plugin.py:6342 plugin.py:6365 plugin.py:6556 plugin.py:7016 plugin.py:7039
-#: plugin.py:7182 plugin.py:7524 plugin.py:7547 plugin.py:7728
-msgid "- Color 1"
-msgstr "- 颜色 1"
-
-#: plugin.py:6343 plugin.py:6366 plugin.py:6557 plugin.py:7017 plugin.py:7040
-#: plugin.py:7183 plugin.py:7525 plugin.py:7548 plugin.py:7729
-msgid "- Color 2"
-msgstr "- 颜色 2"
-
-#: plugin.py:6344 plugin.py:6367 plugin.py:6558 plugin.py:7018 plugin.py:7041
-#: plugin.py:7184 plugin.py:7526 plugin.py:7549 plugin.py:7730
-msgid "- Color 3"
-msgstr "- 颜色 3"
-
-#: plugin.py:6345 plugin.py:6368 plugin.py:6559 plugin.py:7019 plugin.py:7042
-#: plugin.py:7185 plugin.py:7527 plugin.py:7550 plugin.py:7731
-msgid "- Color 4"
-msgstr "- 颜色 4"
-
-#: plugin.py:6346 plugin.py:6369 plugin.py:6560 plugin.py:7020 plugin.py:7043
-#: plugin.py:7186 plugin.py:7528 plugin.py:7551 plugin.py:7732
-msgid "- Color 5"
-msgstr "- 颜色 5"
-
-#: plugin.py:6347 plugin.py:6370 plugin.py:7021 plugin.py:7044 plugin.py:7529
-#: plugin.py:7552
-msgid "- Color 6"
-msgstr "- Spalva 6"
-
-#: plugin.py:6350 plugin.py:7024 plugin.py:7532
-msgid "Netatmo 2"
-msgstr "Netatmo 2"
-
-#: plugin.py:6373 plugin.py:7047 plugin.py:7555
-msgid "Netatmo CO2 Indicator"
-msgstr "Netatmo CO2指标"
-
-#: plugin.py:6379 plugin.py:6389 plugin.py:7053 plugin.py:7063 plugin.py:7561
-#: plugin.py:7571
-msgid "- Length [Bar]"
-msgstr "- 长度 [Bar]"
-
-#: plugin.py:6383 plugin.py:7057 plugin.py:7565
-msgid "Netatmo Comfort Indicator"
-msgstr "Netatmo舒适度指示器"
-
-#: plugin.py:6393 plugin.py:7067 plugin.py:7575
-msgid "Moonphase"
-msgstr "月相"
-
-#: plugin.py:6400 plugin.py:7074 plugin.py:7075 plugin.py:7582
-msgid "- Infolines"
-msgstr "- 线"
-
-#: plugin.py:6401 plugin.py:7583
-msgid "- Trendarrows"
-msgstr "- 趋势箭头"
-
-#: plugin.py:6406 plugin.py:7080 plugin.py:7588
-msgid "Sunrise"
-msgstr "日出"
-
-#: plugin.py:6418 plugin.py:7151 plugin.py:7600
-msgid "Show oscam.lcd"
-msgstr "显示oscam.lcd"
-
-#: plugin.py:6421 plugin.py:6440 plugin.py:6451 plugin.py:6462 plugin.py:6527
-#: plugin.py:7095 plugin.py:7106 plugin.py:7612 plugin.py:7623 plugin.py:7634
-#: plugin.py:7699
-msgid "- File [ok]>"
-msgstr "- 文件路 [ok]>"
-
-#: plugin.py:6428
-msgid "Show ecm.info"
-msgstr "显示ecm.info"
-
-#: plugin.py:6437 plugin.py:7092 plugin.py:7609
-msgid "Show Textfile"
-msgstr "显示文本文件"
-
-#: plugin.py:6448 plugin.py:7103 plugin.py:7620
-msgid "Show Textfile 2"
-msgstr "显示文本文件2"
-
-#: plugin.py:6459 plugin.py:7631
-msgid "Show Textfile 3"
-msgstr "显示文本文件3"
-
-#: plugin.py:6470 plugin.py:7642
-msgid "Show HTTP Text"
-msgstr "显示HTTP文本"
-
-#: plugin.py:6473 plugin.py:6487 plugin.py:7645 plugin.py:7659
-msgid "- URL"
-msgstr "- URL"
-
-#: plugin.py:6481 plugin.py:7653
-msgid "WWW-Internet Converter"
-msgstr "WWW网络转换器"
-
-#: plugin.py:6488 plugin.py:7660
-msgid "- HTTP Width"
-msgstr "- HTTP宽度"
-
-#: plugin.py:6489 plugin.py:7661
-msgid "- HTTP Height"
-msgstr "- HTTP高度"
-
-#: plugin.py:6490 plugin.py:7662
-msgid "- Cut from X"
-msgstr "- 从X剪切"
-
-#: plugin.py:6491 plugin.py:7663
-msgid "- Cut from Y"
-msgstr "- 从Y剪切"
-
-#: plugin.py:6492 plugin.py:7664
-msgid "- Cut Width [disable = 0]"
-msgstr "- 剪切宽度[禁用= 0]"
-
-#: plugin.py:6493 plugin.py:7665
-msgid "- Cut Height [disable = 0]"
-msgstr "- 剪切高度[禁用= 0]"
-
-#: plugin.py:6494 plugin.py:7114 plugin.py:7666
-msgid "Show Picture"
-msgstr "显示图片"
-
-#: plugin.py:6497 plugin.py:6507 plugin.py:6517 plugin.py:7117 plugin.py:7127
-#: plugin.py:7669 plugin.py:7679 plugin.py:7689
-msgid "- File or Path [ok]>"
-msgstr "- 文件或路径[ok]>"
-
-#: plugin.py:6499 plugin.py:6509 plugin.py:6519 plugin.py:6529 plugin.py:7119
-#: plugin.py:7129 plugin.py:7138 plugin.py:7671 plugin.py:7681 plugin.py:7691
-#: plugin.py:7701
-msgid "- Size max Height"
-msgstr "- 最大尺寸高度"
-
-#: plugin.py:6502 plugin.py:6512 plugin.py:6522 plugin.py:6532 plugin.py:7122
-#: plugin.py:7132 plugin.py:7674 plugin.py:7684 plugin.py:7694 plugin.py:7704
-msgid "- Quick Update"
-msgstr "- 快速更新"
-
-#: plugin.py:6504 plugin.py:7124 plugin.py:7676
-msgid "Show Picture 2"
-msgstr "显示图片2"
-
-#: plugin.py:6514 plugin.py:7686
-msgid "Show Picture 3"
-msgstr "显示图片3"
-
-#: plugin.py:6524 plugin.py:7696
-msgid "Show Picture 4"
-msgstr "显示图片4"
-
-#: plugin.py:6534 plugin.py:7160 plugin.py:7706
+#: ..\WebConfigSite.py:28 ..\plugin.py:6460 ..\plugin.py:7086 ..\plugin.py:7632
 msgid "Mail"
 msgstr "邮件"
 
-#: plugin.py:6543 plugin.py:7169 plugin.py:7715
-msgid "- Lines"
-msgstr "- 线"
-
-#: plugin.py:6544 plugin.py:7170 plugin.py:7716
-msgid "- Mail Konto"
-msgstr "- 邮件帐户"
-
-#: plugin.py:6546 plugin.py:6555 plugin.py:6614 plugin.py:7172 plugin.py:7181
-#: plugin.py:7240 plugin.py:7718 plugin.py:7727 plugin.py:7786
-msgid "- max Width"
-msgstr "- 最大宽度"
-
-#: plugin.py:6549 plugin.py:7175 plugin.py:7721
+#: ..\WebConfigSite.py:28 ..\plugin.py:6475 ..\plugin.py:7101 ..\plugin.py:7647
 msgid "Remote Box"
 msgstr "遥控器"
 
-#: plugin.py:6564 plugin.py:7190 plugin.py:7736
-msgid "Remote Box Timer"
-msgstr "遥控盒定时器"
-
-#: plugin.py:6577 plugin.py:7203 plugin.py:7749
+#: ..\WebConfigSite.py:28 ..\plugin.py:6503 ..\plugin.py:7129 ..\plugin.py:7675
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: plugin.py:6586 plugin.py:7212 plugin.py:7758
-msgid "- Picture Size"
-msgstr "- 图片尺寸"
-
-#: plugin.py:6587 plugin.py:7213 plugin.py:7759
-msgid "- Picture Position"
-msgstr "- 图片位置"
-
-#: plugin.py:6588 plugin.py:7214 plugin.py:7760
-msgid "- Picture Alignment"
-msgstr "- 图片对齐"
-
-#: plugin.py:6591 plugin.py:7217 plugin.py:7763
+#: ..\WebConfigSite.py:28 ..\plugin.py:6517 ..\plugin.py:7143 ..\plugin.py:7689
 msgid "Calendar"
 msgstr "日历"
 
-#: plugin.py:6600 plugin.py:7226 plugin.py:7772
+#: ..\WebConfigSite.py:192 ..\plugin.py:5832
+msgid "WebIF IP Allow"
+msgstr "WebIF IP允许"
+
+#: ..\WebConfigSite.py:260
+msgid "No or wrong File selected, try a correct File first !"
+msgstr "没有或选择了错误的文件，请先尝试正确的文件！"
+
+#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5460
+msgid "Mode"
+msgstr "模式"
+
+#: ..\WebConfigSite.py:527
+msgid "IP seurity not supported by Box"
+msgstr "设备不支持IP验证"
+
+#: ..\WebConfigSite.py:542
+msgid "Crashlog"
+msgstr "崩溃日志"
+
+#: ..\WebConfigSite.py:544
+msgid "Show"
+msgstr "显示"
+
+#: ..\WebConfigSite.py:545
+msgid "Delete"
+msgstr "删除"
+
+#: ..\WebConfigSite.py:549
+msgid "Filename"
+msgstr "文档名称"
+
+#: ..\WebConfigSite.py:550
+msgid "Restore Config"
+msgstr "恢复配置"
+
+#: ..\WebConfigSite.py:551
+msgid "Backup Config"
+msgstr "备份配置"
+
+#: ..\WebConfigSite.py:553
+msgid "Delete Logfile"
+msgstr "删除日志文件"
+
+#: ..\WebConfigSite.py:554
+msgid "Download Logfile"
+msgstr "下载日志文件"
+
+#: ..\WebConfigSite.py:555
+msgid "Save Config"
+msgstr "保存配置"
+
+#: ..\WebConfigSite.py:563
+msgid "stop Screencycle"
+msgstr "停止屏幕循环"
+
+#: ..\WebConfigSite.py:569 ..\plugin.py:352 ..\plugin.py:5498 ..\plugin.py:5641
+#: ..\plugin.py:7787 ..\plugin.py:7803
+msgid "Global"
+msgstr "全局"
+
+#: ..\WebConfigSite.py:570 ..\plugin.py:505 ..\plugin.py:5489 ..\plugin.py:5883
+#: ..\plugin.py:7788 ..\plugin.py:7792
+msgid "On"
+msgstr "打开"
+
+#: ..\WebConfigSite.py:571 ..\plugin.py:505 ..\plugin.py:630 ..\plugin.py:5492
+#: ..\plugin.py:6611 ..\plugin.py:7793 ..\plugin.py:7797 ..\plugin.py:7998
+msgid "Media"
+msgstr "媒体"
+
+#: ..\WebConfigSite.py:572 ..\plugin.py:5495 ..\plugin.py:5516
+#: ..\plugin.py:7233 ..\plugin.py:7798 ..\plugin.py:7802 ..\plugin.py:7996
+msgid "Idle"
+msgstr "空闲"
+
+#: ..\WebConfigSite.py:574
+msgid "GUI Restart is required"
+msgstr "需要重新启动GUI"
+
+#: ..\WebConfigSite.py:596
+msgid "Element"
+msgstr "元素"
+
+#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+msgid "other"
+msgstr "其他"
+
+#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+msgid "set Settings"
+msgstr "设置设置"
+
+#: ..\WebConfigSite.py:714
+msgid "copy to On"
+msgstr "复制到"
+
+#: ..\WebConfigSite.py:716
+msgid "copy to Media"
+msgstr "复制到媒体"
+
+#: ..\WebConfigSite.py:718
+msgid "copy to Idle"
+msgstr "复制到空闲"
+
+#: ..\WebConfigSite.py:733
+msgid "Exec"
+msgstr "执行"
+
+#: ..\WebConfigSite.py:752
+msgid "Show Externals"
+msgstr "显示外观"
+
+#: ..\myFileList.py:158
+msgid "List of Storage Devices"
+msgstr "存储设备列表"
+
+#: ..\myFileList.py:160
+msgid "Parent Directory"
+msgstr "父目录"
+
+#: ..\plugin.py:299
+msgid "Fri"
+msgstr "周五"
+
+#: ..\plugin.py:299
+msgid "Mon"
+msgstr "周一"
+
+#: ..\plugin.py:299
+msgid "Sat"
+msgstr "周六"
+
+#: ..\plugin.py:299
+msgid "Sun"
+msgstr "周日"
+
+#: ..\plugin.py:299
+msgid "Thur"
+msgstr "周四"
+
+#: ..\plugin.py:299
+msgid "Tue"
+msgstr "周二"
+
+#: ..\plugin.py:299
+msgid "Wed"
+msgstr "周三"
+
+#: ..\plugin.py:300
+msgid "black"
+msgstr "黑色"
+
+#: ..\plugin.py:300
+msgid "white"
+msgstr "白色"
+
+#: ..\plugin.py:301
+msgid "gray"
+msgstr "灰色"
+
+#: ..\plugin.py:301
+msgid "silver"
+msgstr "银色"
+
+#: ..\plugin.py:301
+msgid "slategray"
+msgstr "青灰色"
+
+#: ..\plugin.py:302
+msgid "aquamarine"
+msgstr "藍綠色"
+
+#: ..\plugin.py:303
+msgid "gold"
+msgstr "金色"
+
+#: ..\plugin.py:303
+msgid "greenyellow"
+msgstr "黄绿色"
+
+#: ..\plugin.py:303
+msgid "yellow"
+msgstr "黄色"
+
+#: ..\plugin.py:304
+msgid "darkorange"
+msgstr "深橙色"
+
+#: ..\plugin.py:304
+msgid "darkred"
+msgstr "深红"
+
+#: ..\plugin.py:304
+msgid "indianred"
+msgstr "印度红"
+
+#: ..\plugin.py:304
+msgid "orange"
+msgstr "橙色"
+
+#: ..\plugin.py:304
+msgid "orangered"
+msgstr "橘红色"
+
+#: ..\plugin.py:304
+msgid "red"
+msgstr "红色"
+
+#: ..\plugin.py:304
+msgid "tomato"
+msgstr "番茄"
+
+#: ..\plugin.py:305
+msgid "darkgreen"
+msgstr "深绿色"
+
+#: ..\plugin.py:305
+msgid "green"
+msgstr "绿色"
+
+#: ..\plugin.py:305
+msgid "lawngreen"
+msgstr "草坪绿"
+
+#: ..\plugin.py:305
+msgid "lightgreen"
+msgstr "浅绿色"
+
+#: ..\plugin.py:305
+msgid "lime"
+msgstr "幸福绿"
+
+#: ..\plugin.py:306
+msgid "blue"
+msgstr "蓝色"
+
+#: ..\plugin.py:306
+msgid "blueviolet"
+msgstr "紫罗兰色"
+
+#: ..\plugin.py:306
+msgid "cadetblue"
+msgstr "灰蓝色"
+
+#: ..\plugin.py:306
+msgid "cornflowerblue"
+msgstr "浅蓝色"
+
+#: ..\plugin.py:306
+msgid "darkblue"
+msgstr "深蓝色"
+
+#: ..\plugin.py:306
+msgid "indigo"
+msgstr "靛藍"
+
+#: ..\plugin.py:306
+msgid "lightblue"
+msgstr "浅蓝"
+
+#: ..\plugin.py:307
+msgid "cyan"
+msgstr "青色"
+
+#: ..\plugin.py:307
+msgid "darkorchid"
+msgstr "深紫色"
+
+#: ..\plugin.py:307
+msgid "deeppink"
+msgstr "深粉红色"
+
+#: ..\plugin.py:307
+msgid "magenta"
+msgstr "紫紅色"
+
+#: ..\plugin.py:307
+msgid "violet"
+msgstr "紫罗兰色"
+
+#: ..\plugin.py:308
+msgid "brown"
+msgstr "棕色"
+
+#: ..\plugin.py:308
+msgid "moccasin"
+msgstr "鹿皮黄色"
+
+#: ..\plugin.py:308
+msgid "olive"
+msgstr "橄榄"
+
+#: ..\plugin.py:308
+msgid "rosybrown"
+msgstr "玫瑰棕色"
+
+#: ..\plugin.py:308
+msgid "sandybrown"
+msgstr "沙棕色"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2"
+msgstr "屏幕1 + 2"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3"
+msgstr "屏幕1 + 2 + 3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+3+4"
+msgstr "屏幕1 + 2 + 3 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+2+4"
+msgstr "屏幕1 + 2 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3"
+msgstr "屏幕1 + 3"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+4"
+msgstr "屏幕1 + 3 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 1+3+5+7+9"
+msgstr "屏幕1 + 3 + 5 + 7 + 9"
+
+#: ..\plugin.py:310
+msgid "Screen 1+4"
+msgstr "屏幕1 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3"
+msgstr "屏幕2 + 3"
+
+#: ..\plugin.py:310
+msgid "Screen 2+3+4"
+msgstr "屏幕2 + 3 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4"
+msgstr "屏幕2 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 2+4+6+8"
+msgstr "屏幕2 + 4 + 6 + 8"
+
+#: ..\plugin.py:310
+msgid "Screen 3+4"
+msgstr "屏幕3 + 4"
+
+#: ..\plugin.py:310
+msgid "Screen 5-8"
+msgstr "屏幕5-8"
+
+#: ..\plugin.py:310
+msgid "Screen 5-9"
+msgstr "屏幕5-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-5"
+msgstr "屏幕1-5"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-6"
+msgstr "屏幕1-6"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-7"
+msgstr "屏幕1-7"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-8"
+msgstr "屏幕1-8"
+
+#: ..\plugin.py:310 ..\plugin.py:311
+msgid "Screen 1-9"
+msgstr "屏幕1-9"
+
+#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+msgid "Screen 1"
+msgstr "屏幕1"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 2"
+msgstr "屏幕2"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 3"
+msgstr "屏幕3"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 4"
+msgstr "屏幕4"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 5"
+msgstr "屏幕5"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 6"
+msgstr "屏幕6"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 7"
+msgstr "屏幕7"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 8"
+msgstr "屏幕8"
+
+#: ..\plugin.py:310 ..\plugin.py:312
+msgid "Screen 9"
+msgstr "屏幕9"
+
+#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
+#: ..\plugin.py:382 ..\plugin.py:391 ..\plugin.py:392 ..\plugin.py:406
+#: ..\plugin.py:468 ..\plugin.py:491 ..\plugin.py:492 ..\plugin.py:517
+#: ..\plugin.py:518 ..\plugin.py:623 ..\plugin.py:640 ..\plugin.py:649
+#: ..\plugin.py:663 ..\plugin.py:672 ..\plugin.py:682 ..\plugin.py:754
+#: ..\plugin.py:923 ..\plugin.py:1059 ..\plugin.py:1134 ..\plugin.py:1142
+#: ..\plugin.py:1153 ..\plugin.py:1164 ..\plugin.py:1174 ..\plugin.py:1184
+#: ..\plugin.py:1194 ..\plugin.py:1202 ..\plugin.py:1267 ..\plugin.py:1275
+#: ..\plugin.py:1286 ..\plugin.py:1414 ..\plugin.py:1598 ..\plugin.py:1691
+#: ..\plugin.py:1702 ..\plugin.py:1712 ..\plugin.py:1722 ..\plugin.py:1746
+#: ..\plugin.py:1754 ..\plugin.py:1768 ..\plugin.py:1777 ..\plugin.py:1787
+#: ..\plugin.py:1827 ..\plugin.py:1835 ..\plugin.py:1847 ..\plugin.py:1855
+#: ..\plugin.py:1866 ..\plugin.py:1972 ..\plugin.py:2061 ..\plugin.py:2133
+#: ..\plugin.py:2144 ..\plugin.py:2155 ..\plugin.py:2165 ..\plugin.py:2175
+#: ..\plugin.py:2185 ..\plugin.py:2193 ..\plugin.py:2251 ..\plugin.py:2265
+#: ..\plugin.py:2274 ..\plugin.py:2284 ..\plugin.py:2324 ..\plugin.py:2332
+msgid "off"
+msgstr "关闭"
+
+#: ..\plugin.py:311
+msgid "Screen 1-2"
+msgstr "屏幕1-2"
+
+#: ..\plugin.py:311
+msgid "Screen 1-3"
+msgstr "屏幕1-3"
+
+#: ..\plugin.py:311
+msgid "Screen 1-4"
+msgstr "屏幕1-4"
+
+#: ..\plugin.py:313 ..\plugin.py:1847
+msgid "on"
+msgstr "启用"
+
+#: ..\plugin.py:314
+msgid "2h"
+msgstr "2小时"
+
+#: ..\plugin.py:314
+msgid "3h"
+msgstr "3小时"
+
+#: ..\plugin.py:314
+msgid "3min"
+msgstr "3分钟"
+
+#: ..\plugin.py:314
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:314
+msgid "4min"
+msgstr "4分钟"
+
+#: ..\plugin.py:314
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:314
+msgid "5h"
+msgstr "5小时"
+
+#: ..\plugin.py:314
+msgid "5s"
+msgstr "5秒"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "10s"
+msgstr "10秒"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "15s"
+msgstr "15秒"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "1min"
+msgstr "1分钟"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "20s"
+msgstr "20s"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "2min"
+msgstr "2分钟"
+
+#: ..\plugin.py:314 ..\plugin.py:475 ..\plugin.py:480 ..\plugin.py:485
+msgid "30s"
+msgstr "30秒"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "10min"
+msgstr "10分钟"
+
+#: ..\plugin.py:314 ..\plugin.py:539
+msgid "5min"
+msgstr "5分钟"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588
+msgid "20min"
+msgstr "20分钟"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "30min"
+msgstr "30分钟"
+
+#: ..\plugin.py:314 ..\plugin.py:539 ..\plugin.py:588 ..\plugin.py:1205
+msgid "60min"
+msgstr "60分钟"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2"
+msgstr "LCD 1+2"
+
+#: ..\plugin.py:315
+msgid "LCD 1+2+3"
+msgstr "LCD 1+2+3"
+
+#: ..\plugin.py:315
+msgid "LCD 1+3"
+msgstr "LCD 1+3"
+
+#: ..\plugin.py:315
+msgid "LCD 2+3"
+msgstr "LCD 2+3"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:315 ..\plugin.py:316
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:316
+msgid "LCD 1-3"
+msgstr "LCD 1-3"
+
+#: ..\plugin.py:317
+msgid "Corby@Pearl 128x128"
+msgstr "Corby @珍珠128x128"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 240x320"
+msgstr "珍珠（或相容的LCD）240x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 320x240"
+msgstr "珍珠（或相容的LCD）320x240"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 480x320"
+msgstr "珍珠（或相容的LCD）480x320"
+
+#: ..\plugin.py:317
+msgid "Pearl (or compatible LCD) 800x480"
+msgstr "珍珠屏（或兼容液晶屏）800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-72H 800x480"
+msgstr "三星SPF-72H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-75H/76H 800x480"
+msgstr "三星SPF-75H / 76H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-83H 800x600"
+msgstr "三星SPF-83H 800x600"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H 800x480"
+msgstr "三星SPF-87H 800x480"
+
+#: ..\plugin.py:318
+msgid "Samsung SPF-87H old 800x480"
+msgstr "三星SPF-87H旧800x480"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-105P 1024x600"
+msgstr "三星SPF-105P 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H 1024x600"
+msgstr "三星SPF-107H 1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-107H old 1024x600"
+msgstr "三星SPF-107H旧的1024x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85H/86H 800x600"
+msgstr "三星SPF-85H / 86H 800x600"
+
+#: ..\plugin.py:319
+msgid "Samsung SPF-85P/86P 800x600"
+msgstr "三星SPF-85P / 86P 800x600"
+
+#: ..\plugin.py:320
+msgid "Internal Box-Skin-LCD"
+msgstr "内盒式皮肤液晶显示器"
+
+#: ..\plugin.py:320
+msgid "Internal TFT-LCD 400x240"
+msgstr "内置TFT-LCD 400x240"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-1000P 1024x600"
+msgstr "三星SPF-1000P 1024x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-700T 800x600"
+msgstr "三星SPF-700T 800x600"
+
+#: ..\plugin.py:320
+msgid "Samsung SPF-800P 800x480"
+msgstr "三星SPF-800P 800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 1024x600"
+msgstr "仅图片1024x600"
+
+#: ..\plugin.py:321
+msgid "only Picture 320x240"
+msgstr "仅图片320x240"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x480"
+msgstr "仅图片800x480"
+
+#: ..\plugin.py:321
+msgid "only Picture 800x600"
+msgstr "仅图片800x600"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size"
+msgstr "仅图片自定义尺寸"
+
+#: ..\plugin.py:321
+msgid "only Picture Custom Size 2"
+msgstr "仅图片自定义尺寸2"
+
+#: ..\plugin.py:323
+msgid "Internal Vu+ Duo2 LCD 400x240"
+msgstr "内置Vu + Duo2 LCD 400x240"
+
+#: ..\plugin.py:324
+msgid "128x32"
+msgstr "128x32"
+
+#: ..\plugin.py:324
+msgid "128x64"
+msgstr "128x64"
+
+#: ..\plugin.py:324
+msgid "132x64"
+msgstr "132x64"
+
+#: ..\plugin.py:324
+msgid "220x176"
+msgstr "220x176"
+
+#: ..\plugin.py:324
+msgid "255x64"
+msgstr "255x64"
+
+#: ..\plugin.py:324
+msgid "400x240"
+msgstr "400x240"
+
+#: ..\plugin.py:324
+msgid "480x320"
+msgstr "480x320"
+
+#: ..\plugin.py:324
+msgid "720x405"
+msgstr "720x405"
+
+#: ..\plugin.py:324
+msgid "800x480"
+msgstr "800x480"
+
+#: ..\plugin.py:324
+msgid "96x64"
+msgstr "96x64"
+
+#: ..\plugin.py:325
+msgid "2 Days 1 Line"
+msgstr "2天1行"
+
+#: ..\plugin.py:325
+msgid "2 Days 2 Line"
+msgstr "2天2行"
+
+#: ..\plugin.py:325
+msgid "4 Days 1 Line"
+msgstr "4天1行"
+
+#: ..\plugin.py:325
+msgid "4 Days 2 Lines"
+msgstr "4天2行"
+
+#: ..\plugin.py:325
+msgid "4 Days Vertical View"
+msgstr "4天垂直视图"
+
+#: ..\plugin.py:325
+msgid "5 Days 1 Line"
+msgstr "5天1行"
+
+#: ..\plugin.py:325
+msgid "5 Days 2 Lines"
+msgstr "5天2行"
+
+#: ..\plugin.py:325
+msgid "5 Days Vertical View"
+msgstr "5天垂直视图"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (+C)"
+msgstr "当前温度（+C）"
+
+#: ..\plugin.py:325
+msgid "Current Temperature (-C)"
+msgstr "当前温度（-C）"
+
+#: ..\plugin.py:325 ..\plugin.py:326
+msgid "Current"
+msgstr "当前"
+
+#: ..\plugin.py:326
+msgid "Current Temperature"
+msgstr "当前温度"
+
+#: ..\plugin.py:327
+msgid "All"
+msgstr "全部"
+
+#: ..\plugin.py:327
+msgid "Temperature"
+msgstr "温度"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2"
+msgstr "温度+二氧化碳"
+
+#: ..\plugin.py:327
+msgid "Temperature+Co2+Pressure"
+msgstr "温度+ CO2 +压力"
+
+#: ..\plugin.py:327
+msgid "Temperature+Humidity"
+msgstr "温度+湿度"
+
+#: ..\plugin.py:328
+msgid "Module 1"
+msgstr "模块1"
+
+#: ..\plugin.py:328
+msgid "Module 1+2"
+msgstr "模块1 + 2"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+3"
+msgstr "模块1 + 2 + 3"
+
+#: ..\plugin.py:328
+msgid "Module 1+2+4"
+msgstr "模块1 + 2 + 4"
+
+#: ..\plugin.py:328
+msgid "Module 1+3"
+msgstr "模块1 + 3"
+
+#: ..\plugin.py:328
+msgid "Module 1+3+4"
+msgstr "模块1 + 3 + 4"
+
+#: ..\plugin.py:328
+msgid "Module 1+4"
+msgstr "模块1 + 4"
+
+#: ..\plugin.py:328
+msgid "Module 1-4"
+msgstr "模块1-4"
+
+#: ..\plugin.py:328
+msgid "Module 1-5"
+msgstr "模块1-5"
+
+#: ..\plugin.py:328
+msgid "Module 1-6"
+msgstr "模块1-6"
+
+#: ..\plugin.py:328
+msgid "Module 2"
+msgstr "模块2"
+
+#: ..\plugin.py:328
+msgid "Module 2+3"
+msgstr "模块2 + 3"
+
+#: ..\plugin.py:328
+msgid "Module 2+3+4"
+msgstr "模块2 + 3 + 4"
+
+#: ..\plugin.py:328
+msgid "Module 2+4"
+msgstr "模块2 + 4"
+
+#: ..\plugin.py:328
+msgid "Module 2-6"
+msgstr "模块2-6"
+
+#: ..\plugin.py:328
+msgid "Module 3"
+msgstr "模块3"
+
+#: ..\plugin.py:328
+msgid "Module 3+4"
+msgstr "模块3 + 4"
+
+#: ..\plugin.py:328
+msgid "Module 3-6"
+msgstr "模块3-6"
+
+#: ..\plugin.py:328
+msgid "Module 4"
+msgstr "模块4"
+
+#: ..\plugin.py:328
+msgid "Module 4-6"
+msgstr "模块4-6"
+
+#: ..\plugin.py:328
+msgid "Module 5"
+msgstr "模块5"
+
+#: ..\plugin.py:328
+msgid "Module 5-6"
+msgstr "模块5-6"
+
+#: ..\plugin.py:328
+msgid "Module 6"
+msgstr "模块6"
+
+#: ..\plugin.py:328
+msgid "userdefined"
+msgstr "用户自定义"
+
+#: ..\plugin.py:329
+msgid "Bar"
+msgstr "条形图"
+
+#: ..\plugin.py:329
+msgid "Bar+Value"
+msgstr "条形+数值"
+
+#: ..\plugin.py:329
+msgid "Knob"
+msgstr "旋钮"
+
+#: ..\plugin.py:329
+msgid "Knob+Value"
+msgstr "旋钮+值"
+
+#: ..\plugin.py:330
+msgid "Analog"
+msgstr "模拟"
+
+#: ..\plugin.py:330
+msgid "Analog+Date"
+msgstr "模拟量+日期"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday"
+msgstr "模拟+日期+周"
+
+#: ..\plugin.py:330
+msgid "Analog+Date+Weekday 2"
+msgstr "模拟+日期+周 2"
+
+#: ..\plugin.py:330
+msgid "Date"
+msgstr "日期"
+
+#: ..\plugin.py:330
+msgid "Date+Time"
+msgstr "日期+时间"
+
+#: ..\plugin.py:330
+msgid "Date+Time+Weekday"
+msgstr "日期+时间+工作日"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Date"
+msgstr "襟翼设计日期"
+
+#: ..\plugin.py:330
+msgid "Flaps Design Weekday"
+msgstr "襟翼设计工作日"
+
+#: ..\plugin.py:330
+msgid "Time"
+msgstr "时间"
+
+#: ..\plugin.py:330
+msgid "Time+Weekday"
+msgstr "时间+工作日"
+
+#: ..\plugin.py:330
+msgid "Weekday"
+msgstr "周日"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "30%"
+msgstr "30%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "35%"
+msgstr "35%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "40%"
+msgstr "40%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "45%"
+msgstr "45%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "50%"
+msgstr "50%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "55%"
+msgstr "55%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "60%"
+msgstr "60%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "65%"
+msgstr "65%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "70%"
+msgstr "70%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "75%"
+msgstr "75%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "80%"
+msgstr "80%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "85%"
+msgstr "85%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "90%"
+msgstr "90%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "95%"
+msgstr "95%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "97%"
+msgstr "97%"
+
+#: ..\plugin.py:331 ..\plugin.py:344
+msgid "98%"
+msgstr "98%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "10%"
+msgstr "10%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "15%"
+msgstr "15%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "2%"
+msgstr "2%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "20%"
+msgstr "20%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "25%"
+msgstr "25%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "3%"
+msgstr "3%"
+
+#: ..\plugin.py:331 ..\plugin.py:345
+msgid "5%"
+msgstr "5%"
+
+#: ..\plugin.py:331 ..\plugin.py:638
+msgid "center"
+msgstr "居中"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "left"
+msgstr "左边"
+
+#: ..\plugin.py:331 ..\plugin.py:638 ..\plugin.py:1131 ..\plugin.py:1139
+#: ..\plugin.py:1743 ..\plugin.py:2130
+msgid "right"
+msgstr "右边"
+
+#: ..\plugin.py:332
+msgid "Extended"
+msgstr "扩展"
+
+#: ..\plugin.py:332
+msgid "Extended (Short)"
+msgstr "扩展（短）"
+
+#: ..\plugin.py:332
+msgid "Short"
+msgstr "短"
+
+#: ..\plugin.py:332
+msgid "Short (Extended)"
+msgstr "短（扩展）"
+
+#: ..\plugin.py:332
+msgid "Short+Extended"
+msgstr "短+扩展"
+
+#: ..\plugin.py:333
+msgid "Month"
+msgstr "月"
+
+#: ..\plugin.py:333
+msgid "Month+Header"
+msgstr "月+标题"
+
+#: ..\plugin.py:333
+msgid "Week"
+msgstr "周"
+
+#: ..\plugin.py:333
+msgid "Week+Header"
+msgstr "周+标题"
+
+#: ..\plugin.py:333
+msgid "no Calendar"
+msgstr "没有日历"
+
+#: ..\plugin.py:334
+msgid "Dates 1 Line"
+msgstr "日期1行"
+
+#: ..\plugin.py:334
+msgid "Dates 3 Lines"
+msgstr "日期3行"
+
+#: ..\plugin.py:334
+msgid "Dates 5 Lines"
+msgstr "日期5行"
+
+#: ..\plugin.py:334
+msgid "Dates 9 Lines"
+msgstr "日期9行"
+
+#: ..\plugin.py:334
+msgid "Dates compact 2 Lines"
+msgstr "日期紧凑2行"
+
+#: ..\plugin.py:334
+msgid "Dates compact 3 Lines"
+msgstr "日期紧凑3行"
+
+#: ..\plugin.py:334 ..\plugin.py:14220
+msgid "no Dates"
+msgstr "没有日期"
+
+#: ..\plugin.py:335
+msgid "Underline"
+msgstr "下划线"
+
+#: ..\plugin.py:335
+msgid "Underline 2"
+msgstr "下划线2"
+
+#: ..\plugin.py:335 ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame"
+msgstr "框架"
+
+#: ..\plugin.py:336
+msgid "Dates"
+msgstr "日期"
+
+#: ..\plugin.py:336
+msgid "Dates compact"
+msgstr "日期紧凑"
+
+#: ..\plugin.py:336
+msgid "Dates compact no Icon"
+msgstr "日期紧凑无图标"
+
+#: ..\plugin.py:336
+msgid "Dates no Icon"
+msgstr "日期无图标"
+
+#: ..\plugin.py:337
+msgid "no Icon"
+msgstr "无图标"
+
+#: ..\plugin.py:337
+msgid "no Icon, with Targetnumber"
+msgstr "没有图标,有目标编号"
+
+#: ..\plugin.py:337
+msgid "with Icon"
+msgstr "带图标"
+
+#: ..\plugin.py:337
+msgid "with Icon & Targetnumber"
+msgstr "带有图标和目标编号"
+
+#: ..\plugin.py:338
+msgid "C"
+msgstr "°C"
+
+#: ..\plugin.py:338
+msgid "C + rpm"
+msgstr "C +转速"
+
+#: ..\plugin.py:338
+msgid "C + rpm/2"
+msgstr "C + 转速 / 2"
+
+#: ..\plugin.py:338
+msgid "rpm"
+msgstr "每分钟转数"
+
+#: ..\plugin.py:338
+msgid "rpm/2"
+msgstr "转速/ 2"
+
+#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:350
+#: ..\plugin.py:418 ..\plugin.py:421 ..\plugin.py:452 ..\plugin.py:454
+#: ..\plugin.py:460 ..\plugin.py:567 ..\plugin.py:569 ..\plugin.py:572
+#: ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:990 ..\plugin.py:1529
+#: ..\plugin.py:1736 ..\plugin.py:2011
+msgid "no"
+msgstr "否"
+
+#: ..\plugin.py:339
+msgid "% + BER"
+msgstr "％+误码率"
+
+#: ..\plugin.py:339
+msgid "db"
+msgstr "分贝"
+
+#: ..\plugin.py:339
+msgid "db + %"
+msgstr "分贝 + %"
+
+#: ..\plugin.py:339
+msgid "db + % + BER"
+msgstr "分贝+％+误码率"
+
+#: ..\plugin.py:339
+msgid "db + BER"
+msgstr "分贝+误码率"
+
+#: ..\plugin.py:339 ..\plugin.py:340
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:340
+msgid "% + Load@1min"
+msgstr "% + 负载@1分钟"
+
+#: ..\plugin.py:340
+msgid "% + Load@5min"
+msgstr "% + 负载@ 5分钟"
+
+#: ..\plugin.py:340
+msgid "Load@1min"
+msgstr "负荷@ 1分钟"
+
+#: ..\plugin.py:340
+msgid "Load@5min"
+msgstr "负荷@ 5分钟"
+
+#: ..\plugin.py:341
+msgid "show run"
+msgstr "显示运行"
+
+#: ..\plugin.py:341
+msgid "show run+sleep"
+msgstr "显示运行+睡眠"
+
+#: ..\plugin.py:342
+msgid "Always All"
+msgstr "总是"
+
+#: ..\plugin.py:342
+msgid "Always New"
+msgstr "总是新的"
+
+#: ..\plugin.py:342
+msgid "Only New"
+msgstr "只有新"
+
+#: ..\plugin.py:343
+msgid "All Informations"
+msgstr "所有信息"
+
+#: ..\plugin.py:343
+msgid "Distance only"
+msgstr "仅距离"
+
+#: ..\plugin.py:343
+msgid "Distance+Illumination"
+msgstr "距离+照度"
+
+#: ..\plugin.py:343
+msgid "Distance+Moonphase"
+msgstr "距离+月相"
+
+#: ..\plugin.py:343
+msgid "Illumination only"
+msgstr "仅照明"
+
+#: ..\plugin.py:343
+msgid "Illumination+Moonphase"
+msgstr "照明+月相"
+
+#: ..\plugin.py:343
+msgid "Moonphase only"
+msgstr "仅月相"
+
+#: ..\plugin.py:344
+msgid "100%"
+msgstr "100%"
+
+#: ..\plugin.py:346
+msgid "1-2"
+msgstr "1-2"
+
+#: ..\plugin.py:346
+msgid "1-3"
+msgstr "1-3"
+
+#: ..\plugin.py:346
+msgid "1-4"
+msgstr "1-4"
+
+#: ..\plugin.py:346
+msgid "1-5"
+msgstr "1-5"
+
+#: ..\plugin.py:346 ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395
+#: ..\plugin.py:468 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:347
+msgid "IMAP"
+msgstr "IMAP"
+
+#: ..\plugin.py:347
+msgid "IMAP-SSL"
+msgstr "IMAP-SSL"
+
+#: ..\plugin.py:347
+msgid "Pop3"
+msgstr "Pop3"
+
+#: ..\plugin.py:347
+msgid "Pop3-SSL"
+msgstr "Pop3-SSL"
+
+#: ..\plugin.py:348
+msgid "Channel"
+msgstr "频道"
+
+#: ..\plugin.py:348
+msgid "Channel+Title"
+msgstr "频道+标题"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel"
+msgstr "Picon +频道"
+
+#: ..\plugin.py:348
+msgid "Picon+Channel+Title"
+msgstr "Picon +频道+标题"
+
+#: ..\plugin.py:348 ..\plugin.py:354 ..\plugin.py:826 ..\plugin.py:837
+#: ..\plugin.py:5895
+msgid "Picon"
+msgstr "皮康"
+
+#: ..\plugin.py:349
+msgid "same color"
+msgstr "相同颜色"
+
+#: ..\plugin.py:350
+msgid "yes +25%"
+msgstr "是+ 25％"
+
+#: ..\plugin.py:350 ..\plugin.py:452 ..\plugin.py:454 ..\plugin.py:567
+#: ..\plugin.py:569 ..\plugin.py:589 ..\plugin.py:699 ..\plugin.py:1736
+msgid "yes"
+msgstr "是"
+
+#: ..\plugin.py:351
+msgid "vertically"
+msgstr "垂直"
+
+#: ..\plugin.py:351 ..\plugin.py:884 ..\plugin.py:1472 ..\plugin.py:1918
+msgid "horizontally"
+msgstr "水平"
+
+#: ..\plugin.py:352
+msgid "4"
+msgstr "4"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:468
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "2"
+msgstr "2"
+
+#: ..\plugin.py:352 ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474
+#: ..\plugin.py:479 ..\plugin.py:484
+msgid "3"
+msgstr "3"
+
+#: ..\plugin.py:352 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "5"
+msgstr "5"
+
+#: ..\plugin.py:353
+msgid "14"
+msgstr "14"
+
+#: ..\plugin.py:353
+msgid "7"
+msgstr "7"
+
+#: ..\plugin.py:353
+msgid "all"
+msgstr "全部"
+
+#: ..\plugin.py:353 ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479
+#: ..\plugin.py:484
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:354
+msgid "Corner"
+msgstr "转角"
+
+#: ..\plugin.py:354
+msgid "Corner+Timeshift"
+msgstr "转角+时移"
+
+#: ..\plugin.py:354
+msgid "Picon+Timeshift"
+msgstr "Picon +时移"
+
+#: ..\plugin.py:355
+msgid "only Progress Bar"
+msgstr "仅进度栏"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes"
+msgstr "剩余分钟"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 1.5)"
+msgstr "剩余分钟 (尺寸1.5)"
+
+#: ..\plugin.py:356
+msgid "with Remaining Minutes (Size 2)"
+msgstr "剩余分钟 (大于2)"
+
+#: ..\plugin.py:357
+msgid "with Percent"
+msgstr "带百分比"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 1.5)"
+msgstr "带百分比 (尺寸1,5)"
+
+#: ..\plugin.py:357
+msgid "with Percent (Size 2)"
+msgstr "与百分比（尺寸2）"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above)"
+msgstr "剩余分钟 (大于)"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 1.5)"
+msgstr "剩余分钟数（大于/尺寸1.5）"
+
+#: ..\plugin.py:358
+msgid "with Remaining Minutes (above/Size 2)"
+msgstr "剩余分钟 (大于/尺寸2)"
+
+#: ..\plugin.py:359
+msgid "with Percent (above)"
+msgstr "与百分比（大于）"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 1.5)"
+msgstr "百分比（大于/尺寸1.5）"
+
+#: ..\plugin.py:359
+msgid "with Percent (above/Size 2)"
+msgstr "百分比（大于/尺寸2）"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below)"
+msgstr "剩下的几分钟 (低于)"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 1.5)"
+msgstr "剩余分钟数（低于/尺寸1.5）"
+
+#: ..\plugin.py:360
+msgid "with Remaining Minutes (below/Size 2)"
+msgstr "剩余分钟数（低于/尺寸2）"
+
+#: ..\plugin.py:361
+msgid "with Percent (below)"
+msgstr "百分比 (低于)"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 1.5)"
+msgstr "百分比（低于/尺寸1.5）"
+
+#: ..\plugin.py:361
+msgid "with Percent (below/Size 2)"
+msgstr "百分比（低于/尺寸2）"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00"
+msgstr "当前00:00"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 1.5)"
+msgstr "当前00:00（尺寸1.5）"
+
+#: ..\plugin.py:362
+msgid "with Current 00:00 (Size 2)"
+msgstr "当前00:00（尺寸2）"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above)"
+msgstr "当前00:00（以上）"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 1.5)"
+msgstr "当前00:00（高于/尺寸1.5）"
+
+#: ..\plugin.py:363
+msgid "with Current 00:00 (above/Size 2)"
+msgstr "当前00:00（尺寸2以上）"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below)"
+msgstr "当前00:00（低于）"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 1.5)"
+msgstr "当前00:00（低于/尺寸1.5）"
+
+#: ..\plugin.py:364
+msgid "with Current 00:00 (below/Size 2)"
+msgstr "当前00:00（下方/尺寸2）"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above)"
+msgstr "分钟/总计百分比 (大于/尺寸2)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 1.5)"
+msgstr "分钟/总计百分比 (大于/尺寸1.5)"
+
+#: ..\plugin.py:365
+msgid "with Percent Minutes / Total (above/Size 2)"
+msgstr "分钟/总计百分比 (大于/尺寸2)"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime"
+msgstr "绝对结束时间"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 1.5)"
+msgstr "绝对结束时间（尺寸1.5）"
+
+#: ..\plugin.py:366
+msgid "with absolute Endtime (Size 2)"
+msgstr "带绝对结束时间 (尺寸2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above)"
+msgstr "分钟/总计百分比 (大于/尺寸2)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 1.5)"
+msgstr "分钟/总计百分比 (大于/尺寸1.5)"
+
+#: ..\plugin.py:367
+msgid "with Minutes Total / Endtime (above/Size 2)"
+msgstr "分钟/总计百分比 (大于/尺寸2)"
+
+#: ..\plugin.py:376
+msgid "Fastmode (2s)"
+msgstr "快速模式（2秒）"
+
+#: ..\plugin.py:376
+msgid "Normal (5s)"
+msgstr "正常 (5秒)"
+
+#: ..\plugin.py:392
+msgid "alphabetic"
+msgstr "按字母顺序排列"
+
+#: ..\plugin.py:392
+msgid "random"
+msgstr "随机"
+
+#: ..\plugin.py:393
+msgid "better/slow"
+msgstr "较好/缓慢"
+
+#: ..\plugin.py:393
+msgid "low/fast (Picture only)"
+msgstr "低/快（仅图片）"
+
+#: ..\plugin.py:393
+msgid "low/fast (all)"
+msgstr "低/快（全部）"
+
+#: ..\plugin.py:395
+msgid "0.5"
+msgstr "0.5"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "10"
+msgstr "10"
+
+#: ..\plugin.py:395 ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "20"
+msgstr "20"
+
+#: ..\plugin.py:398
+msgid "JPG"
+msgstr "JPG"
+
+#: ..\plugin.py:398
+msgid "PNG"
+msgstr "PNG"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (high quality, slow)"
+msgstr "缓存+调整（高质量，慢）"
+
+#: ..\plugin.py:399
+msgid "cache + adjustment (low quality, fast)"
+msgstr "缓存+调整（低质量，快）"
+
+#: ..\plugin.py:399
+msgid "no cache + no adjustment"
+msgstr "没有缓存+没有调整"
+
+#: ..\plugin.py:418
+msgid "Plug Tuner"
+msgstr "插头调谐器"
+
+#: ..\plugin.py:418
+msgid "USB Tuner"
+msgstr "USB调谐器"
+
+#: ..\plugin.py:419
+msgid "EPG"
+msgstr "EPG"
+
+#: ..\plugin.py:419
+msgid "Now/Next"
+msgstr "现在/下一个"
+
+#: ..\plugin.py:433
+msgid "normal"
+msgstr "正常"
+
+#: ..\plugin.py:433
+msgid "reduced"
+msgstr "减少"
+
+#: ..\plugin.py:437
+msgid "Javascript"
+msgstr "Java脚本"
+
+#: ..\plugin.py:437
+msgid "Javascript no Refresh"
+msgstr "Java脚本无刷新"
+
+#: ..\plugin.py:437
+msgid "Reload"
+msgstr "加载"
+
+#: ..\plugin.py:441
+msgid "1 - normal"
+msgstr "1 - 正常"
+
+#: ..\plugin.py:441
+msgid "2 - side by side"
+msgstr "2-并排"
+
+#: ..\plugin.py:442
+msgid "MSN"
+msgstr "MSN"
+
+#: ..\plugin.py:442
+msgid "Open-Meteo"
+msgstr "Open-Meteo"
+
+#: ..\plugin.py:442
+msgid "OpenWeatherMap"
+msgstr "打开天气图"
+
+#: ..\plugin.py:442
+msgid "WeatherUnlocked"
+msgstr "天气解锁"
+
+#: ..\plugin.py:452 ..\plugin.py:589
+msgid "alternative Copy-Mode/DM800hd (24bit)"
+msgstr "备用复制模式/ DM800hd（24位）"
+
+#: ..\plugin.py:454
+msgid "yes + %"
+msgstr "是 + %"
+
+#: ..\plugin.py:460
+msgid "yes, long"
+msgstr "是,很长"
+
+#: ..\plugin.py:460
+msgid "yes, short"
+msgstr "是,简短"
+
+#: ..\plugin.py:467
+msgid "km/h"
+msgstr "公里/小时"
+
+#: ..\plugin.py:467
+msgid "m/s"
+msgstr "米/秒"
+
+#: ..\plugin.py:474 ..\plugin.py:479 ..\plugin.py:484
+msgid "60"
+msgstr "60"
+
+#: ..\plugin.py:486
+msgid "Coversearch"
+msgstr "封面搜索"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "0"
+msgstr "0"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "180"
+msgstr "180"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "270"
+msgstr "270"
+
+#: ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:495
+msgid "90"
+msgstr "90"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504
+msgid "1 / min"
+msgstr "1/分钟"
+
+#: ..\plugin.py:502 ..\plugin.py:503 ..\plugin.py:504 ..\plugin.py:627
+msgid "always"
+msgstr "总是"
+
+#: ..\plugin.py:505
+msgid "On+Media+Standby"
+msgstr "启用+多媒体+唤醒"
+
+#: ..\plugin.py:505
+msgid "Standby"
+msgstr "待机"
+
+#: ..\plugin.py:507
+msgid "32bit - color"
+msgstr "32位-颜色"
+
+#: ..\plugin.py:507
+msgid "8bit - grayscale/color"
+msgstr "8位-灰度/彩色"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey"
+msgstr "2 x快进键"
+
+#: ..\plugin.py:517
+msgid "2 x FastForwardKey Type 2"
+msgstr "2 x快进键类型2"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey"
+msgstr "长按快进键"
+
+#: ..\plugin.py:517
+msgid "Long FastForwardKey Type 2"
+msgstr "长按快进键 类型 2"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x InfoKey"
+msgstr "2 X信息键"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "2 x Mute"
+msgstr "2 x静音"
+
+#: ..\plugin.py:517 ..\plugin.py:518
+msgid "Long InfoKey"
+msgstr "长按信息键"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey"
+msgstr "2 X快速后退键"
+
+#: ..\plugin.py:518
+msgid "2 x FastBackwardKey Type 2"
+msgstr "2 x快退键类型2"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey"
+msgstr "长按快速后退键"
+
+#: ..\plugin.py:518
+msgid "Long FastBackwardKey Type 2"
+msgstr "长按快速后退键 类型 2"
+
+#: ..\plugin.py:539 ..\plugin.py:588
+msgid "15min"
+msgstr "15分钟"
+
+#: ..\plugin.py:567
+msgid "yes, extended"
+msgstr "是,扩展"
+
+#: ..\plugin.py:623
+msgid "Console normal"
+msgstr "控制台正常"
+
+#: ..\plugin.py:623
+msgid "Logfile extensive"
+msgstr "日志文件扩展"
+
+#: ..\plugin.py:623
+msgid "Logfile normal"
+msgstr "日志文件正常"
+
+#: ..\plugin.py:627
+msgid "disabled"
+msgstr "已禁用"
+
+#: ..\plugin.py:630
+msgid "Radio"
+msgstr "无线电"
+
+#: ..\plugin.py:630
+msgid "Radio+Media"
+msgstr "广播+媒体"
+
+#: ..\plugin.py:630
+msgid "TV+Radio"
+msgstr "电视/电台"
+
+#: ..\plugin.py:630
+msgid "TV+Radio+Media"
+msgstr "电视+广播+媒体"
+
+#: ..\plugin.py:630 ..\plugin.py:1259
+msgid "TV"
+msgstr "电视"
+
+#: ..\plugin.py:631
+msgid "TV (full)"
+msgstr "电视（完整）"
+
+#: ..\plugin.py:631
+msgid "normal (full)"
+msgstr "正常（满）"
+
+#: ..\plugin.py:631
+msgid "trimmed (black)"
+msgstr "修剪（黑色）"
+
+#: ..\plugin.py:631
+msgid "trimmed (transparent)"
+msgstr "修剪（透明）"
+
+#: ..\plugin.py:634
+msgid "MUTE or defined Keys"
+msgstr "静音或定义键"
+
+#: ..\plugin.py:634
+msgid "any Key"
+msgstr "任意键"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Info"
+msgstr "信息"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:795 ..\plugin.py:1342
+#: ..\plugin.py:1354
+msgid "Time+Info"
+msgstr "时间+信息"
+
+#: ..\plugin.py:771 ..\plugin.py:783 ..\plugin.py:1342
+msgid "Time+Duration+Info"
+msgstr "时间+持续时间+信息"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Mini-EPG"
+msgstr "迷你EPG"
+
+#: ..\plugin.py:795 ..\plugin.py:1354
+msgid "Time+Length+Info"
+msgstr "时间+长度+信息"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half left"
+msgstr "半面向左转"
+
+#: ..\plugin.py:810 ..\plugin.py:1370
+msgid "half right"
+msgstr "半面向右转"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Frame x2"
+msgstr "框架 x2"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "Line"
+msgstr "行"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Bar"
+msgstr "没有进度条"
+
+#: ..\plugin.py:815 ..\plugin.py:1374
+msgid "no Frame"
+msgstr "无框架"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Gradient"
+msgstr "渐变色"
+
+#: ..\plugin.py:817 ..\plugin.py:1376
+msgid "Shadow Edges"
+msgstr "阴影边缘"
+
+#: ..\plugin.py:817 ..\plugin.py:1376 ..\plugin.py:1737
+msgid "Normal"
+msgstr "正常"
+
+#: ..\plugin.py:826
+msgid "Picon+Position below"
+msgstr "Picon+下方位置"
+
+#: ..\plugin.py:826
+msgid "Picon+Position left"
+msgstr "皮康+左位置"
+
+#: ..\plugin.py:826
+msgid "Picon+Position right"
+msgstr "皮康+位置右"
+
+#: ..\plugin.py:826
+msgid "Position"
+msgstr "位置"
+
+#: ..\plugin.py:826 ..\plugin.py:837
+msgid "Name"
+msgstr "名称"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Offline"
+msgstr "离线"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online"
+msgstr "在线"
+
+#: ..\plugin.py:905 ..\plugin.py:1396 ..\plugin.py:1954
+msgid "Online+Offline"
+msgstr "在线+离线"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "only use Timer"
+msgstr "仅使用定时器"
+
+#: ..\plugin.py:949 ..\plugin.py:1013 ..\plugin.py:1433 ..\plugin.py:1552
+#: ..\plugin.py:1903 ..\plugin.py:1991
+msgid "use lead-time"
+msgstr "使用提前期"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "no total Timer"
+msgstr "没有总计时器"
+
+#: ..\plugin.py:950 ..\plugin.py:1014 ..\plugin.py:1434 ..\plugin.py:1553
+#: ..\plugin.py:1904 ..\plugin.py:1992
+msgid "show total Timer"
+msgstr "显示总计时器"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "one line"
+msgstr "一行"
+
+#: ..\plugin.py:968 ..\plugin.py:1507
+msgid "two lines"
+msgstr "两行"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory available"
+msgstr "可用内存"
+
+#: ..\plugin.py:990 ..\plugin.py:1529 ..\plugin.py:2011
+msgid "Memory free"
+msgstr "内存释放"
+
+#: ..\plugin.py:1206
+msgid "cloudconvert.org"
+msgstr "cloudconvert.org"
+
+#: ..\plugin.py:1206
+msgid "convertapi.com"
+msgstr "convertapi.com"
+
+#: ..\plugin.py:1227 ..\plugin.py:1236 ..\plugin.py:1245 ..\plugin.py:1254
+#: ..\plugin.py:1669 ..\plugin.py:1678 ..\plugin.py:2214 ..\plugin.py:2223
+#: ..\plugin.py:2232 ..\plugin.py:2241
+msgid "full Screen"
+msgstr "全屏"
+
+#: ..\plugin.py:1259
+msgid "TV+OSD"
+msgstr "电视+ OSD"
+
+#: ..\plugin.py:1736
+msgid "yes except records"
+msgstr "是,除了录制"
+
+#: ..\plugin.py:1737
+msgid "Google API"
+msgstr "Google API"
+
+#: ..\plugin.py:2630
+msgid "E"
+msgstr "Ε"
+
+#: ..\plugin.py:2630
+msgid "ENE"
+msgstr "东北偏东"
+
+#: ..\plugin.py:2630
+msgid "ESE"
+msgstr "东南偏东"
+
+#: ..\plugin.py:2630
+msgid "N"
+msgstr "N"
+
+#: ..\plugin.py:2630
+msgid "NE"
+msgstr "东北方"
+
+#: ..\plugin.py:2630
+msgid "NNE"
+msgstr "东北偏北"
+
+#: ..\plugin.py:2630
+msgid "NNW"
+msgstr "西北偏北"
+
+#: ..\plugin.py:2630
+msgid "NW"
+msgstr "西北"
+
+#: ..\plugin.py:2630
+msgid "S"
+msgstr "南"
+
+#: ..\plugin.py:2630
+msgid "SE"
+msgstr "东南"
+
+#: ..\plugin.py:2630
+msgid "SSE"
+msgstr "东南偏南"
+
+#: ..\plugin.py:2630
+msgid "SSW"
+msgstr "西南偏南"
+
+#: ..\plugin.py:2630
+msgid "SW"
+msgstr "西南"
+
+#: ..\plugin.py:2630
+msgid "W"
+msgstr "西"
+
+#: ..\plugin.py:2630
+msgid "WNW"
+msgstr "西北偏西"
+
+#: ..\plugin.py:2630
+msgid "WSW"
+msgstr "西南偏西"
+
+#: ..\plugin.py:4544
+msgid "%d.%m.%Y - %H:%M"
+msgstr "%Y.%m.%d - %H:%M"
+
+#: ..\plugin.py:4545
+msgid "%d.%m.%y %H:%M:%S"
+msgstr "%y.%m.%d %H:%M:%S"
+
+#: ..\plugin.py:5110
+msgid "%d-%b-%Y"
+msgstr "%Y-%b-%d"
+
+#: ..\plugin.py:5236
+msgid "Load Active Config-File"
+msgstr "加载活动配置文件"
+
+#: ..\plugin.py:5237
+msgid "Load Defaults / Empty Config"
+msgstr "加载默认值/清空配置"
+
+#: ..\plugin.py:5238
+msgid "Save Config to File... (%s)"
+msgstr "将配置保存到文件... (%s)"
+
+#: ..\plugin.py:5242 ..\plugin.py:5278
+msgid "Load File : %s"
+msgstr "加载文件：%s"
+
+#: ..\plugin.py:5251
+msgid "Delete File?"
+msgstr "是否删除文件?"
+
+#: ..\plugin.py:5286
+msgid "deleted"
+msgstr "已删除"
+
+#: ..\plugin.py:5311
+msgid "currently set : %s"
+msgstr "当前设置：%s"
+
+#: ..\plugin.py:5419 ..\plugin.py:7804
+msgid "LCD4linux Settings"
+msgstr "LCD4linux设置"
+
+#: ..\plugin.py:5469
+msgid "Cancel"
+msgstr "取消"
+
+#: ..\plugin.py:5470
+msgid "Save"
+msgstr "保存"
+
+#: ..\plugin.py:5471
+msgid "Restart Displays"
+msgstr "重新启动显示"
+
+#: ..\plugin.py:5472 ..\plugin.py:7805
+msgid "Set On >>"
+msgstr "启用 >>"
+
+#: ..\plugin.py:5555
+msgid "no LCD1 Picture-File"
+msgstr "没有LCD1图片文件"
+
+#: ..\plugin.py:5580
+msgid "no LCD2 Picture-File"
+msgstr "没有LCD2图片文件"
+
+#: ..\plugin.py:5606
+msgid "no LCD3 Picture-File"
+msgstr "没有LCD3图片文件"
+
+#: ..\plugin.py:5643
+msgid "LCD4linux enabled"
+msgstr "已启用LCD4linux"
+
+#: ..\plugin.py:5644
+msgid "LCD 1 Type"
+msgstr "LCD 1型"
+
+#: ..\plugin.py:5645
+msgid "- LCD 1 Rotate"
+msgstr "- LCD 1旋转"
+
+#: ..\plugin.py:5646 ..\plugin.py:6613 ..\plugin.py:7241
+msgid "- LCD 1 Background Color"
+msgstr "- LCD 1背景色"
+
+#: ..\plugin.py:5647 ..\plugin.py:6614 ..\plugin.py:7242
+msgid "- LCD 1 Background-Picture [ok]>"
+msgstr "- LCD 1背景图片 [ok]>"
+
+#: ..\plugin.py:5648 ..\plugin.py:6615 ..\plugin.py:7243
+msgid "- LCD 1 Brightness"
+msgstr "- LCD 1亮度"
+
+#: ..\plugin.py:5649 ..\plugin.py:6616 ..\plugin.py:7244
+msgid "- LCD 1 Night Reduction"
+msgstr "- LCD 1夜间还原"
+
+#: ..\plugin.py:5650
+msgid "- LCD 1 Refresh"
+msgstr "- LCD 1刷新"
+
+#: ..\plugin.py:5651
+msgid "LCD 2 Type"
+msgstr "LCD 2型"
+
+#: ..\plugin.py:5653
+msgid "- LCD 2 Rotate"
+msgstr "- LCD 2旋转"
+
+#: ..\plugin.py:5654 ..\plugin.py:6617 ..\plugin.py:7245
+msgid "- LCD 2 Background Color"
+msgstr "- LCD 2背景色"
+
+#: ..\plugin.py:5655 ..\plugin.py:6618 ..\plugin.py:7246
+msgid "- LCD 2 Background-Picture [ok]>"
+msgstr "- LCD 2背景图片[ok]>"
+
+#: ..\plugin.py:5656 ..\plugin.py:6619 ..\plugin.py:7247
+msgid "- LCD 2 Brightness"
+msgstr "- LCD 2亮度"
+
+#: ..\plugin.py:5657 ..\plugin.py:6620 ..\plugin.py:7248
+msgid "- LCD 2 Night Reduction"
+msgstr "- LCD 2夜间还原"
+
+#: ..\plugin.py:5658
+msgid "- LCD 2 Refresh"
+msgstr "- LCD 2刷新"
+
+#: ..\plugin.py:5659
+msgid "LCD 3 Type"
+msgstr "LCD 3型"
+
+#: ..\plugin.py:5661
+msgid "- LCD 3 Rotate"
+msgstr "- LCD 3旋转"
+
+#: ..\plugin.py:5662 ..\plugin.py:6621 ..\plugin.py:7249
+msgid "- LCD 3 Background Color"
+msgstr "- LCD 3背景色"
+
+#: ..\plugin.py:5663 ..\plugin.py:6622 ..\plugin.py:7250
+msgid "- LCD 3 Background-Picture [ok]>"
+msgstr "- LCD 3背景图片 [ok]>"
+
+#: ..\plugin.py:5664 ..\plugin.py:6623 ..\plugin.py:7251
+msgid "- LCD 3 Brightness"
+msgstr "- LCD 3亮度"
+
+#: ..\plugin.py:5665 ..\plugin.py:6624 ..\plugin.py:7252
+msgid "- LCD 3 Night Reduction"
+msgstr "- LCD 3夜间还原"
+
+#: ..\plugin.py:5666
+msgid "- LCD 3 Refresh"
+msgstr "- LCD 3刷新"
+
+#: ..\plugin.py:5668
+msgid "Box-Skin-LCD Dimension"
+msgstr "盒式LCD尺寸"
+
+#: ..\plugin.py:5669
+msgid "Box-Skin-LCD Offset"
+msgstr "Box-Skin-LCD偏移"
+
+#: ..\plugin.py:5670
+msgid "Box-Skin-LCD Color"
+msgstr "盒式液晶显示器颜色"
+
+#: ..\plugin.py:5671
+msgid "Box-Skin-LCD Enable On-Mode"
+msgstr "Box-Skin-LCD启用开启模式"
+
+#: ..\plugin.py:5672
+msgid "Box-Skin-LCD Enable Media-Mode"
+msgstr "Box-Skin-LCD启用媒体模式"
+
+#: ..\plugin.py:5673
+msgid "Box-Skin-LCD Enable Idle-Mode"
+msgstr "Box-Skin-LCD启用空闲模式"
+
+#: ..\plugin.py:5674
+msgid "OSD [display time]"
+msgstr "OSD [显示时间]"
+
+#: ..\plugin.py:5677 ..\plugin.py:5684 ..\plugin.py:5892 ..\plugin.py:5897
+#: ..\plugin.py:5910 ..\plugin.py:5922 ..\plugin.py:5937 ..\plugin.py:5952
+#: ..\plugin.py:5964 ..\plugin.py:5974 ..\plugin.py:5987 ..\plugin.py:6000
+#: ..\plugin.py:6013 ..\plugin.py:6027 ..\plugin.py:6042 ..\plugin.py:6056
+#: ..\plugin.py:6070 ..\plugin.py:6082 ..\plugin.py:6094 ..\plugin.py:6106
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6140 ..\plugin.py:6147
+#: ..\plugin.py:6158 ..\plugin.py:6168 ..\plugin.py:6186 ..\plugin.py:6198
+#: ..\plugin.py:6216 ..\plugin.py:6224 ..\plugin.py:6235 ..\plugin.py:6246
+#: ..\plugin.py:6255 ..\plugin.py:6278 ..\plugin.py:6301 ..\plugin.py:6311
+#: ..\plugin.py:6321 ..\plugin.py:6334 ..\plugin.py:6346 ..\plugin.py:6356
+#: ..\plugin.py:6365 ..\plugin.py:6376 ..\plugin.py:6387 ..\plugin.py:6398
+#: ..\plugin.py:6409 ..\plugin.py:6422 ..\plugin.py:6432 ..\plugin.py:6442
+#: ..\plugin.py:6452 ..\plugin.py:6462 ..\plugin.py:6477 ..\plugin.py:6492
+#: ..\plugin.py:6505 ..\plugin.py:6519 ..\plugin.py:6534 ..\plugin.py:6547
+#: ..\plugin.py:6557 ..\plugin.py:6569 ..\plugin.py:6581 ..\plugin.py:6590
+#: ..\plugin.py:6599 ..\plugin.py:6608 ..\plugin.py:6629 ..\plugin.py:6634
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6672 ..\plugin.py:6684
+#: ..\plugin.py:6697 ..\plugin.py:6710 ..\plugin.py:6725 ..\plugin.py:6735
+#: ..\plugin.py:6742 ..\plugin.py:6757 ..\plugin.py:6772 ..\plugin.py:6785
+#: ..\plugin.py:6798 ..\plugin.py:6808 ..\plugin.py:6822 ..\plugin.py:6833
+#: ..\plugin.py:6843 ..\plugin.py:6861 ..\plugin.py:6872 ..\plugin.py:6890
+#: ..\plugin.py:6898 ..\plugin.py:6909 ..\plugin.py:6920 ..\plugin.py:6929
+#: ..\plugin.py:6952 ..\plugin.py:6975 ..\plugin.py:6985 ..\plugin.py:6995
+#: ..\plugin.py:7008 ..\plugin.py:7020 ..\plugin.py:7031 ..\plugin.py:7042
+#: ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7079 ..\plugin.py:7088
+#: ..\plugin.py:7103 ..\plugin.py:7118 ..\plugin.py:7131 ..\plugin.py:7145
+#: ..\plugin.py:7160 ..\plugin.py:7173 ..\plugin.py:7183 ..\plugin.py:7195
+#: ..\plugin.py:7207 ..\plugin.py:7216 ..\plugin.py:7225 ..\plugin.py:7256
+#: ..\plugin.py:7271 ..\plugin.py:7286 ..\plugin.py:7301 ..\plugin.py:7315
+#: ..\plugin.py:7328 ..\plugin.py:7341 ..\plugin.py:7351 ..\plugin.py:7369
+#: ..\plugin.py:7380 ..\plugin.py:7398 ..\plugin.py:7406 ..\plugin.py:7417
+#: ..\plugin.py:7428 ..\plugin.py:7437 ..\plugin.py:7460 ..\plugin.py:7483
+#: ..\plugin.py:7493 ..\plugin.py:7503 ..\plugin.py:7516 ..\plugin.py:7528
+#: ..\plugin.py:7537 ..\plugin.py:7548 ..\plugin.py:7559 ..\plugin.py:7570
+#: ..\plugin.py:7581 ..\plugin.py:7594 ..\plugin.py:7604 ..\plugin.py:7614
+#: ..\plugin.py:7624 ..\plugin.py:7634 ..\plugin.py:7649 ..\plugin.py:7664
+#: ..\plugin.py:7677 ..\plugin.py:7691 ..\plugin.py:7706 ..\plugin.py:7719
+#: ..\plugin.py:7729 ..\plugin.py:7741 ..\plugin.py:7753 ..\plugin.py:7762
+#: ..\plugin.py:7771
+msgid "- which LCD"
+msgstr "- 创建LCD"
+
+#: ..\plugin.py:5678
+msgid "- Show in Mode"
+msgstr "- 以模式显示"
+
+#: ..\plugin.py:5679
+msgid "- OSD Size"
+msgstr "- OSD尺寸"
+
+#: ..\plugin.py:5680
+msgid "- Background/Transparency"
+msgstr "- 背景/透明度"
+
+#: ..\plugin.py:5681
+msgid "- Fast Grab lower quality"
+msgstr "- 快速抓取低质量"
+
+#: ..\plugin.py:5682
+msgid "Popup Text"
+msgstr "弹出式文本"
+
+#: ..\plugin.py:5685
+msgid "- Clear Key"
+msgstr "- 清除键"
+
+#: ..\plugin.py:5686 ..\plugin.py:5953 ..\plugin.py:5965 ..\plugin.py:5976
+#: ..\plugin.py:5989 ..\plugin.py:6002 ..\plugin.py:6015 ..\plugin.py:6083
+#: ..\plugin.py:6095 ..\plugin.py:6107 ..\plugin.py:6117 ..\plugin.py:6141
+#: ..\plugin.py:6148 ..\plugin.py:6159 ..\plugin.py:6169 ..\plugin.py:6187
+#: ..\plugin.py:6199 ..\plugin.py:6217 ..\plugin.py:6257 ..\plugin.py:6280
+#: ..\plugin.py:6323 ..\plugin.py:6335 ..\plugin.py:6348 ..\plugin.py:6357
+#: ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6389 ..\plugin.py:6400
+#: ..\plugin.py:6463 ..\plugin.py:6478 ..\plugin.py:6493 ..\plugin.py:6506
+#: ..\plugin.py:6559 ..\plugin.py:6571 ..\plugin.py:6635 ..\plugin.py:6647
+#: ..\plugin.py:6660 ..\plugin.py:6673 ..\plugin.py:6686 ..\plugin.py:6699
+#: ..\plugin.py:6736 ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6823
+#: ..\plugin.py:6834 ..\plugin.py:6844 ..\plugin.py:6862 ..\plugin.py:6873
+#: ..\plugin.py:6891 ..\plugin.py:6931 ..\plugin.py:6954 ..\plugin.py:6997
+#: ..\plugin.py:7009 ..\plugin.py:7022 ..\plugin.py:7033 ..\plugin.py:7080
+#: ..\plugin.py:7089 ..\plugin.py:7104 ..\plugin.py:7119 ..\plugin.py:7132
+#: ..\plugin.py:7185 ..\plugin.py:7197 ..\plugin.py:7302 ..\plugin.py:7342
+#: ..\plugin.py:7352 ..\plugin.py:7370 ..\plugin.py:7381 ..\plugin.py:7399
+#: ..\plugin.py:7439 ..\plugin.py:7462 ..\plugin.py:7505 ..\plugin.py:7517
+#: ..\plugin.py:7529 ..\plugin.py:7539 ..\plugin.py:7550 ..\plugin.py:7561
+#: ..\plugin.py:7572 ..\plugin.py:7635 ..\plugin.py:7650 ..\plugin.py:7665
+#: ..\plugin.py:7678 ..\plugin.py:7731 ..\plugin.py:7743
+msgid "- Font Size"
+msgstr "- 字体大小"
+
+#: ..\plugin.py:5687 ..\plugin.py:5899 ..\plugin.py:5912 ..\plugin.py:5929
+#: ..\plugin.py:5944 ..\plugin.py:5955 ..\plugin.py:5966 ..\plugin.py:5978
+#: ..\plugin.py:5991 ..\plugin.py:6004 ..\plugin.py:6017 ..\plugin.py:6031
+#: ..\plugin.py:6047 ..\plugin.py:6061 ..\plugin.py:6072 ..\plugin.py:6084
+#: ..\plugin.py:6096 ..\plugin.py:6108 ..\plugin.py:6121 ..\plugin.py:6132
+#: ..\plugin.py:6142 ..\plugin.py:6149 ..\plugin.py:6160 ..\plugin.py:6170
+#: ..\plugin.py:6188 ..\plugin.py:6200 ..\plugin.py:6218 ..\plugin.py:6225
+#: ..\plugin.py:6236 ..\plugin.py:6247 ..\plugin.py:6256 ..\plugin.py:6279
+#: ..\plugin.py:6302 ..\plugin.py:6312 ..\plugin.py:6324 ..\plugin.py:6336
+#: ..\plugin.py:6349 ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:6379
+#: ..\plugin.py:6390 ..\plugin.py:6401 ..\plugin.py:6411 ..\plugin.py:6426
+#: ..\plugin.py:6436 ..\plugin.py:6446 ..\plugin.py:6456 ..\plugin.py:6464
+#: ..\plugin.py:6479 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6520
+#: ..\plugin.py:6536 ..\plugin.py:6549 ..\plugin.py:6560 ..\plugin.py:6572
+#: ..\plugin.py:6603 ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6662
+#: ..\plugin.py:6675 ..\plugin.py:6688 ..\plugin.py:6701 ..\plugin.py:6714
+#: ..\plugin.py:6727 ..\plugin.py:6737 ..\plugin.py:6749 ..\plugin.py:6764
+#: ..\plugin.py:6776 ..\plugin.py:6789 ..\plugin.py:6800 ..\plugin.py:6813
+#: ..\plugin.py:6824 ..\plugin.py:6835 ..\plugin.py:6845 ..\plugin.py:6863
+#: ..\plugin.py:6874 ..\plugin.py:6892 ..\plugin.py:6899 ..\plugin.py:6910
+#: ..\plugin.py:6921 ..\plugin.py:6930 ..\plugin.py:6953 ..\plugin.py:6976
+#: ..\plugin.py:6986 ..\plugin.py:6998 ..\plugin.py:7010 ..\plugin.py:7023
+#: ..\plugin.py:7034 ..\plugin.py:7046 ..\plugin.py:7056 ..\plugin.py:7065
+#: ..\plugin.py:7081 ..\plugin.py:7090 ..\plugin.py:7105 ..\plugin.py:7123
+#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7175
+#: ..\plugin.py:7186 ..\plugin.py:7198 ..\plugin.py:7229 ..\plugin.py:7278
+#: ..\plugin.py:7293 ..\plugin.py:7306 ..\plugin.py:7319 ..\plugin.py:7332
+#: ..\plugin.py:7343 ..\plugin.py:7353 ..\plugin.py:7371 ..\plugin.py:7382
+#: ..\plugin.py:7400 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7429
+#: ..\plugin.py:7438 ..\plugin.py:7461 ..\plugin.py:7484 ..\plugin.py:7494
+#: ..\plugin.py:7506 ..\plugin.py:7518 ..\plugin.py:7530 ..\plugin.py:7540
+#: ..\plugin.py:7551 ..\plugin.py:7562 ..\plugin.py:7573 ..\plugin.py:7583
+#: ..\plugin.py:7598 ..\plugin.py:7608 ..\plugin.py:7618 ..\plugin.py:7628
+#: ..\plugin.py:7636 ..\plugin.py:7651 ..\plugin.py:7669 ..\plugin.py:7679
+#: ..\plugin.py:7692 ..\plugin.py:7708 ..\plugin.py:7721 ..\plugin.py:7732
+#: ..\plugin.py:7744 ..\plugin.py:7775
+msgid "- Position"
+msgstr "- 位置"
+
+#: ..\plugin.py:5688 ..\plugin.py:5900 ..\plugin.py:5913 ..\plugin.py:5930
+#: ..\plugin.py:5945 ..\plugin.py:5956 ..\plugin.py:5967 ..\plugin.py:5979
+#: ..\plugin.py:5992 ..\plugin.py:6005 ..\plugin.py:6018 ..\plugin.py:6032
+#: ..\plugin.py:6048 ..\plugin.py:6062 ..\plugin.py:6073 ..\plugin.py:6085
+#: ..\plugin.py:6097 ..\plugin.py:6109 ..\plugin.py:6122 ..\plugin.py:6133
+#: ..\plugin.py:6143 ..\plugin.py:6151 ..\plugin.py:6161 ..\plugin.py:6171
+#: ..\plugin.py:6189 ..\plugin.py:6201 ..\plugin.py:6219 ..\plugin.py:6227
+#: ..\plugin.py:6238 ..\plugin.py:6249 ..\plugin.py:6258 ..\plugin.py:6281
+#: ..\plugin.py:6304 ..\plugin.py:6314 ..\plugin.py:6325 ..\plugin.py:6337
+#: ..\plugin.py:6350 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6380
+#: ..\plugin.py:6391 ..\plugin.py:6402 ..\plugin.py:6412 ..\plugin.py:6427
+#: ..\plugin.py:6437 ..\plugin.py:6447 ..\plugin.py:6457 ..\plugin.py:6465
+#: ..\plugin.py:6480 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6522
+#: ..\plugin.py:6537 ..\plugin.py:6550 ..\plugin.py:6561 ..\plugin.py:6573
+#: ..\plugin.py:6604 ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:6663
+#: ..\plugin.py:6676 ..\plugin.py:6689 ..\plugin.py:6702 ..\plugin.py:6715
+#: ..\plugin.py:6728 ..\plugin.py:6738 ..\plugin.py:6750 ..\plugin.py:6765
+#: ..\plugin.py:6777 ..\plugin.py:6790 ..\plugin.py:6801 ..\plugin.py:6814
+#: ..\plugin.py:6826 ..\plugin.py:6836 ..\plugin.py:6846 ..\plugin.py:6864
+#: ..\plugin.py:6875 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6912
+#: ..\plugin.py:6923 ..\plugin.py:6932 ..\plugin.py:6955 ..\plugin.py:6978
+#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7011 ..\plugin.py:7024
+#: ..\plugin.py:7035 ..\plugin.py:7047 ..\plugin.py:7057 ..\plugin.py:7066
+#: ..\plugin.py:7082 ..\plugin.py:7091 ..\plugin.py:7106 ..\plugin.py:7124
+#: ..\plugin.py:7134 ..\plugin.py:7148 ..\plugin.py:7163 ..\plugin.py:7176
+#: ..\plugin.py:7187 ..\plugin.py:7199 ..\plugin.py:7230 ..\plugin.py:7279
+#: ..\plugin.py:7294 ..\plugin.py:7307 ..\plugin.py:7320 ..\plugin.py:7333
+#: ..\plugin.py:7344 ..\plugin.py:7354 ..\plugin.py:7372 ..\plugin.py:7383
+#: ..\plugin.py:7401 ..\plugin.py:7409 ..\plugin.py:7420 ..\plugin.py:7431
+#: ..\plugin.py:7440 ..\plugin.py:7463 ..\plugin.py:7486 ..\plugin.py:7496
+#: ..\plugin.py:7507 ..\plugin.py:7519 ..\plugin.py:7531 ..\plugin.py:7541
+#: ..\plugin.py:7552 ..\plugin.py:7563 ..\plugin.py:7574 ..\plugin.py:7584
+#: ..\plugin.py:7599 ..\plugin.py:7609 ..\plugin.py:7619 ..\plugin.py:7629
+#: ..\plugin.py:7637 ..\plugin.py:7652 ..\plugin.py:7670 ..\plugin.py:7680
+#: ..\plugin.py:7694 ..\plugin.py:7709 ..\plugin.py:7722 ..\plugin.py:7733
+#: ..\plugin.py:7745 ..\plugin.py:7776
+msgid "- Alignment"
+msgstr "- 对齐"
+
+#: ..\plugin.py:5689 ..\plugin.py:5765 ..\plugin.py:5767 ..\plugin.py:5769
+#: ..\plugin.py:5771 ..\plugin.py:5773 ..\plugin.py:5893 ..\plugin.py:5932
+#: ..\plugin.py:5947 ..\plugin.py:5959 ..\plugin.py:5968 ..\plugin.py:5982
+#: ..\plugin.py:5995 ..\plugin.py:6008 ..\plugin.py:6021 ..\plugin.py:6034
+#: ..\plugin.py:6051 ..\plugin.py:6065 ..\plugin.py:6076 ..\plugin.py:6087
+#: ..\plugin.py:6099 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6153
+#: ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6191 ..\plugin.py:6203
+#: ..\plugin.py:6230 ..\plugin.py:6241 ..\plugin.py:6252 ..\plugin.py:6267
+#: ..\plugin.py:6290 ..\plugin.py:6329 ..\plugin.py:6339 ..\plugin.py:6352
+#: ..\plugin.py:6361 ..\plugin.py:6370 ..\plugin.py:6381 ..\plugin.py:6392
+#: ..\plugin.py:6403 ..\plugin.py:6467 ..\plugin.py:6509 ..\plugin.py:6527
+#: ..\plugin.py:6542 ..\plugin.py:6563 ..\plugin.py:6575 ..\plugin.py:6586
+#: ..\plugin.py:6595 ..\plugin.py:6630 ..\plugin.py:6641 ..\plugin.py:6653
+#: ..\plugin.py:6666 ..\plugin.py:6679 ..\plugin.py:6692 ..\plugin.py:6705
+#: ..\plugin.py:6717 ..\plugin.py:6731 ..\plugin.py:6752 ..\plugin.py:6767
+#: ..\plugin.py:6780 ..\plugin.py:6793 ..\plugin.py:6817 ..\plugin.py:6828
+#: ..\plugin.py:6838 ..\plugin.py:6848 ..\plugin.py:6866 ..\plugin.py:6877
+#: ..\plugin.py:6904 ..\plugin.py:6915 ..\plugin.py:6926 ..\plugin.py:6941
+#: ..\plugin.py:6964 ..\plugin.py:7003 ..\plugin.py:7013 ..\plugin.py:7025
+#: ..\plugin.py:7036 ..\plugin.py:7084 ..\plugin.py:7093 ..\plugin.py:7135
+#: ..\plugin.py:7153 ..\plugin.py:7168 ..\plugin.py:7189 ..\plugin.py:7201
+#: ..\plugin.py:7212 ..\plugin.py:7221 ..\plugin.py:7257 ..\plugin.py:7281
+#: ..\plugin.py:7296 ..\plugin.py:7310 ..\plugin.py:7323 ..\plugin.py:7336
+#: ..\plugin.py:7356 ..\plugin.py:7374 ..\plugin.py:7385 ..\plugin.py:7412
+#: ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7449 ..\plugin.py:7472
+#: ..\plugin.py:7511 ..\plugin.py:7521 ..\plugin.py:7533 ..\plugin.py:7542
+#: ..\plugin.py:7553 ..\plugin.py:7564 ..\plugin.py:7575 ..\plugin.py:7639
+#: ..\plugin.py:7681 ..\plugin.py:7699 ..\plugin.py:7714 ..\plugin.py:7735
+#: ..\plugin.py:7747 ..\plugin.py:7758 ..\plugin.py:7767
+msgid "- Color"
+msgstr "- 颜色"
+
+#: ..\plugin.py:5690 ..\plugin.py:5969 ..\plugin.py:6192 ..\plugin.py:6340
+#: ..\plugin.py:6353 ..\plugin.py:6362 ..\plugin.py:6371 ..\plugin.py:6382
+#: ..\plugin.py:6393 ..\plugin.py:6404 ..\plugin.py:6468 ..\plugin.py:6510
+#: ..\plugin.py:6564 ..\plugin.py:6576 ..\plugin.py:6587 ..\plugin.py:6596
+#: ..\plugin.py:6867 ..\plugin.py:7014 ..\plugin.py:7026 ..\plugin.py:7037
+#: ..\plugin.py:7085 ..\plugin.py:7094 ..\plugin.py:7136 ..\plugin.py:7190
+#: ..\plugin.py:7202 ..\plugin.py:7213 ..\plugin.py:7222 ..\plugin.py:7375
+#: ..\plugin.py:7522 ..\plugin.py:7534 ..\plugin.py:7543 ..\plugin.py:7554
+#: ..\plugin.py:7565 ..\plugin.py:7576 ..\plugin.py:7640 ..\plugin.py:7682
+#: ..\plugin.py:7736 ..\plugin.py:7748 ..\plugin.py:7759 ..\plugin.py:7768
+msgid "- Background Color"
+msgstr "- 背景色"
+
+#: ..\plugin.py:5691 ..\plugin.py:5934 ..\plugin.py:5949 ..\plugin.py:5961
+#: ..\plugin.py:5971 ..\plugin.py:5984 ..\plugin.py:5997 ..\plugin.py:6010
+#: ..\plugin.py:6023 ..\plugin.py:6039 ..\plugin.py:6053 ..\plugin.py:6067
+#: ..\plugin.py:6091 ..\plugin.py:6103 ..\plugin.py:6113 ..\plugin.py:6127
+#: ..\plugin.py:6155 ..\plugin.py:6165 ..\plugin.py:6175 ..\plugin.py:6194
+#: ..\plugin.py:6205 ..\plugin.py:6232 ..\plugin.py:6243 ..\plugin.py:6275
+#: ..\plugin.py:6298 ..\plugin.py:6331 ..\plugin.py:6343 ..\plugin.py:6373
+#: ..\plugin.py:6384 ..\plugin.py:6395 ..\plugin.py:6406 ..\plugin.py:6474
+#: ..\plugin.py:6489 ..\plugin.py:6502 ..\plugin.py:6516 ..\plugin.py:6531
+#: ..\plugin.py:6544 ..\plugin.py:6566 ..\plugin.py:6578 ..\plugin.py:6643
+#: ..\plugin.py:6655 ..\plugin.py:6668 ..\plugin.py:6681 ..\plugin.py:6694
+#: ..\plugin.py:6707 ..\plugin.py:6722 ..\plugin.py:6754 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6805 ..\plugin.py:6819
+#: ..\plugin.py:6830 ..\plugin.py:6840 ..\plugin.py:6850 ..\plugin.py:6869
+#: ..\plugin.py:6879 ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6949
+#: ..\plugin.py:6972 ..\plugin.py:7005 ..\plugin.py:7017 ..\plugin.py:7028
+#: ..\plugin.py:7039 ..\plugin.py:7100 ..\plugin.py:7115 ..\plugin.py:7128
+#: ..\plugin.py:7142 ..\plugin.py:7157 ..\plugin.py:7170 ..\plugin.py:7192
+#: ..\plugin.py:7204 ..\plugin.py:7283 ..\plugin.py:7298 ..\plugin.py:7312
+#: ..\plugin.py:7325 ..\plugin.py:7338 ..\plugin.py:7348 ..\plugin.py:7358
+#: ..\plugin.py:7377 ..\plugin.py:7387 ..\plugin.py:7414 ..\plugin.py:7425
+#: ..\plugin.py:7457 ..\plugin.py:7480 ..\plugin.py:7513 ..\plugin.py:7525
+#: ..\plugin.py:7545 ..\plugin.py:7556 ..\plugin.py:7567 ..\plugin.py:7578
+#: ..\plugin.py:7646 ..\plugin.py:7661 ..\plugin.py:7674 ..\plugin.py:7688
+#: ..\plugin.py:7703 ..\plugin.py:7716 ..\plugin.py:7738 ..\plugin.py:7750
+msgid "- Font"
+msgstr "- 字体"
+
+#: ..\plugin.py:5694
+msgid "Active Screen"
+msgstr "活动画面"
+
+#: ..\plugin.py:5695
+msgid "Screen Switch Select - Screen"
+msgstr "屏幕开关选择-屏幕"
+
+#: ..\plugin.py:5696
+msgid "Screen Switch Select - LCD"
+msgstr "屏幕开关选择-LCD"
+
+#: ..\plugin.py:5697
+msgid "Screens used for Changing"
+msgstr "用于更换的屏幕"
+
+#: ..\plugin.py:5698 ..\plugin.py:7259
+msgid "Screen 1 Changing Time"
+msgstr "屏幕1更改时间"
+
+#: ..\plugin.py:5700 ..\plugin.py:7261
+msgid "- Screen 2 Changing Time"
+msgstr "- 屏幕2更改时间"
+
+#: ..\plugin.py:5701 ..\plugin.py:7262
+msgid "- Screen 3 Changing Time"
+msgstr "- 屏幕3更改时间"
+
+#: ..\plugin.py:5702 ..\plugin.py:7263
+msgid "- Screen 4 Changing Time"
+msgstr "- 屏幕4更改时间"
+
+#: ..\plugin.py:5703 ..\plugin.py:7264
+msgid "- Screen 5 Changing Time"
+msgstr "- 屏幕5更改时间"
+
+#: ..\plugin.py:5704 ..\plugin.py:7265
+msgid "- Screen 6 Changing Time"
+msgstr "- 屏幕6更改时间"
+
+#: ..\plugin.py:5705 ..\plugin.py:7266
+msgid "- Screen 7 Changing Time"
+msgstr "- 屏幕7更改时间"
+
+#: ..\plugin.py:5706 ..\plugin.py:7267
+msgid "- Screen 8 Changing Time"
+msgstr "- 屏幕8更改时间"
+
+#: ..\plugin.py:5707 ..\plugin.py:7268
+msgid "- Screen 9 Changing Time"
+msgstr "- 屏幕9更改时间"
+
+#: ..\plugin.py:5708
+msgid "Picture Changing Time"
+msgstr "图片更改时间"
+
+#: ..\plugin.py:5709
+msgid "Picture Sort"
+msgstr "图片排序"
+
+#: ..\plugin.py:5710
+msgid "Picture Directory Recursive"
+msgstr "图片目录递归"
+
+#: ..\plugin.py:5711
+msgid "Picture Quality for Resizing"
+msgstr "调整画质的图像质量"
+
+#: ..\plugin.py:5713
+msgid "Picture Quick Update Time [s]"
+msgstr "图片快速更新时间[s]"
+
+#: ..\plugin.py:5715
+msgid "Picture Type [only Picture]"
+msgstr "图片类型[仅图片]"
+
+#: ..\plugin.py:5716
+msgid "Background-Picture Type"
+msgstr "背景图片类型"
+
+#: ..\plugin.py:5717
+msgid "Weather API"
+msgstr "天气 API"
+
+#: ..\plugin.py:5718
+msgid "Weather API-Key OpenWeatherMap"
+msgstr "天气API键打开天气图"
+
+#: ..\plugin.py:5719
+msgid "Weather API-ID Key WeatherUnlocked"
+msgstr "天气API-ID密钥天气解锁"
+
+#: ..\plugin.py:5720
+msgid "Weather City"
+msgstr "天气城市"
+
+#: ..\plugin.py:5721
+msgid "Weather City 2"
+msgstr "天气城市2"
+
+#: ..\plugin.py:5722
+msgid "Weather-Icon-Path [ok]>"
+msgstr "天气图标路径 [ok]>"
+
+#: ..\plugin.py:5723
+msgid "Weather-Icon Zoom"
+msgstr "天气图标放大"
+
+#: ..\plugin.py:5724
+msgid "Weather Low Temperature Color"
+msgstr "天气低温色"
+
+#: ..\plugin.py:5725
+msgid "Weather High Temperature Color"
+msgstr "天气高温色"
+
+#: ..\plugin.py:5726
+msgid "Weather Transparency"
+msgstr "天气透明度"
+
+#: ..\plugin.py:5727
+msgid "Weather Wind speed unit"
+msgstr "天气风速单位"
+
+#: ..\plugin.py:5728
+msgid "Weather Wind Info Lines"
+msgstr "天气线"
+
+#: ..\plugin.py:5729
+msgid "Weather Rain Chance"
+msgstr "天气雨"
+
+#: ..\plugin.py:5731
+msgid "- Rain Zoom"
+msgstr "- 雨缩放"
+
+#: ..\plugin.py:5732
+msgid "- Rain Color"
+msgstr "- 雨色"
+
+#: ..\plugin.py:5733
+msgid "- Rain use Color 2 from"
+msgstr "- 从雨中使用颜色2"
+
+#: ..\plugin.py:5734
+msgid "- Rain Color 2"
+msgstr "- 雨色2"
+
+#: ..\plugin.py:5735
+msgid "Weather Humidity Color"
+msgstr "天气 湿度 颜色"
+
+#: ..\plugin.py:5736
+msgid "Weather Lines"
+msgstr "天气线"
+
+#: ..\plugin.py:5737
+msgid "Weather Trendarrows"
+msgstr "天气趋势箭头"
+
+#: ..\plugin.py:5738
+msgid "Weather Extra Infos"
+msgstr "天气额外信息"
+
+#: ..\plugin.py:5740
+msgid "- Extra Zoom"
+msgstr "- 额外缩放"
+
+#: ..\plugin.py:5741
+msgid "- Show chill temperature from difference"
+msgstr "- 显示温差"
+
+#: ..\plugin.py:5742
+msgid "- Extra Color City"
+msgstr "- 城市的附加颜色"
+
+#: ..\plugin.py:5743
+msgid "- Extra Color Chill"
+msgstr "- 额外颜色冷色"
+
+#: ..\plugin.py:5744
+msgid "Netatmo CO2 Min Range"
+msgstr "Netatmo CO2最小范围"
+
+#: ..\plugin.py:5745
+msgid "Netatmo CO2 Max Range"
+msgstr "Netatmo CO2最大范围"
+
+#: ..\plugin.py:5746
+msgid "Meteo URL"
+msgstr "气象网址"
+
+#: ..\plugin.py:5747
+msgid "Moon-Icon-Path [ok]>"
+msgstr "月亮图标路径 [ok]>"
+
+#: ..\plugin.py:5748
+msgid "Recording Picture [ok]>"
+msgstr "录制图片 [ok]>"
+
+#: ..\plugin.py:5749
+msgid "Double-button switches"
+msgstr "双按钮开关"
+
+#: ..\plugin.py:5750
+msgid "Key for Screen Change"
+msgstr "屏幕切换键"
+
+#: ..\plugin.py:5751
+msgid "Key for Screen On/Off"
+msgstr "屏幕开/关键"
+
+#: ..\plugin.py:5752
+msgid "FritzCall Picture Path [ok]>"
+msgstr "FritzCall图片路径 [ok]>"
+
+#: ..\plugin.py:5753
+msgid "FritzCall Number of Lines per Entry"
+msgstr "FritzCall每个条目的行数"
+
+#: ..\plugin.py:5754
+msgid "FritzCall Number of List Entries"
+msgstr "FritzCall列表条目数"
+
+#: ..\plugin.py:5755
+msgid "FritzCall Number of Pictures"
+msgstr "FritzCall图片数"
+
+#: ..\plugin.py:5756
+msgid "FritzCall Picture Orientation"
+msgstr "FritzCall图像定向"
+
+#: ..\plugin.py:5757
+msgid "FritzCall Picture Transparency"
+msgstr "FritzCall图片透明度"
+
+#: ..\plugin.py:5758
+msgid "FritzCall Pictures Search"
+msgstr "FritzCall图片搜索"
+
+#: ..\plugin.py:5759
+msgid "FritzCall remove Calls after hours"
+msgstr "FritzCall在(小时)后取消呼叫"
+
+#: ..\plugin.py:5760
+msgid "FritzCall Popup-Time"
+msgstr "FritzCall弹出时间"
+
+#: ..\plugin.py:5761
+msgid "FritzCall Popup LCD"
+msgstr "FritzCall弹出式液晶屏"
+
+#: ..\plugin.py:5762
+msgid "FritzCall Popup Color"
+msgstr "FritzCall弹出窗口的颜色"
+
+#: ..\plugin.py:5763
+msgid "FritzCall Frame Picture [ok]>"
+msgstr "FritzCall相框图片 [ok]>"
+
+#: ..\plugin.py:5764
+msgid "Calendar ics-Path [ok]>"
+msgstr "日历象形图路径[ok]>"
+
+#: ..\plugin.py:5766 ..\plugin.py:5768 ..\plugin.py:5770
+msgid "Calendar ics-URL"
+msgstr "日历象形图互联网地址"
+
+#: ..\plugin.py:5772
+msgid "Calendar planerFS"
+msgstr "日历调度程序FS"
+
+#: ..\plugin.py:5774
+msgid "Calendar Saturday Color"
+msgstr "日历中的星期六颜色"
+
+#: ..\plugin.py:5775
+msgid "Calendar Sunday Color"
+msgstr "日历中的星期日颜色"
+
+#: ..\plugin.py:5776
+msgid "Calendar Line Thickness"
+msgstr "日历线条粗细"
+
+#: ..\plugin.py:5777
+msgid "Calendar Day Event Preview"
+msgstr "日历日活动预览"
+
+#: ..\plugin.py:5778
+msgid "Calendar Timezone Correction"
+msgstr "日历时区修正"
+
+#: ..\plugin.py:5779
+msgid "Calendar Transparency"
+msgstr "日历透明度"
+
+#: ..\plugin.py:5780
+msgid "Calendar Poll Interval"
+msgstr "日历轮询间隔"
+
+#: ..\plugin.py:5781
+msgid "Tuner Color"
+msgstr "调谐器颜色"
+
+#: ..\plugin.py:5782
+msgid "Tuner Color Active"
+msgstr "调谐器颜色有效"
+
+#: ..\plugin.py:5783
+msgid "Tuner Color On"
+msgstr "调谐器颜色开启"
+
+#: ..\plugin.py:5784
+msgid "Service search first"
+msgstr "服务搜索优先"
+
+#: ..\plugin.py:5785
+msgid "DVB-T Signal-Quality Correction"
+msgstr "DVB-T信号质量校正"
+
+#: ..\plugin.py:5786
+msgid "Font global [ok]>"
+msgstr "字体全局 [ok]>"
+
+#: ..\plugin.py:5787
+msgid "Font 1 [ok]>"
+msgstr "字体1 [ok]>"
+
+#: ..\plugin.py:5788
+msgid "Font 2 [ok]>"
+msgstr "字体 2 [ok]>"
+
+#: ..\plugin.py:5789
+msgid "Font 3 [ok]>"
+msgstr "字体 3 [ok]>"
+
+#: ..\plugin.py:5790
+msgid "Font 4 [ok]>"
+msgstr "字体 4 [ok]>"
+
+#: ..\plugin.py:5791
+msgid "Font 5 [ok]>"
+msgstr "字体 5 [ok]>"
+
+#: ..\plugin.py:5792
+msgid "Mail 1 Connect"
+msgstr "邮件1连接"
+
+#: ..\plugin.py:5793
+msgid "Mail 1 Server"
+msgstr "邮件1服务器"
+
+#: ..\plugin.py:5794
+msgid "Mail 1 [Displayname:]Username"
+msgstr "邮件1 [显示名称:]用户名"
+
+#: ..\plugin.py:5795
+msgid "Mail 1 Password"
+msgstr "邮件1密码"
+
+#: ..\plugin.py:5796
+msgid "Mail 2 Connect"
+msgstr "邮件2连接"
+
+#: ..\plugin.py:5797
+msgid "Mail 2 Server"
+msgstr "邮件2服务器"
+
+#: ..\plugin.py:5798
+msgid "Mail 2 [Displayname:]Username"
+msgstr "邮件2 [显示名称:]用户名"
+
+#: ..\plugin.py:5799
+msgid "Mail 2 Password"
+msgstr "邮件2密码"
+
+#: ..\plugin.py:5800
+msgid "Mail 3 Connect"
+msgstr "邮件3连接"
+
+#: ..\plugin.py:5801
+msgid "Mail 3 Server"
+msgstr "邮件3服务器"
+
+#: ..\plugin.py:5802
+msgid "Mail 3 [Displayname:]Username"
+msgstr "邮件3 [显示名称:]用户名"
+
+#: ..\plugin.py:5803
+msgid "Mail 3 Password"
+msgstr "邮件3密码"
+
+#: ..\plugin.py:5804
+msgid "Mail 4 Connect"
+msgstr "邮件4连接"
+
+#: ..\plugin.py:5805
+msgid "Mail 4 Server"
+msgstr "邮件4服务器"
+
+#: ..\plugin.py:5806
+msgid "Mail 4 [Displayname:]Username"
+msgstr "邮件4 [显示名称:]用户名"
+
+#: ..\plugin.py:5807
+msgid "Mail 4 Password"
+msgstr "邮件4密码"
+
+#: ..\plugin.py:5808
+msgid "Mail 5 Connect"
+msgstr "邮件5连接"
+
+#: ..\plugin.py:5809
+msgid "Mail 5 Server"
+msgstr "邮件5服务器"
+
+#: ..\plugin.py:5810
+msgid "Mail 5 [Displayname:]Username"
+msgstr "邮件5 [显示名称:]用户名"
+
+#: ..\plugin.py:5811
+msgid "Mail 5 Password"
+msgstr "邮件5密码"
+
+#: ..\plugin.py:5812
+msgid "Mail Poll Interval"
+msgstr "邮件轮询间隔"
+
+#: ..\plugin.py:5813
+msgid "Mail IMAP limit to last days"
+msgstr "邮寄IMAP限制到最后几天"
+
+#: ..\plugin.py:5814
+msgid "Mail Show Empty Mailboxes"
+msgstr "邮件显示空邮箱"
+
+#: ..\plugin.py:5815
+msgid "Mail Show Date"
+msgstr "邮件显示日期"
+
+#: ..\plugin.py:5816
+msgid "Mail Hide Mailadress"
+msgstr "邮件隐藏邮件地址"
+
+#: ..\plugin.py:5817
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr "远程文件夹1 [显示名称:] IP /名称"
+
+#: ..\plugin.py:5818
+msgid "Remote Box 2 [Displayname:]IP/Name"
+msgstr "Remote Box 2 [显示名称:] IP /名称"
+
+#: ..\plugin.py:5819
+msgid "Remote Box 3 [Displayname:]IP/Name"
+msgstr "遥控器3 [显示名称:] IP /名称"
+
+#: ..\plugin.py:5820
+msgid "Remote Box 4 [Displayname:]IP/Name"
+msgstr "Remote Box 4 [显示名称:] IP /名称"
+
+#: ..\plugin.py:5821
+msgid "Remote Box 5 [Displayname:]IP/Name"
+msgstr "Remote Box 5 [显示名称:] IP /名称"
+
+#: ..\plugin.py:5822
+msgid "Remote Box Poll every Minutes"
+msgstr "每分钟进行一次远程箱投票"
+
+#: ..\plugin.py:5823
+msgid "Remote Box Timer [Displayname:]IP/Name"
+msgstr "远程盒定时器[显示名称:] IP /名称"
+
+#: ..\plugin.py:5824
+msgid "Remote Box Timer Poll every Minutes"
+msgstr "每隔一分钟的远程Box Timer轮询"
+
+#: ..\plugin.py:5825
+msgid "WWW Converter Poll Interval"
+msgstr "WWW转换器轮询间隔"
+
+#: ..\plugin.py:5826
+msgid "WWW Converter Usage"
+msgstr "WWW转换器使用"
+
+#: ..\plugin.py:5827
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr "来自cloudconvert.org的WWW ApiKey"
+
+#: ..\plugin.py:5828
+msgid "WWW ApiKey from convertapi.com"
+msgstr "来自convertapi.com的WWW ApiKey"
+
+#: ..\plugin.py:5829
+msgid "WebIF Refresh [s]"
+msgstr "WebIF刷新[s]"
+
+#: ..\plugin.py:5830
+msgid "WebIF Refresh Type"
+msgstr "WebIF刷新类型"
+
+#: ..\plugin.py:5831
+msgid "WebIF Init Delay"
+msgstr "WebIF初始化延迟"
+
+#: ..\plugin.py:5833
+msgid "WebIF IP Deny"
+msgstr "WebIF IP拒绝"
+
+#: ..\plugin.py:5834
+msgid "WebIF Design"
+msgstr "WebIF设计"
+
+#: ..\plugin.py:5835
+msgid "Save as Picture for WebIF"
+msgstr "另存为WebIF图片"
+
+#: ..\plugin.py:5836
+msgid "MJPEG Stream LCD 1 enable"
+msgstr "MJPEG流LCD 1启用"
+
+#: ..\plugin.py:5837
+msgid "MJPEG Stream LCD 1 Port"
+msgstr "MJPEG流LCD 1端口"
+
+#: ..\plugin.py:5838
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "MJPEG流LCD 1虚拟亮度"
+
+#: ..\plugin.py:5839
+msgid "MJPEG Stream LCD 2 enable"
+msgstr "MJPEG流LCD 2启用"
+
+#: ..\plugin.py:5840
+msgid "MJPEG Stream LCD 2 Port"
+msgstr "MJPEG流LCD 2端口"
+
+#: ..\plugin.py:5841
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "MJPEG Stream LCD 2虚拟亮度"
+
+#: ..\plugin.py:5842
+msgid "MJPEG Stream LCD 3 enable"
+msgstr "MJPEG流LCD 3启用"
+
+#: ..\plugin.py:5843
+msgid "MJPEG Stream LCD 3 Port"
+msgstr "MJPEG流LCD 3端口"
+
+#: ..\plugin.py:5844
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "MJPEG流LCD 3虚拟亮度"
+
+#: ..\plugin.py:5846
+msgid "MJPEG Cycle"
+msgstr "MJPEG循环"
+
+#: ..\plugin.py:5847
+msgid "MJPEG Restart on Error"
+msgstr "出错时MJPEG重新启动"
+
+#: ..\plugin.py:5848
+msgid "MJPEG Header Mode"
+msgstr "MJPEG标题模式"
+
+#: ..\plugin.py:5849
+msgid "Sonos IP"
+msgstr "Sonos IP地址"
+
+#: ..\plugin.py:5850
+msgid "Sonos Ping Timeout [ms]"
+msgstr "休眠Ping超时[毫秒]"
+
+#: ..\plugin.py:5851
+msgid "Sonos Play Check"
+msgstr "休眠播放检查"
+
+#: ..\plugin.py:5852
+msgid "Sonos Refresh [s]"
+msgstr "休眠更新间隔[秒]"
+
+#: ..\plugin.py:5853
+msgid "BlueSound IP"
+msgstr "BlueSound IP"
+
+#: ..\plugin.py:5854
+msgid "BlueSound Ping Timeout [ms]"
+msgstr "BlueSound Ping 超时 [ms]"
+
+#: ..\plugin.py:5855
+msgid "BlueSound Play Check"
+msgstr "BlueSound 玩检查"
+
+#: ..\plugin.py:5856
+msgid "BlueSound Refresh [s]"
+msgstr "BlueSound刷新 [s]"
+
+#: ..\plugin.py:5857
+msgid "MusicCast IP"
+msgstr "音乐广播IP"
+
+#: ..\plugin.py:5858
+msgid "MusicCast Server IP [optional]"
+msgstr "MusicCast服务器IP [可选]"
+
+#: ..\plugin.py:5859
+msgid "MusicCast Ping Timeout [ms]"
+msgstr "音乐播放Ping超时 [毫秒]"
+
+#: ..\plugin.py:5860
+msgid "MusicCast Play Check"
+msgstr "MusicCast播放检查"
+
+#: ..\plugin.py:5861
+msgid "MusicCast Refresh [s]"
+msgstr "MusicCast刷新[s]"
+
+#: ..\plugin.py:5862
+msgid "MusicCast Cover"
+msgstr "音乐广告封面"
+
+#: ..\plugin.py:5863
+msgid "LCD Custom Width"
+msgstr "LCD自定义宽度"
+
+#: ..\plugin.py:5864
+msgid "LCD Custom Height"
+msgstr "LCD自定义高度"
+
+#: ..\plugin.py:5865
+msgid "LCD Custom Width 2"
+msgstr "LCD自定义宽度2"
+
+#: ..\plugin.py:5866
+msgid "LCD Custom Height 2"
+msgstr "LCD自定义高度2"
+
+#: ..\plugin.py:5867
+msgid "LCD Off when shutdown"
+msgstr "关机时液晶屏关闭"
+
+#: ..\plugin.py:5868
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr "时机！在快速模式下计算所有时间到时间/ 5 * 2"
+
+#: ..\plugin.py:5869
+msgid "Display Delay [ms]"
+msgstr "显示延迟[毫秒]"
+
+#: ..\plugin.py:5870
+msgid "Threads per LCD"
+msgstr "每个LCD的线程数"
+
+#: ..\plugin.py:5871
+msgid "Show Crash Corner"
+msgstr "显示崩溃角"
+
+#: ..\plugin.py:5872
+msgid "Show 'no ....' Messages"
+msgstr "显示“否 ....”消息"
+
+#: ..\plugin.py:5873
+msgid "Storage-Devices: Force Read"
+msgstr "存储设备：强制读取"
+
+#: ..\plugin.py:5874
+msgid "Storage-Devices: Color Back"
+msgstr "存储设备：彩色背"
+
+#: ..\plugin.py:5875
+msgid "Storage-Devices: Color Bar"
+msgstr "存储设备：颜色栏"
+
+#: ..\plugin.py:5876
+msgid "Storage-Devices: Color Full"
+msgstr "存储设备：全彩色"
+
+#: ..\plugin.py:5877
+msgid "Network Check active"
+msgstr "网络检查处于活动状态"
+
+#: ..\plugin.py:5878
+msgid "Switch FrameBuffer [if possible]"
+msgstr "切换帧缓冲区 [如果可能]"
+
+#: ..\plugin.py:5879
+msgid "Config Backup Path [ok]>"
+msgstr "配置备份路径[ok]>"
+
+#: ..\plugin.py:5880
+msgid "Config Restore All Settings"
+msgstr "配置还原所有设置"
+
+#: ..\plugin.py:5881
+msgid "Debug-Logging > /tmp/L4log.txt"
+msgstr "调试日志 > /tmp/L4log.txt"
+
+#: ..\plugin.py:5885 ..\plugin.py:7236
+msgid "- Backlight Off [disable set Off=On]"
+msgstr "- 背光关闭[禁用设置关闭=打开]"
+
+#: ..\plugin.py:5886 ..\plugin.py:7237
+msgid "- Backlight On"
+msgstr "- 背光开启"
+
+#: ..\plugin.py:5887 ..\plugin.py:7238
+msgid "- Backlight Weekend Off [disable set Off=On]"
+msgstr "- 周末背光关闭 [禁用设置关闭=打开]"
+
+#: ..\plugin.py:5888 ..\plugin.py:7239
+msgid "- Backlight Weekend On"
+msgstr "- 背光周末开启"
+
+#: ..\plugin.py:5889 ..\plugin.py:6625 ..\plugin.py:7240
+msgid "- LCD Auto-OFF"
+msgstr "- LCD自动关闭"
+
+#: ..\plugin.py:5890 ..\plugin.py:6627 ..\plugin.py:7254
+msgid "Background"
+msgstr "背景"
+
+#: ..\plugin.py:5894 ..\plugin.py:6631 ..\plugin.py:7258
+msgid "- Picture [ok]>"
+msgstr "- 图片 [ok]>"
+
+#: ..\plugin.py:5898 ..\plugin.py:5911
+msgid "- Picon Size"
+msgstr "- Picon大小"
+
+#: ..\plugin.py:5901 ..\plugin.py:5914 ..\plugin.py:5931 ..\plugin.py:5946
+#: ..\plugin.py:5958 ..\plugin.py:5981 ..\plugin.py:5994 ..\plugin.py:6007
+#: ..\plugin.py:6020 ..\plugin.py:6049 ..\plugin.py:6063 ..\plugin.py:6075
+#: ..\plugin.py:6086 ..\plugin.py:6098 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6135 ..\plugin.py:6144 ..\plugin.py:6152 ..\plugin.py:6162
+#: ..\plugin.py:6172 ..\plugin.py:6190 ..\plugin.py:6202 ..\plugin.py:6220
+#: ..\plugin.py:6228 ..\plugin.py:6239 ..\plugin.py:6250 ..\plugin.py:6259
+#: ..\plugin.py:6282 ..\plugin.py:6306 ..\plugin.py:6316 ..\plugin.py:6328
+#: ..\plugin.py:6338 ..\plugin.py:6351 ..\plugin.py:6360 ..\plugin.py:6466
+#: ..\plugin.py:6500 ..\plugin.py:6523 ..\plugin.py:6538 ..\plugin.py:6551
+#: ..\plugin.py:6562 ..\plugin.py:6574 ..\plugin.py:6605 ..\plugin.py:6640
+#: ..\plugin.py:6652 ..\plugin.py:6665 ..\plugin.py:6678 ..\plugin.py:6691
+#: ..\plugin.py:6704 ..\plugin.py:6730 ..\plugin.py:6739 ..\plugin.py:6751
+#: ..\plugin.py:6766 ..\plugin.py:6778 ..\plugin.py:6791 ..\plugin.py:6802
+#: ..\plugin.py:6816 ..\plugin.py:6827 ..\plugin.py:6837 ..\plugin.py:6847
+#: ..\plugin.py:6865 ..\plugin.py:6876 ..\plugin.py:6894 ..\plugin.py:6902
+#: ..\plugin.py:6913 ..\plugin.py:6924 ..\plugin.py:6933 ..\plugin.py:6956
+#: ..\plugin.py:6980 ..\plugin.py:6990 ..\plugin.py:7002 ..\plugin.py:7012
+#: ..\plugin.py:7083 ..\plugin.py:7092 ..\plugin.py:7126 ..\plugin.py:7149
+#: ..\plugin.py:7164 ..\plugin.py:7177 ..\plugin.py:7188 ..\plugin.py:7200
+#: ..\plugin.py:7231 ..\plugin.py:7280 ..\plugin.py:7295 ..\plugin.py:7309
+#: ..\plugin.py:7321 ..\plugin.py:7334 ..\plugin.py:7345 ..\plugin.py:7355
+#: ..\plugin.py:7373 ..\plugin.py:7384 ..\plugin.py:7402 ..\plugin.py:7410
+#: ..\plugin.py:7421 ..\plugin.py:7432 ..\plugin.py:7441 ..\plugin.py:7464
+#: ..\plugin.py:7488 ..\plugin.py:7498 ..\plugin.py:7510 ..\plugin.py:7520
+#: ..\plugin.py:7532 ..\plugin.py:7638 ..\plugin.py:7672 ..\plugin.py:7695
+#: ..\plugin.py:7710 ..\plugin.py:7723 ..\plugin.py:7734 ..\plugin.py:7746
+#: ..\plugin.py:7777
+msgid "- Split Screen"
+msgstr "- 分屏"
+
+#: ..\plugin.py:5902 ..\plugin.py:5915
+msgid "- Full Screen"
+msgstr "- 全屏显示"
+
+#: ..\plugin.py:5903 ..\plugin.py:5916
+msgid "- Text Size"
+msgstr "- 文本大小"
+
+#: ..\plugin.py:5904 ..\plugin.py:6429 ..\plugin.py:6439 ..\plugin.py:6449
+#: ..\plugin.py:6459 ..\plugin.py:7049 ..\plugin.py:7059 ..\plugin.py:7072
+#: ..\plugin.py:7601 ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7631
+msgid "- Transparency"
+msgstr "- 透明度"
+
+#: ..\plugin.py:5905 ..\plugin.py:5917 ..\plugin.py:6089 ..\plugin.py:6101
+msgid "- Picon Path [ok]>"
+msgstr "- Picon路径 [ok]>"
+
+#: ..\plugin.py:5906 ..\plugin.py:5918
+msgid "- Picon Path 2 [ok]>"
+msgstr "- Picon路径2[ok]>"
+
+#: ..\plugin.py:5907 ..\plugin.py:5919
+msgid "- Picon Cache Path [ok]>"
+msgstr "- Picon缓存路径 [ok]>"
+
+#: ..\plugin.py:5908
+msgid "Picon 2"
+msgstr "Picon 2"
+
+#: ..\plugin.py:5920 ..\plugin.py:6740 ..\plugin.py:7269
+msgid "Clock"
+msgstr "时钟"
+
+#: ..\plugin.py:5923 ..\plugin.py:5938 ..\plugin.py:6600 ..\plugin.py:7226
+#: ..\plugin.py:7772
+msgid "-  Type"
+msgstr "-  类型"
+
+#: ..\plugin.py:5925 ..\plugin.py:5940 ..\plugin.py:6745 ..\plugin.py:6760
+#: ..\plugin.py:7274 ..\plugin.py:7289
+msgid "- Analog Clock"
+msgstr "- 模拟时钟"
+
+#: ..\plugin.py:5927 ..\plugin.py:5942 ..\plugin.py:6747 ..\plugin.py:6762
+#: ..\plugin.py:7276 ..\plugin.py:7291
+msgid "- Spacing"
+msgstr "- 间距"
+
+#: ..\plugin.py:5928 ..\plugin.py:5943 ..\plugin.py:6030 ..\plugin.py:6046
+#: ..\plugin.py:6060 ..\plugin.py:6071 ..\plugin.py:6131 ..\plugin.py:6303
+#: ..\plugin.py:6313 ..\plugin.py:6322 ..\plugin.py:6410 ..\plugin.py:6424
+#: ..\plugin.py:6434 ..\plugin.py:6444 ..\plugin.py:6454 ..\plugin.py:6535
+#: ..\plugin.py:6548 ..\plugin.py:6601 ..\plugin.py:6713 ..\plugin.py:6726
+#: ..\plugin.py:6748 ..\plugin.py:6763 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6977 ..\plugin.py:6987 ..\plugin.py:6996 ..\plugin.py:7044
+#: ..\plugin.py:7054 ..\plugin.py:7063 ..\plugin.py:7161 ..\plugin.py:7174
+#: ..\plugin.py:7227 ..\plugin.py:7277 ..\plugin.py:7292 ..\plugin.py:7318
+#: ..\plugin.py:7331 ..\plugin.py:7485 ..\plugin.py:7495 ..\plugin.py:7504
+#: ..\plugin.py:7582 ..\plugin.py:7596 ..\plugin.py:7606 ..\plugin.py:7616
+#: ..\plugin.py:7626 ..\plugin.py:7707 ..\plugin.py:7720 ..\plugin.py:7773
+msgid "- Size"
+msgstr "- 大小"
+
+#: ..\plugin.py:5933 ..\plugin.py:5948 ..\plugin.py:5960 ..\plugin.py:5970
+#: ..\plugin.py:5983 ..\plugin.py:5996 ..\plugin.py:6009 ..\plugin.py:6022
+#: ..\plugin.py:6052 ..\plugin.py:6066 ..\plugin.py:6090 ..\plugin.py:6102
+#: ..\plugin.py:6126 ..\plugin.py:6154 ..\plugin.py:6164 ..\plugin.py:6174
+#: ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6231 ..\plugin.py:6242
+#: ..\plugin.py:6274 ..\plugin.py:6297 ..\plugin.py:6330 ..\plugin.py:6342
+#: ..\plugin.py:6372 ..\plugin.py:6383 ..\plugin.py:6394 ..\plugin.py:6405
+#: ..\plugin.py:6473 ..\plugin.py:6488 ..\plugin.py:6501 ..\plugin.py:6515
+#: ..\plugin.py:6530 ..\plugin.py:6543 ..\plugin.py:6565 ..\plugin.py:6577
+#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6667 ..\plugin.py:6680
+#: ..\plugin.py:6693 ..\plugin.py:6706 ..\plugin.py:6753 ..\plugin.py:6768
+#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6818 ..\plugin.py:6829
+#: ..\plugin.py:6839 ..\plugin.py:6849 ..\plugin.py:6868 ..\plugin.py:6878
+#: ..\plugin.py:6905 ..\plugin.py:6916 ..\plugin.py:6948 ..\plugin.py:6971
+#: ..\plugin.py:7004 ..\plugin.py:7016 ..\plugin.py:7027 ..\plugin.py:7038
+#: ..\plugin.py:7099 ..\plugin.py:7114 ..\plugin.py:7127 ..\plugin.py:7141
+#: ..\plugin.py:7156 ..\plugin.py:7169 ..\plugin.py:7191 ..\plugin.py:7203
+#: ..\plugin.py:7282 ..\plugin.py:7297 ..\plugin.py:7311 ..\plugin.py:7324
+#: ..\plugin.py:7337 ..\plugin.py:7357 ..\plugin.py:7376 ..\plugin.py:7386
+#: ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7456 ..\plugin.py:7479
+#: ..\plugin.py:7512 ..\plugin.py:7524 ..\plugin.py:7544 ..\plugin.py:7555
+#: ..\plugin.py:7566 ..\plugin.py:7577 ..\plugin.py:7645 ..\plugin.py:7660
+#: ..\plugin.py:7673 ..\plugin.py:7687 ..\plugin.py:7702 ..\plugin.py:7715
+#: ..\plugin.py:7737 ..\plugin.py:7749
+msgid "- Shadow Edges"
+msgstr "- 阴影边缘"
+
+#: ..\plugin.py:5935 ..\plugin.py:6755 ..\plugin.py:7284
+msgid "Clock 2"
+msgstr "时钟2"
+
+#: ..\plugin.py:5950 ..\plugin.py:6670
+msgid "Program Name"
+msgstr "程序名称"
+
+#: ..\plugin.py:5954 ..\plugin.py:5977 ..\plugin.py:5990 ..\plugin.py:6003
+#: ..\plugin.py:6016 ..\plugin.py:6050 ..\plugin.py:6064 ..\plugin.py:6118
+#: ..\plugin.py:6494 ..\plugin.py:6539 ..\plugin.py:6636 ..\plugin.py:6648
+#: ..\plugin.py:6661 ..\plugin.py:6674 ..\plugin.py:6687 ..\plugin.py:6700
+#: ..\plugin.py:6779 ..\plugin.py:6792 ..\plugin.py:6810 ..\plugin.py:7120
+#: ..\plugin.py:7165 ..\plugin.py:7303 ..\plugin.py:7322 ..\plugin.py:7335
+#: ..\plugin.py:7666 ..\plugin.py:7711
+msgid "- maximum Lines"
+msgstr "- 最大行数"
+
+#: ..\plugin.py:5957 ..\plugin.py:5980 ..\plugin.py:5993 ..\plugin.py:6006
+#: ..\plugin.py:6019 ..\plugin.py:6033 ..\plugin.py:6074 ..\plugin.py:6123
+#: ..\plugin.py:6134 ..\plugin.py:6499 ..\plugin.py:6639 ..\plugin.py:6651
+#: ..\plugin.py:6664 ..\plugin.py:6677 ..\plugin.py:6690 ..\plugin.py:6703
+#: ..\plugin.py:6716 ..\plugin.py:6729 ..\plugin.py:6815 ..\plugin.py:7125
+#: ..\plugin.py:7308 ..\plugin.py:7671
+msgid "- Length"
+msgstr "- 长度"
+
+#: ..\plugin.py:5962
+msgid "Program Number"
+msgstr "程序号码示例"
+
+#: ..\plugin.py:5972 ..\plugin.py:6682
+msgid "Program Info"
+msgstr "程序信息"
+
+#: ..\plugin.py:5975 ..\plugin.py:5988 ..\plugin.py:6001 ..\plugin.py:6014
+#: ..\plugin.py:6028 ..\plugin.py:6029 ..\plugin.py:6088 ..\plugin.py:6100
+#: ..\plugin.py:6111 ..\plugin.py:6119 ..\plugin.py:6120 ..\plugin.py:6150
+#: ..\plugin.py:6176 ..\plugin.py:6206 ..\plugin.py:6221 ..\plugin.py:6265
+#: ..\plugin.py:6266 ..\plugin.py:6288 ..\plugin.py:6289 ..\plugin.py:6308
+#: ..\plugin.py:6318 ..\plugin.py:6341 ..\plugin.py:6471 ..\plugin.py:6487
+#: ..\plugin.py:6495 ..\plugin.py:6496 ..\plugin.py:6511 ..\plugin.py:6524
+#: ..\plugin.py:6525 ..\plugin.py:6541 ..\plugin.py:6552 ..\plugin.py:6609
+#: ..\plugin.py:6659 ..\plugin.py:6685 ..\plugin.py:6698 ..\plugin.py:6711
+#: ..\plugin.py:6712 ..\plugin.py:6743 ..\plugin.py:6758 ..\plugin.py:6803
+#: ..\plugin.py:6811 ..\plugin.py:6812 ..\plugin.py:6825 ..\plugin.py:6851
+#: ..\plugin.py:6880 ..\plugin.py:6895 ..\plugin.py:6939 ..\plugin.py:6940
+#: ..\plugin.py:6962 ..\plugin.py:6963 ..\plugin.py:6982 ..\plugin.py:6992
+#: ..\plugin.py:7015 ..\plugin.py:7097 ..\plugin.py:7113 ..\plugin.py:7121
+#: ..\plugin.py:7122 ..\plugin.py:7137 ..\plugin.py:7150 ..\plugin.py:7151
+#: ..\plugin.py:7167 ..\plugin.py:7178 ..\plugin.py:7272 ..\plugin.py:7287
+#: ..\plugin.py:7304 ..\plugin.py:7305 ..\plugin.py:7346 ..\plugin.py:7359
+#: ..\plugin.py:7388 ..\plugin.py:7403 ..\plugin.py:7447 ..\plugin.py:7448
+#: ..\plugin.py:7470 ..\plugin.py:7471 ..\plugin.py:7490 ..\plugin.py:7500
+#: ..\plugin.py:7523 ..\plugin.py:7643 ..\plugin.py:7659 ..\plugin.py:7667
+#: ..\plugin.py:7668 ..\plugin.py:7683 ..\plugin.py:7696 ..\plugin.py:7697
+#: ..\plugin.py:7713 ..\plugin.py:7724
+msgid "- Type"
+msgstr "- 类型"
+
+#: ..\plugin.py:5985
+msgid "Program Info 2"
+msgstr "程序信息 2"
+
+#: ..\plugin.py:5998 ..\plugin.py:6695
+msgid "Next Program Info"
+msgstr "下一个程序信息"
+
+#: ..\plugin.py:6011 ..\plugin.py:6656
+msgid "Extended Description"
+msgstr "扩展描述"
+
+#: ..\plugin.py:6024 ..\plugin.py:6669
+msgid "- use Info when empty"
+msgstr "- 空时使用信息"
+
+#: ..\plugin.py:6025 ..\plugin.py:6708
+msgid "Progress Bar"
+msgstr "进度条"
+
+#: ..\plugin.py:6035 ..\plugin.py:6718
+msgid "- Color Text"
+msgstr "- 文本颜色"
+
+#: ..\plugin.py:6036 ..\plugin.py:6719
+msgid "- Border"
+msgstr "- 边界"
+
+#: ..\plugin.py:6037 ..\plugin.py:6137 ..\plugin.py:6720 ..\plugin.py:6732
+msgid "- Shaded"
+msgstr "- 阴影"
+
+#: ..\plugin.py:6038 ..\plugin.py:6721
+msgid "- Unit min"
+msgstr "- 单位最小值"
+
+#: ..\plugin.py:6040 ..\plugin.py:6770 ..\plugin.py:7313
+msgid "Informations"
+msgstr "信息"
+
+#: ..\plugin.py:6043 ..\plugin.py:6057
+msgid "- Tunerinfo"
+msgstr "- 调谐器信息"
+
+#: ..\plugin.py:6044 ..\plugin.py:6058 ..\plugin.py:6773 ..\plugin.py:6786
+#: ..\plugin.py:7316 ..\plugin.py:7329
+msgid "- Sensors"
+msgstr "- 传感器"
+
+#: ..\plugin.py:6045 ..\plugin.py:6059 ..\plugin.py:6774 ..\plugin.py:6787
+#: ..\plugin.py:7317 ..\plugin.py:7330
+msgid "- CPU"
+msgstr "- 处理器"
+
+#: ..\plugin.py:6054 ..\plugin.py:6783 ..\plugin.py:7326
+msgid "Informations 2"
+msgstr "信息 2"
+
+#: ..\plugin.py:6068
+msgid "Signal Quality Bar"
+msgstr "信号质量条"
+
+#: ..\plugin.py:6077
+msgid "- Gradient"
+msgstr "- 渐变色"
+
+#: ..\plugin.py:6078
+msgid "- Bar Range Min"
+msgstr "- 最小范围"
+
+#: ..\plugin.py:6079
+msgid "- Bar Range Max"
+msgstr "- 最大范围"
+
+#: ..\plugin.py:6080
+msgid "Satellite"
+msgstr "卫星"
+
+#: ..\plugin.py:6092
+msgid "Provider"
+msgstr "供应商"
+
+#: ..\plugin.py:6104 ..\plugin.py:6796 ..\plugin.py:7339
+msgid "Used Tuner"
+msgstr "使用调谐器"
+
+#: ..\plugin.py:6112 ..\plugin.py:6804 ..\plugin.py:7347
+msgid "- only active Tuner"
+msgstr "- 仅活动调谐器"
+
+#: ..\plugin.py:6114 ..\plugin.py:6806 ..\plugin.py:7299
+msgid "Next Timer Event"
+msgstr "下次计时器事件"
+
+#: ..\plugin.py:6128 ..\plugin.py:6723
+msgid "Volume"
+msgstr "体积"
+
+#: ..\plugin.py:6138 ..\plugin.py:6733
+msgid "Mute"
+msgstr "静音"
+
+#: ..\plugin.py:6145 ..\plugin.py:6820
+msgid "Audio/Video"
+msgstr "音频/视频"
+
+#: ..\plugin.py:6156 ..\plugin.py:6831
+msgid "Bitrate"
+msgstr "比特率"
+
+#: ..\plugin.py:6166 ..\plugin.py:6841 ..\plugin.py:7349
+msgid "Online [Ping]"
+msgstr "在线[Ping]"
+
+#: ..\plugin.py:6177 ..\plugin.py:6852 ..\plugin.py:7360
+msgid "- Show State"
+msgstr "- 显示状态"
+
+#: ..\plugin.py:6178 ..\plugin.py:6853 ..\plugin.py:7361
+msgid "- Timeout [ms]"
+msgstr "- 超时[毫秒]"
+
+#: ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6181 ..\plugin.py:6182
+#: ..\plugin.py:6183 ..\plugin.py:6854 ..\plugin.py:6855 ..\plugin.py:6856
+#: ..\plugin.py:6857 ..\plugin.py:6858 ..\plugin.py:7362 ..\plugin.py:7363
+#: ..\plugin.py:7364 ..\plugin.py:7365 ..\plugin.py:7366
+msgid "- Online Name:Address"
+msgstr "- 在线名称:地址"
+
+#: ..\plugin.py:6184 ..\plugin.py:6859 ..\plugin.py:7367
+msgid "External IP Address"
+msgstr "外部 IP 地址"
+
+#: ..\plugin.py:6195
+msgid "- external IP URL"
+msgstr "- 外部 IP 网址"
+
+#: ..\plugin.py:6196 ..\plugin.py:6870 ..\plugin.py:7378
+msgid "Storage-Devices"
+msgstr "存储设备"
+
+#: ..\plugin.py:6207 ..\plugin.py:6881 ..\plugin.py:7389
+msgid "- free Warning"
+msgstr "- 免费警告"
+
+#: ..\plugin.py:6208 ..\plugin.py:6882 ..\plugin.py:7390
+msgid "- extra Info"
+msgstr "- 额外信息"
+
+#: ..\plugin.py:6209 ..\plugin.py:6210 ..\plugin.py:6211 ..\plugin.py:6212
+#: ..\plugin.py:6213 ..\plugin.py:6883 ..\plugin.py:6884 ..\plugin.py:6885
+#: ..\plugin.py:6886 ..\plugin.py:6887 ..\plugin.py:7391 ..\plugin.py:7392
+#: ..\plugin.py:7393 ..\plugin.py:7394 ..\plugin.py:7395
+msgid "- Device Name"
+msgstr "- 设备名称"
+
+#: ..\plugin.py:6214 ..\plugin.py:6888 ..\plugin.py:7396
+msgid "HDD"
+msgstr "HDD"
+
+#: ..\plugin.py:6226 ..\plugin.py:6237 ..\plugin.py:6248 ..\plugin.py:6521
+#: ..\plugin.py:6900 ..\plugin.py:6911 ..\plugin.py:6922 ..\plugin.py:7147
+#: ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7430 ..\plugin.py:7693
+msgid "- Zoom"
+msgstr "- 缩小 -"
+
+#: ..\plugin.py:6229 ..\plugin.py:6240 ..\plugin.py:6251 ..\plugin.py:6903
+#: ..\plugin.py:6914 ..\plugin.py:6925 ..\plugin.py:7411 ..\plugin.py:7422
+#: ..\plugin.py:7433
+msgid "- Weather Type"
+msgstr "- 天气类型"
+
+#: ..\plugin.py:6233 ..\plugin.py:6907 ..\plugin.py:7415
+msgid "Weather 2"
+msgstr "天气2"
+
+#: ..\plugin.py:6244 ..\plugin.py:6918 ..\plugin.py:7426
+msgid "Meteo-Weather Station"
+msgstr "气象站"
+
+#: ..\plugin.py:6260 ..\plugin.py:6283 ..\plugin.py:6307 ..\plugin.py:6317
+#: ..\plugin.py:6934 ..\plugin.py:6957 ..\plugin.py:6981 ..\plugin.py:6991
+#: ..\plugin.py:7442 ..\plugin.py:7465 ..\plugin.py:7489 ..\plugin.py:7499
+msgid "- Station"
+msgstr "- 站"
+
+#: ..\plugin.py:6261 ..\plugin.py:6284 ..\plugin.py:6935 ..\plugin.py:6958
+#: ..\plugin.py:7443 ..\plugin.py:7466
+msgid "- Module"
+msgstr "- 模块"
+
+#: ..\plugin.py:6262 ..\plugin.py:6285 ..\plugin.py:6936 ..\plugin.py:6959
+#: ..\plugin.py:7444 ..\plugin.py:7467
+msgid "- Module userdefined"
+msgstr "- 未指定模块"
+
+#: ..\plugin.py:6263 ..\plugin.py:6286 ..\plugin.py:6937 ..\plugin.py:6960
+#: ..\plugin.py:7445 ..\plugin.py:7468
+msgid "- Base"
+msgstr "- 基本"
+
+#: ..\plugin.py:6264 ..\plugin.py:6287 ..\plugin.py:6938 ..\plugin.py:6961
+#: ..\plugin.py:7446 ..\plugin.py:7469
+msgid "- Name"
+msgstr "- 名称"
+
+#: ..\plugin.py:6268 ..\plugin.py:6291 ..\plugin.py:6482 ..\plugin.py:6942
+#: ..\plugin.py:6965 ..\plugin.py:7108 ..\plugin.py:7450 ..\plugin.py:7473
+#: ..\plugin.py:7654
+msgid "- Color 1"
+msgstr "- 颜色 1"
+
+#: ..\plugin.py:6269 ..\plugin.py:6292 ..\plugin.py:6483 ..\plugin.py:6943
+#: ..\plugin.py:6966 ..\plugin.py:7109 ..\plugin.py:7451 ..\plugin.py:7474
+#: ..\plugin.py:7655
+msgid "- Color 2"
+msgstr "- 颜色 2"
+
+#: ..\plugin.py:6270 ..\plugin.py:6293 ..\plugin.py:6484 ..\plugin.py:6944
+#: ..\plugin.py:6967 ..\plugin.py:7110 ..\plugin.py:7452 ..\plugin.py:7475
+#: ..\plugin.py:7656
+msgid "- Color 3"
+msgstr "- 颜色 3"
+
+#: ..\plugin.py:6271 ..\plugin.py:6294 ..\plugin.py:6485 ..\plugin.py:6945
+#: ..\plugin.py:6968 ..\plugin.py:7111 ..\plugin.py:7453 ..\plugin.py:7476
+#: ..\plugin.py:7657
+msgid "- Color 4"
+msgstr "- 颜色 4"
+
+#: ..\plugin.py:6272 ..\plugin.py:6295 ..\plugin.py:6486 ..\plugin.py:6946
+#: ..\plugin.py:6969 ..\plugin.py:7112 ..\plugin.py:7454 ..\plugin.py:7477
+#: ..\plugin.py:7658
+msgid "- Color 5"
+msgstr "- 颜色 5"
+
+#: ..\plugin.py:6273 ..\plugin.py:6296 ..\plugin.py:6947 ..\plugin.py:6970
+#: ..\plugin.py:7455 ..\plugin.py:7478
+msgid "- Color 6"
+msgstr "- Spalva 6"
+
+#: ..\plugin.py:6276 ..\plugin.py:6950 ..\plugin.py:7458
+msgid "Netatmo 2"
+msgstr "Netatmo 2"
+
+#: ..\plugin.py:6299 ..\plugin.py:6973 ..\plugin.py:7481
+msgid "Netatmo CO2 Indicator"
+msgstr "Netatmo CO2指标"
+
+#: ..\plugin.py:6305 ..\plugin.py:6315 ..\plugin.py:6979 ..\plugin.py:6989
+#: ..\plugin.py:7487 ..\plugin.py:7497
+msgid "- Length [Bar]"
+msgstr "- 长度 [Bar]"
+
+#: ..\plugin.py:6309 ..\plugin.py:6983 ..\plugin.py:7491
+msgid "Netatmo Comfort Indicator"
+msgstr "Netatmo舒适度指示器"
+
+#: ..\plugin.py:6319 ..\plugin.py:6993 ..\plugin.py:7501
+msgid "Moonphase"
+msgstr "月相"
+
+#: ..\plugin.py:6326 ..\plugin.py:7000 ..\plugin.py:7001 ..\plugin.py:7508
+msgid "- Infolines"
+msgstr "- 线"
+
+#: ..\plugin.py:6327 ..\plugin.py:7509
+msgid "- Trendarrows"
+msgstr "- 趋势箭头"
+
+#: ..\plugin.py:6332 ..\plugin.py:7006 ..\plugin.py:7514
+msgid "Sunrise"
+msgstr "日出"
+
+#: ..\plugin.py:6344 ..\plugin.py:7077 ..\plugin.py:7526
+msgid "Show oscam.lcd"
+msgstr "显示oscam.lcd"
+
+#: ..\plugin.py:6347 ..\plugin.py:6366 ..\plugin.py:6377 ..\plugin.py:6388
+#: ..\plugin.py:6453 ..\plugin.py:7021 ..\plugin.py:7032 ..\plugin.py:7538
+#: ..\plugin.py:7549 ..\plugin.py:7560 ..\plugin.py:7625
+msgid "- File [ok]>"
+msgstr "- 文件路 [ok]>"
+
+#: ..\plugin.py:6354
+msgid "Show ecm.info"
+msgstr "显示ecm.info"
+
+#: ..\plugin.py:6363 ..\plugin.py:7018 ..\plugin.py:7535
+msgid "Show Textfile"
+msgstr "显示文本文件"
+
+#: ..\plugin.py:6374 ..\plugin.py:7029 ..\plugin.py:7546
+msgid "Show Textfile 2"
+msgstr "显示文本文件2"
+
+#: ..\plugin.py:6385 ..\plugin.py:7557
+msgid "Show Textfile 3"
+msgstr "显示文本文件3"
+
+#: ..\plugin.py:6396 ..\plugin.py:7568
+msgid "Show HTTP Text"
+msgstr "显示HTTP文本"
+
+#: ..\plugin.py:6399 ..\plugin.py:6413 ..\plugin.py:7571 ..\plugin.py:7585
+msgid "- URL"
+msgstr "- URL"
+
+#: ..\plugin.py:6407 ..\plugin.py:7579
+msgid "WWW-Internet Converter"
+msgstr "WWW网络转换器"
+
+#: ..\plugin.py:6414 ..\plugin.py:7586
+msgid "- HTTP Width"
+msgstr "- HTTP宽度"
+
+#: ..\plugin.py:6415 ..\plugin.py:7587
+msgid "- HTTP Height"
+msgstr "- HTTP高度"
+
+#: ..\plugin.py:6416 ..\plugin.py:7588
+msgid "- Cut from X"
+msgstr "- 从X剪切"
+
+#: ..\plugin.py:6417 ..\plugin.py:7589
+msgid "- Cut from Y"
+msgstr "- 从Y剪切"
+
+#: ..\plugin.py:6418 ..\plugin.py:7590
+msgid "- Cut Width [disable = 0]"
+msgstr "- 剪切宽度[禁用= 0]"
+
+#: ..\plugin.py:6419 ..\plugin.py:7591
+msgid "- Cut Height [disable = 0]"
+msgstr "- 剪切高度[禁用= 0]"
+
+#: ..\plugin.py:6420 ..\plugin.py:7040 ..\plugin.py:7592
+msgid "Show Picture"
+msgstr "显示图片"
+
+#: ..\plugin.py:6423 ..\plugin.py:6433 ..\plugin.py:6443 ..\plugin.py:7043
+#: ..\plugin.py:7053 ..\plugin.py:7595 ..\plugin.py:7605 ..\plugin.py:7615
+msgid "- File or Path [ok]>"
+msgstr "- 文件或路径[ok]>"
+
+#: ..\plugin.py:6425 ..\plugin.py:6435 ..\plugin.py:6445 ..\plugin.py:6455
+#: ..\plugin.py:7045 ..\plugin.py:7055 ..\plugin.py:7064 ..\plugin.py:7597
+#: ..\plugin.py:7607 ..\plugin.py:7617 ..\plugin.py:7627
+msgid "- Size max Height"
+msgstr "- 最大尺寸高度"
+
+#: ..\plugin.py:6428 ..\plugin.py:6438 ..\plugin.py:6448 ..\plugin.py:6458
+#: ..\plugin.py:7048 ..\plugin.py:7058 ..\plugin.py:7600 ..\plugin.py:7610
+#: ..\plugin.py:7620 ..\plugin.py:7630
+msgid "- Quick Update"
+msgstr "- 快速更新"
+
+#: ..\plugin.py:6430 ..\plugin.py:7050 ..\plugin.py:7602
+msgid "Show Picture 2"
+msgstr "显示图片2"
+
+#: ..\plugin.py:6440 ..\plugin.py:7612
+msgid "Show Picture 3"
+msgstr "显示图片3"
+
+#: ..\plugin.py:6450 ..\plugin.py:7622
+msgid "Show Picture 4"
+msgstr "显示图片4"
+
+#: ..\plugin.py:6469 ..\plugin.py:7095 ..\plugin.py:7641
+msgid "- Lines"
+msgstr "- 线"
+
+#: ..\plugin.py:6470 ..\plugin.py:7096 ..\plugin.py:7642
+msgid "- Mail Konto"
+msgstr "- 邮件帐户"
+
+#: ..\plugin.py:6472 ..\plugin.py:6481 ..\plugin.py:6540 ..\plugin.py:7098
+#: ..\plugin.py:7107 ..\plugin.py:7166 ..\plugin.py:7644 ..\plugin.py:7653
+#: ..\plugin.py:7712
+msgid "- max Width"
+msgstr "- 最大宽度"
+
+#: ..\plugin.py:6490 ..\plugin.py:7116 ..\plugin.py:7662
+msgid "Remote Box Timer"
+msgstr "遥控盒定时器"
+
+#: ..\plugin.py:6512 ..\plugin.py:7138 ..\plugin.py:7684
+msgid "- Picture Size"
+msgstr "- 图片尺寸"
+
+#: ..\plugin.py:6513 ..\plugin.py:7139 ..\plugin.py:7685
+msgid "- Picture Position"
+msgstr "- 图片位置"
+
+#: ..\plugin.py:6514 ..\plugin.py:7140 ..\plugin.py:7686
+msgid "- Picture Alignment"
+msgstr "- 图片对齐"
+
+#: ..\plugin.py:6526 ..\plugin.py:7152 ..\plugin.py:7698
 msgid "- Layout"
 msgstr "- 布局"
 
-#: plugin.py:6602 plugin.py:7228 plugin.py:7774
+#: ..\plugin.py:6528 ..\plugin.py:7154 ..\plugin.py:7700
 msgid "- Current Day Background Color"
 msgstr "- 当前日期背景色"
 
-#: plugin.py:6603 plugin.py:7229 plugin.py:7775
+#: ..\plugin.py:6529 ..\plugin.py:7155 ..\plugin.py:7701
 msgid "- Caption Color"
 msgstr "- 标题颜色"
 
-#: plugin.py:6606 plugin.py:7232 plugin.py:7778
+#: ..\plugin.py:6532 ..\plugin.py:7158 ..\plugin.py:7704
 msgid "Dates List"
 msgstr "日期列表"
 
-#: plugin.py:6619 plugin.py:7245 plugin.py:7791
+#: ..\plugin.py:6545 ..\plugin.py:7171 ..\plugin.py:7717
 msgid "Event Icon Bar"
 msgstr "事件图标栏"
 
-#: plugin.py:6627 plugin.py:7253 plugin.py:7799
+#: ..\plugin.py:6553 ..\plugin.py:7179 ..\plugin.py:7725
 msgid "- Popup Screen"
 msgstr "- 弹出式屏幕"
 
-#: plugin.py:6628 plugin.py:7254 plugin.py:7800
+#: ..\plugin.py:6554 ..\plugin.py:7180 ..\plugin.py:7726
 msgid "- Popup LCD"
 msgstr "- 弹出式LCD"
 
-#: plugin.py:6629 plugin.py:7255 plugin.py:7801
+#: ..\plugin.py:6555 ..\plugin.py:7181 ..\plugin.py:7727
 msgid "Show Text 1"
 msgstr "显示文字1"
 
-#: plugin.py:6632 plugin.py:6644 plugin.py:7258 plugin.py:7270 plugin.py:7804
-#: plugin.py:7816
+#: ..\plugin.py:6558 ..\plugin.py:6570 ..\plugin.py:7184 ..\plugin.py:7196
+#: ..\plugin.py:7730 ..\plugin.py:7742
 msgid "- Text"
 msgstr "- 文本"
 
-#: plugin.py:6641 plugin.py:7267 plugin.py:7813
+#: ..\plugin.py:6567 ..\plugin.py:7193 ..\plugin.py:7739
 msgid "Show Text 2"
 msgstr "显示文字2"
 
-#: plugin.py:6653 plugin.py:7279 plugin.py:7825
+#: ..\plugin.py:6579 ..\plugin.py:7205 ..\plugin.py:7751
 msgid "Rectangle 1"
 msgstr "矩形1"
 
-#: plugin.py:6656 plugin.py:6665 plugin.py:7282 plugin.py:7291 plugin.py:7828
-#: plugin.py:7837
+#: ..\plugin.py:6582 ..\plugin.py:6591 ..\plugin.py:7208 ..\plugin.py:7217
+#: ..\plugin.py:7754 ..\plugin.py:7763
 msgid "- Position x"
 msgstr "- 位置x"
 
-#: plugin.py:6657 plugin.py:6666 plugin.py:7283 plugin.py:7292 plugin.py:7829
-#: plugin.py:7838
+#: ..\plugin.py:6583 ..\plugin.py:6592 ..\plugin.py:7209 ..\plugin.py:7218
+#: ..\plugin.py:7755 ..\plugin.py:7764
 msgid "- Position y"
 msgstr "- 位置y"
 
-#: plugin.py:6658 plugin.py:6667 plugin.py:7284 plugin.py:7293 plugin.py:7830
-#: plugin.py:7839
+#: ..\plugin.py:6584 ..\plugin.py:6593 ..\plugin.py:7210 ..\plugin.py:7219
+#: ..\plugin.py:7756 ..\plugin.py:7765
 msgid "- Size x"
 msgstr "- 尺寸x"
 
-#: plugin.py:6659 plugin.py:6668 plugin.py:7285 plugin.py:7294 plugin.py:7831
-#: plugin.py:7840
+#: ..\plugin.py:6585 ..\plugin.py:6594 ..\plugin.py:7211 ..\plugin.py:7220
+#: ..\plugin.py:7757 ..\plugin.py:7766
 msgid "- Size y"
 msgstr "- 尺寸y"
 
-#: plugin.py:6662 plugin.py:7288 plugin.py:7834
+#: ..\plugin.py:6588 ..\plugin.py:7214 ..\plugin.py:7760
 msgid "Rectangle 2"
 msgstr "矩形2"
 
-#: plugin.py:6671 plugin.py:7297 plugin.py:7843
+#: ..\plugin.py:6597 ..\plugin.py:7223 ..\plugin.py:7769
 msgid "Recording"
 msgstr "录像"
 
-#: plugin.py:6680
+#: ..\plugin.py:6606
 msgid "Stutter TV"
 msgstr "卡顿电视"
 
-#: plugin.py:6700 plugin.py:7327
+#: ..\plugin.py:6626 ..\plugin.py:7253
 msgid "- Screens used for Changing"
 msgstr "- 用于更改的屏幕"
 
-#: plugin.py:6706
+#: ..\plugin.py:6632
 msgid "Title"
 msgstr "标题"
 
-#: plugin.py:6718
+#: ..\plugin.py:6644
 msgid "Infos"
 msgstr "系统信息"
 
-#: plugin.py:7134
+#: ..\plugin.py:7060
 msgid "Show Cover"
 msgstr "显示封面"
 
-#: plugin.py:7141 plugin.py:7142
+#: ..\plugin.py:7067 ..\plugin.py:7068
 msgid "- Search Path [ok]>"
 msgstr "- 搜索路径 [ok]>"
 
-#: plugin.py:7143
+#: ..\plugin.py:7069
 msgid "- Find Cover File [ok]>"
 msgstr "- 查找封面文件[ok]>"
 
-#: plugin.py:7144
+#: ..\plugin.py:7070
 msgid "- Default Cover [ok]>"
 msgstr "- 默认封面[确定]>"
 
-#: plugin.py:7145
+#: ..\plugin.py:7071
 msgid "- Picon First"
 msgstr "- picon优先"
 
-#: plugin.py:7147
+#: ..\plugin.py:7073
 msgid "- Trimmed"
 msgstr "- 修剪"
 
-#: plugin.py:7148
+#: ..\plugin.py:7074
 msgid "- Download Cover"
 msgstr "- 下载封面"
 
-#: plugin.py:7149
+#: ..\plugin.py:7075
 msgid "- Download Type"
 msgstr "- 下载类型"
 
-#: plugin.py:7150
+#: ..\plugin.py:7076
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "-Google API密钥console.developers.google.com/apis"
 
-#: plugin.py:7309
+#: ..\plugin.py:7235
 msgid "LCD Display"
 msgstr "液晶显示屏"
 
-#: plugin.py:7863
+#: ..\plugin.py:7789
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux显示模式开启"
 
-#: plugin.py:7864
+#: ..\plugin.py:7790
 msgid "Set Media >>"
 msgstr "设置媒体 >>"
 
-#: plugin.py:7868
+#: ..\plugin.py:7794
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux显示模式媒体播放器"
 
-#: plugin.py:7869
+#: ..\plugin.py:7795
 msgid "Set Idle >>"
 msgstr "设置空闲 >>"
 
-#: plugin.py:7873
+#: ..\plugin.py:7799
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux显示模式空闲"
 
-#: plugin.py:7874
+#: ..\plugin.py:7800
 msgid "Set Global >>"
 msgstr "设置全局 >>"
 
-#: plugin.py:7892
+#: ..\plugin.py:7818
 msgid "Choose dir"
 msgstr "选择目录"
 
-#: plugin.py:7895 plugin.py:7898 plugin.py:7904 plugin.py:7907
+#: ..\plugin.py:7821 ..\plugin.py:7824 ..\plugin.py:7830 ..\plugin.py:7833
 msgid "Choose file"
 msgstr "选择文件"
 
-#: plugin.py:7901
+#: ..\plugin.py:7827
 msgid "Choose font"
 msgstr "选择字体"
 
-#: plugin.py:8065
+#: ..\plugin.py:7990
 msgid "%s - Current value: %s"
 msgstr "%s - 当前值：%s"
 
-#: plugin.py:8197
+#: ..\plugin.py:8132
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -3845,95 +4078,95 @@ msgstr ""
 "需要重新启动图形用户界面以应用新的皮肤。\n"
 "是否要现在重新启动图形用户界面？"
 
-#: plugin.py:8198
+#: ..\plugin.py:8133
 msgid "Restart GUI now?"
 msgstr "重新启动GUI吗?"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Indoor"
 msgstr "室内"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Outdoor"
 msgstr "室外"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Rain"
 msgstr "雨"
 
-#: plugin.py:8780
+#: ..\plugin.py:8687
 msgid "Wind"
 msgstr "风向"
 
-#: plugin.py:10558
+#: ..\plugin.py:10516
 msgid "New Moon"
 msgstr "新月"
 
-#: plugin.py:10559
+#: ..\plugin.py:10517
 msgid "First Quarter"
 msgstr "第一季度"
 
-#: plugin.py:10560
+#: ..\plugin.py:10518
 msgid "Waxing Crescent"
 msgstr "娥眉月"
 
-#: plugin.py:10561
+#: ..\plugin.py:10519
 msgid "Waxing Moon"
 msgstr "月相"
 
-#: plugin.py:10562
+#: ..\plugin.py:10520
 msgid "Full Moon"
 msgstr "满月"
 
-#: plugin.py:10563
+#: ..\plugin.py:10521
 msgid "Waning Moon"
 msgstr "残月"
 
-#: plugin.py:10564
+#: ..\plugin.py:10522
 msgid "Waning Crescent"
 msgstr "残月"
 
-#: plugin.py:10565
+#: ..\plugin.py:10523
 msgid "Last Quarter"
 msgstr "第四季度"
 
-#: plugin.py:11646 plugin.py:11715 plugin.py:11732 plugin.py:11741
+#: ..\plugin.py:11554 ..\plugin.py:11623 ..\plugin.py:11640 ..\plugin.py:11649
 msgid "%d.%m.%Y"
 msgstr "%Y.%m.%d"
 
-#: plugin.py:11919
+#: ..\plugin.py:11822
 msgid "Picture not available"
 msgstr "图片不可用"
 
-#: plugin.py:12072 plugin.py:12073
+#: ..\plugin.py:11972 ..\plugin.py:11973
 msgid "no Timer"
 msgstr "没有计时器"
 
-#: plugin.py:13345 plugin.py:13348
+#: ..\plugin.py:13223 ..\plugin.py:13226
 msgid "OSCAM not running"
 msgstr "OSCAM未运行"
 
-#: plugin.py:13694
+#: ..\plugin.py:13573
 msgid "no Calls"
 msgstr "没有呼叫"
 
-#: plugin.py:13729
+#: ..\plugin.py:13609
 msgid "%d Mails  %d New  %s"
 msgstr "%d 封邮件 %d 封新邮件 %s"
 
-#: plugin.py:13936
+#: ..\plugin.py:13809
 msgid "no Netatmo-Plugin installed"
 msgstr "未安装Netatmo插件"
 
-#: plugin.py:15606 plugin.py:15611
+#: ..\plugin.py:15464 ..\plugin.py:15465
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15614 plugin.py:15615
+#: ..\plugin.py:15466
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: plugin.py:15620 plugin.py:15621
+#: ..\plugin.py:15467
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux屏幕开关"
 
@@ -3951,111 +4184,3 @@ msgstr "LCD4linux屏幕开关"
 
 #~ msgid "Weather Wind direction"
 #~ msgstr "天气 风向"
-
-#~ msgid "Backup Config"
-#~ msgstr "备份配置"
-
-#~ msgid "BlueSound"
-#~ msgstr "BlueSound"
-
-#~ msgid "Box-Skin-LCD"
-#~ msgstr "盒式液晶显示器"
-
-#~ msgid "Crashlog"
-#~ msgstr "崩溃日志"
-
-#~ msgid "Delete"
-#~ msgstr "删除"
-
-#~ msgid "Delete Logfile"
-#~ msgstr "删除日志文件"
-
-#~ msgid "Download Logfile"
-#~ msgstr "下载日志文件"
-
-#~ msgid "Element"
-#~ msgstr "元素"
-
-#~ msgid "Exec"
-#~ msgstr "执行"
-
-#~ msgid "Filename"
-#~ msgstr "文档名称"
-
-#~ msgid "Font"
-#~ msgstr "字体"
-
-#~ msgid "GUI Restart is required"
-#~ msgstr "需要重新启动GUI"
-
-#~ msgid "IP seurity not supported by Box"
-#~ msgstr "设备不支持IP验证"
-
-#~ msgid "Key"
-#~ msgstr "按键"
-
-#~ msgid "List of Storage Devices"
-#~ msgstr "存储设备列表"
-
-#~ msgid "MJPEG Stream"
-#~ msgstr "MJPEG流"
-
-#~ msgid "No or wrong File selected, try a correct File first !"
-#~ msgstr "没有或选择了错误的文件，请先尝试正确的文件！"
-
-#~ msgid "OSD"
-#~ msgstr "OSD菜单"
-
-#~ msgid "Parent Directory"
-#~ msgstr "父目录"
-
-#~ msgid "Picture"
-#~ msgstr "图片"
-
-#~ msgid "Popup-Text"
-#~ msgstr "弹出式文本"
-
-#~ msgid "Restore Config"
-#~ msgstr "恢复配置"
-
-#~ msgid "Save Config"
-#~ msgstr "保存配置"
-
-#~ msgid "Screen"
-#~ msgstr "屏幕"
-
-#~ msgid "Show"
-#~ msgstr "显示"
-
-#~ msgid "Show Externals"
-#~ msgstr "显示外观"
-
-#~ msgid "Sonos"
-#~ msgstr "Sonos"
-
-#~ msgid "Tuner"
-#~ msgstr "调谐器"
-
-#~ msgid "WWW Converter"
-#~ msgstr "WWW转换器"
-
-#~ msgid "WebIF"
-#~ msgstr "WebIF"
-
-#~ msgid "copy to Idle"
-#~ msgstr "复制到空闲"
-
-#~ msgid "copy to Media"
-#~ msgstr "复制到媒体"
-
-#~ msgid "copy to On"
-#~ msgstr "复制到"
-
-#~ msgid "other"
-#~ msgstr "其他"
-
-#~ msgid "set Settings"
-#~ msgstr "设置设置"
-
-#~ msgid "stop Screencycle"
-#~ msgstr "停止屏幕循环"

--- a/LCD4linux/src/WebConfigSite.py
+++ b/LCD4linux/src/WebConfigSite.py
@@ -20,7 +20,6 @@ from .plugin import *
 from . import _
 
 Py = resolveFilename(SCOPE_PLUGINS, "Extensions/LCD4linux/plugin.py")
-DPKG = False
 L1 = []
 L2 = []
 L3 = []
@@ -124,10 +123,7 @@ class LCD4linuxConfigweb(resource.Resource):
 
 	def __init__(self):
 		self.StatusTimer = eTimer()
-		if DPKG:
-			self.StatusTimer_conn = self.StatusTimer.timeout.connect(self.resetWeb)
-		else:
-			self.StatusTimer.callback.append(self.resetWeb)
+		self.StatusTimer.callback.append(self.resetWeb)
 		self.CurrentMode = ("-", "-")
 
 	def resetWeb(self):
@@ -379,7 +375,6 @@ class LCD4linuxConfigweb(resource.Resource):
 						obja = eval(a)
 						objb = eval(b)
 						objb.value = obja.value
-
 				elif ".Standby" in _a:
 					b = _a.replace(".Standby", ".")
 					if (" " + b) in list(zip(*L2))[2]:
@@ -479,7 +474,8 @@ class LCD4linuxConfigweb(resource.Resource):
 			if Cfritz:
 				rmFile(PICfritz)
 			if Cwetter:
-				resetWetter(None)
+#				resetWetter(None)  # action after changing weather parameters
+				pass
 			if Cpicon:
 				if len(LCD4linux.PiconCache.value) > 2:
 					rmFiles(join(LCD4linux.PiconCache.value, "*.png"))
@@ -559,18 +555,14 @@ class LCD4linuxConfigweb(resource.Resource):
 		html += "<input type=\"image\" name=\"save\" value=\"klick\" src=\"/lcd4linux/data/WEBsave.png\" height=\"40\" title=\"%s\" class=\"style1\" >\n" % _l(_("Save Config"))
 		html += "</form>\n"
 		html += "<form method=\"post\"><font color=\"#FFFFFF\">%s</font>\n" % _l(_("Screen"))
-
 		html += "<input type=\"hidden\" name=\"cmd\" value=\"\">\n"
 		for i in range(1, 10):
 			html += "<input type=\"button\" value=\"%d\" style=\"width:15px; text-align:center; font-size:8pt%s\" onclick=\"this.form.cmd.value = 'Screen%d'; this.form.submit();\">\n" % (i, AktiveScreen(str(i)), i)
-
 		Aktiv = "checked" if getSaveEventListChanged() else ""
 		html += "<input type=\"hidden\" name=\"hold\" value=\"%s\">" % ("unchecked")
 		html += "<input type=\"checkbox\" title=\"%s\" name=\"hold\" value=\"%s\" onclick=\"this.form.cmd.value = 'hold'; this.form.submit();\" %s>" % (_l(_("stop Screencycle")), "checked", Aktiv)
-
 		html += "</form>\n"
 		html += "</td></tr></table>\n"
-
 		html += "<form method=\"get\">"
 		html += "<fieldset style=\"width:auto\" name=\"Mode1\">"
 		html += "<legend style=\"color: #FFCC00\">%s&nbsp;</legend>\n" % _l(_("Mode"))
@@ -583,7 +575,6 @@ class LCD4linuxConfigweb(resource.Resource):
 		if str(LCD4linux.Popup.value) != "0":
 			html += "<input id=\"r5\" name=\"Mode\" type=\"radio\" value=\"5\" %s onclick=\"this.form.submit();\"><label %s for=\"r5\">%s&nbsp;&nbsp;</label>\n" % (AktiveMode("5", "Popup-Text"))
 		html += "</fieldset></form>\n"
-
 		if Mode != "5":
 			if Mode == "1":
 				L = L1
@@ -646,9 +637,7 @@ class LCD4linuxConfigweb(resource.Resource):
 			for LL in L:
 				Conf = LL[2].strip()
 				ConfObj = eval(Conf)
-
 				if (Conf.startswith(Element) and (LL[3] == AktCode or AktCode == 0)) or (Element == "other" and LL[3] == 0):
-
 					if Mode in "2":
 						if "." in Conf:
 							b = Conf.replace(".", ".MP")


### PR DESCRIPTION
**plugin.py:**
- size/position calculations/alignment adjusted for the weather type "Current" and others
- new setting 'Weather Humidity Color' added
- trend arrow corrected for moon illumination (the trend arrow '●' is permanently shown at 0%)
- immediate call-up of the weather due to 'NETworkCheckEnable=False' (per default)
- improved error logging
- removed DPKG ('Components.Network.iNetworkInfo' is not available in OpenATV)
- some tiny code improvements / corrections
- all translations modified accordingly

**WebConfigSite.py:**
- no more reloading of the weather after changes in the WebIF (commented out 'resetWetter(None)')
- removed DPKG ('Components.Network.iNetworkInfo' is not available in OpenATV)
- some tiny code improvements / corrections
- all translations modified accordingly

Special thanks for testing to **Turbohai@OpenATV**

HINT: **LCD4linux** is still working under Python2 and Python3