### PR TITLE
[LCD4linux] V5.0-r33 bugfixes and improvements

### DIFF
--- a/LCD4linux/po/cs.po
+++ b/LCD4linux/po/cs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD 4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:35+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:34+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: none\n"
 "Language: cs\n"
@@ -11,7 +11,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -65,47 +66,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Obrazovka"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Počasí"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Pošta"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Vzdálený Box"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalendář"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP povol"
 
@@ -113,8 +102,7 @@ msgstr "WebIF IP povol"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "Žádný a nebo nesprávný soubor, skus nejdříve správný soubor !"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Režim"
 
@@ -130,7 +118,7 @@ msgstr "Chybový výpis"
 msgid "Show"
 msgstr "Zobrazit"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Zmazat"
 
@@ -162,35 +150,24 @@ msgstr "Ulož Config"
 msgid "stop Screencycle"
 msgstr "zastav výměnu obrazovek"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Celkový"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Zapnuté"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Nečinný"
 
@@ -238,253 +215,299 @@ msgstr "Seznam úložných zařízení"
 msgid "Parent Directory"
 msgstr "Nadřazený adresář"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Pá"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Po"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "So"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Ne"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Čt"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Út"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "St"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "černá"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "bílá"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "šedá"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "stříbrná"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "břidlicově šedá"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aquamarine"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "zlatá"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "zelenožlutá"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "žlutá"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "tmavě ooranžová"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "tmavě červená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indiánská červená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "oranžová"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "oranžově červená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "červená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "rajčatová"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "tmavě zelená"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "zelená"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "zelený trávník"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "svetlejší zelená"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "limetka"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "modrofialová"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "kadetská modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "chrpa modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "tmavě modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "světlejší modrá"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "světle modrá"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "tmavá orchidej"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "tmavě růžová"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "purpurová"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "fialová"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "hnědá"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "mokasín"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olivová"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "růžově hnědá"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "pískově hnědá"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Obrazovka 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Obrazovka 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Obrazovka 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Obrazovka 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Obrazovka 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Obrazovka 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Obrazovka 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Obrazovka 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Obrazovka 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Obrazovka 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Obrazovka 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Obrazovka 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Obrazovka 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Obrazovka 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Obrazovka 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Obrazovka 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Obrazovka 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Obrazovka 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Obrazovka 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Obrazovka 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Obrazovka 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Obrazovka 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Obrazovka 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Obrazovka 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Obrazovka 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Obrazovka 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Obrazovka 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Obrazovka 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Obrazovka 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Obrazovka 9"
 
@@ -506,1312 +529,1131 @@ msgstr "Obrazovka 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "vypnuto"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Obrazovka 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Obrazovka 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Obrazovka 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Obrazovka 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Obrazovka 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Obrazovka 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Obrazovka 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Obrazovka 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Obrazovka 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Obrazovka 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Obrazovka 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Obrazovka 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Obrazovka 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Obrazovka 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Obrazovka 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Obrazovka 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Obrazovka 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Obrazovka 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "zapnuto"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "AX206 (nebo kompatibilní LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "AX206 (nebo kompatibilní LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (nebo kompaktibilní LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (nebo kompaktibilní LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Zabudovaný box-skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Zabudovaný TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "jen obrázek 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "jen obrázek 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "jen obrázek 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "jen obrázek 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "jen obrázek vlastní velikosti"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "jen obrázek vlastní velikosti 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Zabudovaný Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Aktuální"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 dny 1 řádek"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 dny 2 řádky"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 dny 1 řádek"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 dny 2 řádky"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 dny svislý pohled"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 dnů 1 řádek"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 dnů 2 řádky"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 svislý pohled na dny"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Aktuální teplota (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Aktuální teplota (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Aktuální"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Aktuální teplota"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Vše"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Teplota"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Teplota+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Teplota+Co2+Tlak"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Teplota+Vlhkost"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modul 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Modul 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Modul 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Modul 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Modul 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Modul 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Modul 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Modul 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Modul 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Modul 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modul 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Modul 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Modul 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Module 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Modul 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modul 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Module 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Module 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modul 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Modul 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modul 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Modul 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Modul 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "definováno uživatelem"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Sloupec"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Sloupec+hodnota"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Knoflík"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Knoflík+hodnota"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analogové"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analogové + datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analogové + datum + všední den"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analogové + datum + všední den 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Datum+ čas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Datum+čas+Všední den"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Datum prvních kapek"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Návrh kapek pro všední den"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Čas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Čas+Všední den"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Všední den"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "vycentorovat"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "levý"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "v pravo"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "vycentorovat"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Rozšířený"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Rozšířený (méně info.)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Krátký"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Krátký (rozšířený)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Krátký +rozšířený"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Měsíc"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Měsíc+hlavička"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Týden"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Týden+Hlavička"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "žádný kalendář"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "žádné termíny"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Datumy 1 řádek"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Datumy 3 řádek"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Datumy 5 řádek"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Datumy 9 řádek"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Kompaktní datumy 2 řádky"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Kompaktní datumy 3 řádky"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Rámeček"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "žádné termíny"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Podtrhnutí"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Podtrhnutí 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Rámeček"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Datumy"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Kompaktní datumy"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Kompaktní datumy bez ikon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Datumy bez ikony"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "žádná ikona"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "žádná ikona, s cílovým číslem"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "s ikonou"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "s ikonou & cílovým číslem"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + otáčky"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + otáčky/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "otáčky"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "otáčky/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "ne"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + otáčky"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + otáčky/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "otáčky"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "otáčky/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "zobrazit aktivní"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "zobrazit aktivní+čekající"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Vždy vše"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Vždy nové"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "jen nové"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Všechny informace"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "jen vzdálenost"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Vzdálenost + osvětlení"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Vzdálenost + fáze měsíce"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "jen osvětlení"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Osvětlení+Fáze měsíce"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "jen měsíční fáze"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanál"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanál + titulek"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+kanál"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+kanál+název"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "stejná barva"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparentní"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "ano"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "ano 25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "vodorovně"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "ano"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "svisle"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "vodorovně"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "vše"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Roh"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Roh + časový posun"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Časový posun"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "jen ukazatel průběhu"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "a zbývající minuty"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "a zbývající minuty (velikost 1,5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "a zbývající minuty (velikost 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "s procenty minut"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "s procenty (velikost 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "s procenty (velikost 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "a zbývající minuty (nad)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "a zbývající minuty (nad / velikost 1,5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "a zbývající minuty (nad / velikost 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "s procenty (nad)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "s procenty (nad/velikost 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "s procenty (nad/velikost 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "a zbývající minuty (pod)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "a zbývající minuty (pod /velikost 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "a zbývající minuty (pod /velikost 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "s procenty (pod)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "s procenty (pod/velikost 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "s procenty (pod/velikost 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "s aktuálním 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "s aktuálním 00:00 (Size 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "s aktuálním 00:00 (Size 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "s aktuálním 00:00 (nad)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "s aktuálním 00:00 (nad /velikost 1,5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "s aktuálním 00:00 (nad /velikost 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "s aktuálním 00:00 (pod)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "s aktuálním 00:00 (pod/velikost 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "s aktuálním 00:00 (pod/velikost 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "s procenty minut / Celkově (nad)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "s procenty minut / Celkově (nad/velikost 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "s procenty minut / Celkově (nad/velikost 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "s absolutním časem ukončení"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "s absolutním časem ukončení (velikost 1,2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "s absolutním časem ukončení (velikost 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "s minutami celkem / čas ukončení (nad)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "s minutami celkem / čas ukončení (nad/velikost1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "s minutami celkem / čas ukončení (nad/velikost 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Rychlý mód (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normální (5s)"
 
@@ -1819,3437 +1661,2467 @@ msgstr "Normální (5s)"
 msgid "last Screen"
 msgstr "poslední obrazovka"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "abecedně"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "náhodně"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "better/slow"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "pomalu/rychle (jen obrázek)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "pomalu/rychle (vše)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + nastavení (vysoká kvalita, pomale)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + nastavení (nízká kvalita, rychle)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "bez cache + bez nastavování"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Zabudovaný tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Teď/Další"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normálně"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "redukované"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Neobnovit JavaScript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Znovu načíst"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normalně"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - bok po boku"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "Otevřít mapu počasí"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternativní Mod kopírování-Mode/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "ano + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "ano, dlouhé"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "ano, krátké"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Hledat obal"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "vždy"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "vždy"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "Zapnuté+Media+Pohotovostní režim"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Pohotovostní režim"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - barva"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - černobílá /barva"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Info tlačítko"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x ztlumit zvuk"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Dlouhé tlačítko info"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x Tlačítko rychle vpřed"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x Tlačítko rychle vpřed Typ 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Dlouhé tlačítko rychle dopředu"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Dlouhé tlačítko rychle dopředu Typ 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Info tlačítko"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x ztlumit zvuk"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Dlouhé tlačítko info"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x Rychle zpět tlačítko"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x Rychle zpět tlačítkoTyp 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Dlouhé tlčítko rychle nazpět"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Dlouhé tlčítko rychle nazpět Typ 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "ao, rozšířené"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Běžná konzole"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Rozsáhlý log soubor"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Normální log soubor"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "zakázáno"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Rádio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Rádio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Rádio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (plný)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normální (plný)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "zdobené (černé)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "zdobené (průhledné)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "ZTLUM nebo definuj klíče"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "libovolné tlačítko"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Čas+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Čas+Trvání+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Čas+Délka+info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "polovina vlevo"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "polovina vpravo"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Rámeček x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Řádek"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "zádný bar"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "žádný rámeček"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normální"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Spád"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Hrany stínu"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Jméno"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normální"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Pozice pod"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Pozice vlevo"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Pozice vpravo"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Umístění"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Jméno"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Vypnuté"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Aktivní"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Aktivní+Neaktivní"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "jen použitý časovač"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "použít čas dodání"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "žádný celkový časovač"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "zobrazit celkový časovač"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "jeden řádek"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "dva řádky"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Dostupná paměť"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Volná paměť"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "na celou obrazovku"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "ano kromě nahrávek"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "V"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "VSV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "VJV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "SV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "SSV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "SSZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "SZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "J"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "JV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "JJV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "JJZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "JZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "Z"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "ZSZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "ZJZ"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Nahrej aktivní konfig. soubor"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Načíst výchozí hodnoty / prázdná konfigurace"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Ulož Config do souboru... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Nahrej soubor: %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Zmazat soubor?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "smazáno"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "aktuální nastavení: %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Vyberte"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux Nastavení"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Nabídka"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Uložit"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Restart displejů"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Do nastavení >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "žádný LCD1 obrazový soubor"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "žádný LCD2 obrazový soubor"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "žádný LCD3 obrazový soubor"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux povolený"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Typ"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 otočit"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 barva pozadí"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 obrázek pozadí [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 jas"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 noční mód"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 obnova"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Typ"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 otočit"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 barva pozadí"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 obrázek pozadí [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 jas"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 noční mód"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 obnova"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Typ"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 otočit"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 barva pozadí"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 obrázek pozadí [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 jas"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Noční mód"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 obnova"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD rozměry"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD barva"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD Povolit zapnutý mód"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD povolit media mód"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD povolit čekací mód"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [čas zobrazení]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- které LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Ukázat v módě"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Velikost OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Pozadí/Průhlednost"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Rychlý snímek nízké kvality"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Vyskakovací text"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Vymazat klíč"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Velikost písma"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Pozice"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Zarovnání"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Barva"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Barva pozadí"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Písmo"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Aktivní obrazovka"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Výběr přepínače obrazovky - obrazovka"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Výchozí obrazovka po změně režimu - obrazovka"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Výběr přepínače obrazovky - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Obrazovky používané ke změně"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Obrazovka 1 čas změny"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Čas změny obrazovky 2"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Čas změny obrazovky 3"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Čas změny obrazovky 4"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Čas změny obrazovky 5"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Čas změny obrazovky 6"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Čas změny obrazovky 7"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Čas změny obrazovky 8"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Čas změny obrazovky 9"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Obrázek čas změny"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Seřazení obrázků"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Obrázek rekurzivní složka"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Kvalita obrazu pro změnu velikosti"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Obrázek čas rychlé aktualizace [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Typ obrázku [jen obrázek]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Typ obrázku pozadí"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Počasí výběr poskytovatele"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Počasí API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Počasí API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Počasí Město"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Počasí Město 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Počasí- Ikona- Cesta [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Počasí- Ikona zvětšení"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Počasí barva nízké (-) teploty"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Počasí barva vysoké (+) teploty"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Počasí průhlednost"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Počasí jednotka rychlosti větru"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Počasí směr a rychlost větru"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Počasí možnost deště"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Zvětšení deště"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Barva deště"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Déšť používá barvu 2 z"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Barva deště 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Počasí Vlhkost Barva"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Počasí linky"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Počasí sípky trendov"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Počasí rozšířené info"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra zvětšení"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Zobrazit teplotu ochlazení jeli rozdíl"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra barva města"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra barva ochlazení"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Min rozsah"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Max rozsah"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "URL počasí"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Měsíc - cesta k ikoně [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Obrázek záznamu [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Změna dvoj-stlačením tlačítka"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Klíč pro změnu obrazovky"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Tlačítko pro zapnutí/vypnutí obrazovky"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall acesta k obrázkům [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Počet řádků na vstupní údaj"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall počet položek seznamu"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall počet obrázků"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall orientace obrázku"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall průhlednost obrázku"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall vyhledávání obrazku"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall odstranit hovory po hodinách"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall čas vyskakovacího okna"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall vyskakovací LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall barva vyskakovacího okna"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall rámeček obrázku [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kalendář - ics-cesta [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalendař - ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalendář - plánovač"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Kalendář - barva soboty"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Kalendář - barva neděle"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalendář - tloušťka čáry"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Kalendář - denní přehled"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalendář - oprava časové zóny"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Kalendář - průsvitnost"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Kalendář - čas obnovy"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Tuner Barva"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Tuner Barva aktivní"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Tuner Barva zapnuto"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Nejdřív prohledat kanál"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T korekce kvality signálu"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Druh písma celkově [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Druh písma 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Druh písma 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Druh písma 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Druh písma 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Druh písma 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 připojení"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Zobrazené jméno:]Uživatelské jméno"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 heslo"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 připojení"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Zobrazené jméno:]Uživatelské jméno"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 heslo"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 připojení"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Zobrazené jméno:]Uživatelské jméno"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 heslo"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 připojení"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Zobrazené jméno:]Uživatelské jméno"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 heslo"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 připojení"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Zobrazené jméno:]Uživatelské jméno"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 heslo"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Pošta obnovovací interval"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Pošta IMAP limit na posledné dny"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail Zobrazit prázdné schránky"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Pošta ukaž datum"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Pošta skrýt adresu"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Vzdálený Box 1 [Zobrazované jméno:]IP/Jméno"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Vzdálený Box 2 [Zobrazované jméno:]IP/Jméno"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Vzdálený Box 3 [Zobrazované jméno:]IP/Jméno"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Vzdálený Box 4 [Zobrazované jméno:]IP/Jméno"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Vzdálený Box 5 [Zobrazované jméno:]IP/Jméno"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "RVzdálený Box obnova v minutách"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Vzdálený Box 1 [Zobrazované jméno:]IP/Jméno"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Vzdálený Box obnova v minutách"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Konvertor časové obnovy"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "Použiť WWW konvertor"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey from cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey from convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF aktualizace [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF Typ aktualizace"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Inicializace zpoždění"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP zakaž"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF vzhled"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Uložit jako obrázek pro WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 povolit"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 Port"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 Virtuální jas"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 povolit"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 Port"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 Virtuální jas"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 povolit"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 Port"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 Virtuální jas"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG Cyklus"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Při chybě restartujte"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG Režim záhlaví"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Zobrazit proudy '4097; 5001...5003' v režimu"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos časový limit ping [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Přehrát šek"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Obnovit [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Časový limit ping [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "Kontrola přehrávání BlueSound"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Obnovit [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [volitelný]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Časový limit ping [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Kontrola přehrávání"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Obnovit [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Obal"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD volitelná šířka"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD volitelná výška"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD volitelná šířka 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD volitelná výška 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD Vypnuto při vypnutí"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Časování ! výpočet všech časů na Čas/5*2 v rychlém módě"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Zpoždění displeje [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Návrhy na LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Zobrazit Chybové hlášení"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Zobrazit 'žádné ....' Hlášení"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Úložná zařízení: Vynutit čtení"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Úložná zařízení: Barva zpět"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Úložná zařízení: Barevná lišta"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Úložná zařízení: Barva plná"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Kontrola sítě aktivní"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Přepnout FrameBuffer [pokud je to možné]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Záloha nastavení [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Obnova všeho nastavení"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Logování > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Podsvícení Off [Zakázat nastavení Off = On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Podsvícení zapnout"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Podsvícení víkend [Zakázat nastavení Off = On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Podsvícení přes víkend zapnout"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD automatické vypnutí"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Pozadí"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Obrázek [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon Size"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Rozdělená obrazovka"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Celá obrazovka"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Velikost textu"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Průhlednost"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon cesta [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon cesta 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache cesta [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Hodiny"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Typ"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analogové Hodiny"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Vzdálenost"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Velikost"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Hrany stínu"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Hodiny 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Název kanálu"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- maximum řádků"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Délka"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Číslo kanálu"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Info o programu"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Typ"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Info o programu 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Info o dalším programu"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Rozšířený popis"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- prázdné použijte informace"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Ukazatel průběhu"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Barevný Text"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Barevné pozadí"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Okraj"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Stínované"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Jednotka min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informace"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Informace o tuneru"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Snímače"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informace 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Lišta kvality signálu"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Spád"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Rozsah sloupce kvality signálu na Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Rozsah sloupce kvality signálu na Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satelit"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Poskytovatel"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Použitý tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- jen aktivní tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Další časovač udalosti"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Hlasitost"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Ztlumit zvuk"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Stav sítě [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Zobrazit stav"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Časový limit [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Síťové jméno: Adresa"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Externí IP adresa"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- externí IP adresa"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Paměťové - zařízení"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- bez varování"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- další informace"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Jméno zařízení"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zvětšení"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Typ počasí"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Počasí 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteorologická stanice"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Stanice"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Modul"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Modul definovaný uživatelem"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Základ"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Jméno"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Barva 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Barva 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Barva 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Barva 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Barva 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Barva 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Indikátor"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Délka [Bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Konforktní indikátor"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Fáze měsíce"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Informační linky"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Šípky trendov"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Východ slunce"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Zobraz oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Soubor [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Zobraz ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Zobraz textový soubor"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Zobraz textový soubor 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Zobraz textový soubor 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Zobraz HTTP Text"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "Konvertor web. stránek"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP šířka"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP výška"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Vystřiženo z X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Vystřiženo z Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Zmenšit šířku [zakázat = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Výška střihu [deaktivovat = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Zobraz obrázek"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Soubor nebo cesta [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Maximální Výška"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Rychlá aktualizace"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Zobraz obrázek 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Zobraz obrázek 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Zobraz obrázek 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Zobraz obrázek 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Zobraz obrázek 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Řádky"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- e-mailové konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- maximální šířka"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Vzdálený Box"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Velikost obrázku"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Pozice obrázku"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Zarovnání obrázku"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Rozložení"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Barva pozadí aktuálního dne"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Barva titulku"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Seznam datumů"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Panel ikon události"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Vyskakovací obrazovka"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Vyskakovací LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Zobraz text 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Text"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Zobraz text 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Obdélník 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Pozice x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Pozice y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Velikost x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Velikost y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Obdélník 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Záznam"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Zobraz - zrcadlení TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Obrazovky použíté na výměnu"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Titulek"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informace"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Zobrazit obálku"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Hledaná cesta [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Najdi soubor obalu [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Výchozí obálka [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Nejdřív Picon"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Oříznuto"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Stáhnout obálku"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Typ stahování"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Displej"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Režim zobrazení - zapnutý"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Nastavit Media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Přehrávač médií v zobrazovacím režimu"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Nastavit Idle >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Režim nečinnosti displeje"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Obecná nastavení >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Zvol složku"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Zvol soubor"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Zvol písmo"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Současná hodnota: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5257,114 +4129,94 @@ msgstr ""
 "Je pořeba restaru GUI, k aplikaci změn.\n"
 "Chcete nyní restartovat GUI?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Restartovar GUI teď?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Vnitřní"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Venkovní"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Déšť"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Vítr"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Nový měsíc"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "První čtvrtina"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Dorůstající srpek"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Dorůstající měsíc"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Úplněk"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Ubývající měsíc"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Ubývající srpek"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Poslední čtvrtina"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Obrázek není k dispozici"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "žádný časovač"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM neběží"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "žádné volání"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Správy  %d Nové  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "nenainstalovaný Netatmo-Plugin"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux povolen"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Přepínač obrazovky"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "ano (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "šipka + text"
-
-#~ msgid "only arrow"
-#~ msgstr "jen šipka"
-
-#~ msgid "only text"
-#~ msgstr "jen text"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Počasí Směr větru"

--- a/LCD4linux/po/de.po
+++ b/LCD4linux/po/de.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:37+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:27+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -13,7 +13,7 @@ msgstr ""
 "X-Poedit-KeywordsList: _;gettext;gettext_noop\n"
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -67,47 +67,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Schirm"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Wetter"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Remote Box"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalender"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP erlaubt"
 
@@ -116,8 +104,7 @@ msgid "No or wrong File selected, try a correct File first !"
 msgstr ""
 "Keine oder eine falsche Datei ausgewählt, wähle zuerst eine richtige Datei !"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Modus"
 
@@ -133,7 +120,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Zeige"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Löschen"
 
@@ -165,35 +152,24 @@ msgstr "Speichern der Einstellungen"
 msgid "stop Screencycle"
 msgstr "Schirmwechsel anhalten"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Global"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "On"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Medien"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Leerlauf"
 
@@ -241,253 +217,299 @@ msgstr "Liste der Speichergeräte"
 msgid "Parent Directory"
 msgstr "Übergeordnetes Verzeichnis"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Fr"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Mo"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sa"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "So"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Do"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Di"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Mi"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "schwarz"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "weiss"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "grau"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "silber"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "schiefergrau"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aquamarine"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "gold"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "grüngelb"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "gelb"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "dunkelorange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "dunkelrot"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indianrot"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "orange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "orangerot"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "rot"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomate"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "dunkelgrün"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "grün"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "rasengrün"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "hellgrün"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "limone"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "blau"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "blauviolett"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "kadettblau"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "kornblumenblau"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "dunkelblau"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "hellblau"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cyan"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "dunkelorchidee"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "dunkelrosa"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violett"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "braun"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "moccasin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olive"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "rosigbraun"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "sandbraun"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Schirm 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Schirm 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Schirm 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Schirm 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Schirm 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Schirm 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Schirm 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Schirm 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Schirm 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Schirm 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Schirm 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Schirm 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Schirm 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Schirm 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Screen 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Schirm 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Schirm 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Schirm 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Schirm 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Schirm 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Schirm 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Schirm 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Schirm 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Schirm 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Schirm 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Schirm 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Schirm 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Schirm 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Schirm 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Schirm 9"
 
@@ -509,1312 +531,1131 @@ msgstr "Schirm 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "aus"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Schirm 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Schirm 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Schirm 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Schirm 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Schirm 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Schirm 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Schirm 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Schirm 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Schirm 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Schirm 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Schirm 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Schirm 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Schirm 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Screen 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Schirm 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Schirm 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Schirm 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Schirm 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "ein"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2 Std"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3 Std"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4 min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1 min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10 min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5 min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60 min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10 min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5 min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2 Std"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3 Std"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4 min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (oder kompatibles LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (oder kompatibles LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (oder kompatibles LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (oder kompatibles LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H alt 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H alt 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Internes Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Internes TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "nur Bild 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "nur Bild 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "nur Bild 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "nur Bild 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "nur Bild benutzerdefinierte Größe"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "nur Bild benutzerdefinierte Größe 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Internes Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Aktuell"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 Tage 1 Zeile"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 Tage 2 Zeilen"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 Tage 1 Zeile"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 Tage 2 Zeilen"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 Tage vertikale Ansicht"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 Tage 1 Zeile"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Tage 2 Zeilen"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 Tage vertikale Ansicht"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Aktuelle Temperatur (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Aktuelle Temperatur (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Aktuell"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Aktuelle Temperatur"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Alles"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatur+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatur+Co2+Luftdruck"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatur+Luftfeuchte"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modul 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Modul 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Modul 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Modul 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Modul 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Modul 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Modul 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Modul 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Modul 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Module 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modul 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Modul 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Modul 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Modul 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Module 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modul 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Modul 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Module 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modul 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Module 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modul 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Module 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Modul 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "Benutzerdefiniert"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Balken"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Balken+Wert"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Knopf"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Knopf+Wert"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analog"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analog+Datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analog+Datum+Wochentag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analog+Datum+Wochentag 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Datum+Uhrzeit"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Datum+Uhrzeit+Wochentag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Klappen Design Datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Klappen Design Wochentag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Zeit"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Uhrzeit+Wochentag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Wochentag"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "zentriert"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "links"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "rechts"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "zentriert"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Erweitert"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Erweitert (Kurz)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Kurz"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Kurz (Erweitert)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Kurz+Erweitert"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Monat"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Monat+Kopf"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Woche"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Woche+Kopf"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "kein Kalender"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "keine Termine"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Termine 1 Zeile"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Termine 3 Zeilen"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Termine 5 Zeilen"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Termine 9 Zeilen"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Termine kompakt 2 Zeilen"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Termine kompakt 3 Zeilen"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Rahmen"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "keine Termine"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Unterstrich"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Unterstrich 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Rahmen"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Termine"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Termine kompakt"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Termine kompakt kein Icon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Termine kein Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "kein Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "ohne Icon, mit Zielnummer"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "mit Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "mit Icon & Zielnummer"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "nein"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "zeige aktiv"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "zeige aktiv+schlafend"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Immer Alle"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Immer Neue"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Nur Neue"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Alle Informationen"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "nur Abstand"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Abstand+Ausleuchtung"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Abstand+Mondphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "nur Ausleuchtung"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Ausleuchtung+Mondphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "nur Mondphase"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanal+Titel"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Kanal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Kanal+Titel"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "gleiche Farbe"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "durchsichtig"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "ja"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "ja +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontal"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "ja"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "vertikal"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontal"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "Alles"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Ecke"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Ecke+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "nur Fortschrittsbalken"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "mit verbleibenden Minuten"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "mit verbleibenden Minuten (Größe 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "mit verbleibenden Minuten (Größe 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "mit Prozent"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "mit Prozent (Größe 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "mit Prozent (Größe 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "mit verbleibenden Minuten (oberhalb)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "mit verbleibenden Minuten (oberhalb/Größe 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "mit verbleibenden Minuten (oberhalb/Größe 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "mit Prozent (oberhalb)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "mit Prozent (oberhalb/Größe 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "mit Prozent (oberhalb/Größe 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "mit verbleibenden Minuten (unterhalb)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "mit verbleibenden Minuten (unterhalb/Größe 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "mit verbleibenden Minuten (unterhalb/Größe 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "mit Prozent (unterhalb)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "mit Prozent (unterhalb/Größe 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "mit Prozent (unterhalb/Größe 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "mit Aktuell 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "mit Aktuell 00:00 (Größe 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "mit Aktuell 00:00 (Größe 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "mit Aktuell 00:00 (oberhalb)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "mit Aktuell 00:00 (oberhalb/Größe 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "mit Aktuell 00:00 (oberhalb/Größe 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "mit Aktuell 00:00 (unterhalb)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "mit Aktuell 00:00 (unterhalb/Größe 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "mit Aktuell 00:00 (unterhalb/Größe 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "mit Prozent Minuten / Gesamt (oberhalb)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "mit Prozent Minuten / Gesamt (oberhalb/Größe 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "mit Prozent Minuten / Gesamt  (oberhalb/Größe 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "mit absoluter Endzeit"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "mit absoluter Endzeit (Größe 1,5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "mit absoluter Endzeit (Größe 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "mit Minuten Gesamt/Endzeit (oben)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "mit Minuten Gesamt/Endzeit (oben/Größe 1,5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "mit Minuten Gesamt/Endzeit (oben/Größe 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Fastmode (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5s)"
 
@@ -1822,3437 +1663,2467 @@ msgstr "Normal (5s)"
 msgid "last Screen"
 msgstr "letzter Schirm"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alphabetisch"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "zufällig"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "besser/langsam"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "niedrig/schnell (nur Bild)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "niedrig/schnell (alles)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "Cache + Anpassung (hohe Qualität, langsam)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "Cache + Anpassung (niedrige Qualität, schnell)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "kein Cache + keine Anpassung"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Steck Tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Now/Next"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "reduziert"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Keine JavaScript Auffrischung"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Neu Laden"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - nebeneinander"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternativer Kopiermodus/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "ja + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "ja, lang"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "ja, kurz"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversuche"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "immer"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "immer"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Medien+Standby"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Standby"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32 Bit Farbtiefe"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8 Bit Graustufen/Farbe"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Infotaste"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Stumm"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Lang InfoTaste"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x Vorspultaste"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x Vorspultaste Typ 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Lang Vorspultaste"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Lang Vorspultaste Typ 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Infotaste"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Stumm"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Lang InfoTaste"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x Rückspultaste"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x Rückspultaste Typ 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Lang RückSpulTaste"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Lang RückSpulTaste Typ 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15 min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "ja, erweitert"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Konsole normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "LogDatei umfangreich"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "LogDatei normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Medien"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Medien"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (voll)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normal (voll)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "getrimmt (schwarz)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "getrimmt (transparent)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "STUMM oder definierte Schlüssel"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "Jeder Key"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Zeit+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Zeit+Info+Dauerr"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Zeit+Länge+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "halb links"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "halb rechts"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Frame x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Linie"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "keine Bar"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "Kein Rahmen"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Verlauf"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Schattenkanten"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Name"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Position unterhalb"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Position links"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Position rechts"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Position"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Name"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Offline"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Online"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Online+Offline"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "verwende nur Timer"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "verwende Vorlaufzeit"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "keine Timeranzahl"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "zeige Timeranzahl"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "eine Zeile"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "zwei Zeilen"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Hauptspeicher verfügbar"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Hauptspeicher frei"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "Vollbild"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "ja außer Aufnahmen"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "O"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ONO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "OSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WSW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Lade aktive Konfig-Datei"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Lade Standard/Leere Konfiguration"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Speichere Konfig in Datei... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Lade Datei : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Datei löschen?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "gelöscht"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "aktuell eingestellt : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Wähle"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux Einstellungen Global"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menü"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Speichern"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Neustart Displays"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Setze An >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "keine LCD1 Bild-Datei"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "keine LCD2 Bild-Datei"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "keine LCD3 Bild-Datei"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux aktiviert"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Typ"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Drehung"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Hintergrundfarbe"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Hintergrundbild [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Helligkeit"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Nachtabsenkung"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Aktualisierung"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Typ"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Drehung"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Hintergrundfarbe"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Hintergrundbild [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Helligkeit"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Nachtabsenkung"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Aktualisierung"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Typ"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Drehung"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Hintergrundfarbe"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Hintergrundbild [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Helligkeit"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Nachtabsenkung"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Aktualisierung"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Boxskin-LCD Größe"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Boxskin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Boxskin-LCD Farbe"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Boxskin-LCD Aktiviere Modus An"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Boxskin-LCD Aktiviere Modus Medien"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Boxskin-LCD Aktiviere Modus Leerlauf"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [Anzeigezeit]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- welches LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Zeige im Modus"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- OSD-Größe"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Hintergrund/Transparenz"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- schneller Zugriff niedrige Qualität"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Popup Text"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Schlüssel löschen"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Schriftgröße"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Position"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Ausrichtung"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Farbe"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Hintergrundfarbe"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Schriftart"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Aktiver Schirm"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Schirm Schalter Auswahl - Schirm"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Vorgabeschirm nach Moduswechsel - Schirm"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Schirm Schalter Auswahl - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Benutzte Schirme zum Wechsel"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Schirm 1 Wechselzeit"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Umschaltzeit Schirm 2"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Umschaltzeit Schirm 3"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Umschaltzeit Schirm 4"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Umschaltzeit Schirm 5"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Umschaltzeit Schirm 6"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Umschaltzeit Schirm 7"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Umschaltzeit Schirm 8"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Umschaltzeit Schirm 9"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Bild Wechselzeit"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Bild Sortierung"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Bild Verzeichnis Rekursiv"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Bild Qualität für Größenänderung"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Bild Quick Aktualisierung Zeit [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Bild Typ [nur Bild]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Hintergrundbild-Typ"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Wetter API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Wetter API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Wetter API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Wetter Stadt"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Wetter Stadt 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Wetter-Icon-Verz. [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Wetter-Icon Zoom"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Wetter Niedrige Temperatur Farbe"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Wetter Hohe Temperatur Farbe"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Wetter Transparenz"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Wetter Wind Einheit"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Wetter Wind Infozeilen"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Wetter Regen Wahrscheinlichkeit"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Regenzoom"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Regenfarbe"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Regen verwende Farbe 2 ab"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Regenfarbe 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Wetter Luftfeuchtefarbe"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Wetter Linien"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Wetter Trendpfeile"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Wetter Extra Infos"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra Zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Zeige gefühlte Temperatur ab Differenz"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extrafarbe Stadt"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extrafarbe gefühlte Temperatur"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Min Bereich"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Max Bereich"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteo URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Mond-Icon-Verz. [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Aufnahme Bilddatei [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Doppel-Tasten Schalter"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Taste für Schirmwechsel"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Taste für Schirm Ein/Aus"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall Bilder Verz. [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Anzahl Zeilen je Eintrag"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Anzahl Listeneinträge"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Anzahl Bilder"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall Bilder Ausrichtung"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall Bilder Transparenz"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall Bilder Suche"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall entferne Anrufe nach Stunden"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Popup-Zeit"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall Popup LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Popup Farbe"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Rahmen Bild [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kalender ics-Verzeichnis [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalender ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalender planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Kalender Samstag Farbe"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Kalender Sonntag Farbe"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalender Linienstärke"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Kalender Tage Ereignisvorschau"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalender Zeitzone Korrektur"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Kalender Transparenz"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Kalender Abruf Interval"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Tuner Farbe"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Tuner Farbe Aktiv"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Tuner Farbe Ein"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Service Suche zuerst"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Signal-Qualitäts-Korrektur"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Zeichensatz Global [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Zeichensatz 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Zeichensatz 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Zeichensatz 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Zeichensatz 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Zeichensatz 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 Connect"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 Server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Anzeigename:]Nutzername"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 Passwort"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 Connect"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 Server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Anzeigename:]Nutzername"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 Passwort"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 Connect"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Anzeigename:]Nutzername"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 Passwort"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 Connect"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 Server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Anzeigename:]Nutzername"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 Passwort"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 Connect"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 Server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Anzeigename:]Nutzername"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 Passwort"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Mail Abruf Interval"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP begrenze auf letze Tage"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail Zeige Leere Mailboxen"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Mail zeige Datum"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail verberge Mailadresse"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Remote Box 1 [Anzeigename:]IP/Name"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Remote Box 2 [Anzeigename:]IP/Name"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Remote Box 3 [Anzeigename:]IP/Name"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Remote Box 4 [Anzeigename:]IP/Name"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Remote Box 5 [Anzeigename:]IP/Name"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Remote Box Abruf alle Minuten"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Remote Box Timer [Displayname:]IP/Name"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Remote Box Timer anfrage Minuten"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Konverter Abruf Interval"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW Konverter Verwendung"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey von cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey von convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF Aktualisierung [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF Aktualisierungstyp"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Init Verzögert"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP verweigert"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Design"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Speichern als Bild für WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 aktiv"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 Port"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 virtuelle Helligkeit"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 aktiv"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 Port"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 virtuelle Helligkeit"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 aktiv"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 Port"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 virtuelle Helligkeit"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG Zyklus"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Neustart bei Fehler"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG Header Modus"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Zeige Streams '4097; 5001...5003' im Modus"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Timeout [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Play Check"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Refresh [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping Timeout [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Play-Prüfung"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Refresh [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [optional]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Timeout [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Play Check"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Refresh [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Cover"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD benutzerdefinierte Breite"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD benutzerdefinierte Höhe"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD-Sonderbreite 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD-Sonderhöhe 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD aus, beim Abschalten"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing ! rechne alle Zeiten um Zeit/5*2 im Schnellmodus"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Verzögerung [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Threads pro LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Zeige Crash Ecke"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Zeige 'keine ....' Mitteilungen"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Speicher-Geräte: erzwinge Lesen"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Speicher-Geräte: Farbe zurück"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Speicher-Geräte: Farbbar"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Speicher-Geräte: Farbe voll"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Netzwerk Check Aktive"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "FramBuffer umschalten [wenn möglich]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Konfig Backup Verz. [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Alle Einstellungen wiederherstellen"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debug-Logging > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Hintergrundbeleuchtung aus [inaktiv bei Aus=Ein]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Hintergrundbeleuchtung Ein"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Hintergrundbeleuchtung am Wochenende aus [inaktiv bei Aus=Ein]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Hintergrundbeleuchtung am Wochenende Ein"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD-Auto-Aus"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Bild [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon Größe"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Geteilter Schirm"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Vollbild"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Zeichengröße"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparenz"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon Verzeichnis [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon Verzeichnis 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache Verz. [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Uhrzeit"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
-msgstr "- Typ"
+msgstr "-  Typ"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analoguhr"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Abstand"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Größe"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Schattenkanten"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Uhrzeit 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Programm Name"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- maximale Zeilen"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Länge"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Programm Nummer"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Programm Info"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Typ"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Programm Info 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Nächste Programm Info"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Erweiterte Beschreibung"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- benutze Info wenn leer"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Fortschrittsbalken"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Textfarbe"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Hintergrundfarbe"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Umrandung"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Schattiert"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Einheit min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informationen"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Tunerinfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensoren"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- Prozessor"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informationen 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Signal Qualität Bar"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Verlauf"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Bar-Bereich Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Bar-Bereich Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satellit"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Provider"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Verwendete Tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- nur aktive Tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Nächste Aufnahme"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Lautstärke"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Stumm"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Zeige Status"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Timeout [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Online Name:Adresse"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Externe IP Adresse"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- externe IP-URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Speicher-Geräte"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- frei Warnung"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- Zusatzinfo"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Gerätename"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Wettertyp"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Wetter 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo-Wetter Station"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Station"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Modul"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Benutzerdefinierte Module"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Basis"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Name"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Farbe 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Farbe 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Farbe 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Farbe 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Farbe 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Farbe 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Indikator"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Länge [Balken]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Komfort Indikator"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Mondphase"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Infozeilen"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Trendpfeile"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Sonnenaufgang"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Zeige oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Datei [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Zeige ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Zeige Textdatei"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Zeige Textdatei 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Zeige Textdatei 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Zeige HTTP Text"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-Internet Konverter"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP-Breite"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP-Höhe"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Beschneiden ab X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Beschneiden ab Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Breite beschneiden [deaktiviert = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Höhe beschneiden [deaktiviert = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Zeige Bild"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Datei oder Verzeichnis [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Größe max. Höhe"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Schnellaktualisierung"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Zeige Bild 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Zeige Bild 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Zeige Bild 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Zeige Bild 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Zeige Bild 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Zeilen"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Mail-Konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- max Breite"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Remote Box Timer"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Bildgröße"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Bildposition"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Bildausrichtung"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Layout"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Hintergrundfarbe für aktuellen Tag"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Beschriftungsfarbe"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Termine Liste"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Ereignis Icon Bar"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popup Schirm"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Text 1 anzeigen"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Text"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Text 2 anzeigen"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rechteck 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Position x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Position y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Größe x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Größe y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rechteck 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Aufnahme"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stotter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Benutzte Schirme zum Wechsel"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Titel"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Infos"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Zeige Cover"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Suche im Verzeichnis [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Finde Cover-Datei [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Standardcover [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon zuerst"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Getrimmt"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Cover herunterladen"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Downloadtyp"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google-API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Anzeige"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display Modus An"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Setze Medien >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Display Modus Medien Player"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Setze Leerlauf >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display Modus Leerlauf"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Setze Global >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Wähle Verzeichnis"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Wähle Verzeichnis"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Wähle Zeichensatz"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Aktueller Wert: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5260,114 +4131,94 @@ msgstr ""
 "GUI muss für das Aktiveren der Änderungen neu gestartet werden.\n"
 "Soll die GUI jetzt neu gestartet werden?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Neustart GUI jetzt?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Indoor"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Outdoor"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Regen"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Wind"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Neumond"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Erstes Viertel"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Zunehmender Halbmond"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Zunehmender Mond"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Vollmond"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Abnehmender Mond"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Abnehmender Halbmond"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Letztes Viertel"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Bild nicht verfügbar"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "kein Timer"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM läuft nicht"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "keine Anrufe"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d Neu  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "kein Netatmo-Plugin installiert"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Schirm Schalter"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "ja (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "Pfeil + Text"
-
-#~ msgid "only arrow"
-#~ msgstr "nur Pfeil"
-
-#~ msgid "only text"
-#~ msgstr "nur Text"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Wetter Wind Richtung"

--- a/LCD4linux/po/en.po
+++ b/LCD4linux/po/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD 4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:38+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:34+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: none\n"
 "Language: en\n"
@@ -16,7 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -70,47 +71,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Screen"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Weather"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Remote Box"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Calendar"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP Allow"
 
@@ -118,8 +107,7 @@ msgstr "WebIF IP Allow"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "No or wrong File selected, try a correct File first !"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Mode"
 
@@ -135,7 +123,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Show"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Delete"
 
@@ -167,35 +155,24 @@ msgstr "Save Config"
 msgid "stop Screencycle"
 msgstr "show total Timer"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Global"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "On"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Idle"
 
@@ -243,253 +220,299 @@ msgstr "List of Storage Devices"
 msgid "Parent Directory"
 msgstr "Parent Directory"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Fri"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Mon"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sat"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Sun"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Thur"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Tue"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Wed"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "black"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "white"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "gray"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "silver"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "slategray"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aquamarine"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "gold"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "greenyellow"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "yellow"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "darkorange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "darkred"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indianred"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "orange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "orangered"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "red"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomato"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "darkgreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "green"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "lawngreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "lightgreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "lime"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "blue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "blueviolet"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "cadetblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "cornflowerblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "darkblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "lightblue"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cyan"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "darkorchid"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "deeppink"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violet"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "brown"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "moccasin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olive"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "rosybrown"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "sandybrown"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Screen 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Screen 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Screen 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Screen 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Screen 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Screen 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Screen 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Screen 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Screen 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Screen 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Screen 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Screen 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Screen 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Screen 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Screen 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Screen 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Screen 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Screen 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Screen 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Screen 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Screen 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Screen 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Screen 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Screen 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Screen 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Screen 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Screen 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Screen 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Screen 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Screen 9"
 
@@ -511,1312 +534,1131 @@ msgstr "Screen 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "off"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Screen 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Screen 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Screen 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Screen 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Screen 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Screen 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Screen 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Screen 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Screen 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Screen 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Screen 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Screen 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Screen 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Screen 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Screen 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Screen 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Screen 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Screen 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "on"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (or compatible LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (or compatible LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (or compatible LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (or compatible LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Internal Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Internal TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "only Picture 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "only Picture 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "only Picture 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "only Picture 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "only Picture Custom Size"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "only Picture Custom Size 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Internal Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Current"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 Days 2 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 Days 2 Lines"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 Days Vertical View"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Days 2 Lines"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 Days Vertical View"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Current Temperature (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Current Temperature (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Current"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Current Temperature"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "All"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperature"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperature+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperature+Co2+Pressure"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperature+Humidity"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Module 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Module 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Module 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Module 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Module 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Module 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Module 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Module 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Module 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Module 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Module 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Module 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Module 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Module 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Module 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Module 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Module 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Module 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Module 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Module 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Module 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Module 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Module 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "userdefined"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Bar"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Bar+Value"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Knob"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Knob+Value"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analog"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analog+Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analog+Date+Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analog+Date+Weekday 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Date+Time"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Date+Time+Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Flaps Design Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Flaps Design Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Time"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Time+Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Weekday"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "center"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "left"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "right"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "center"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Extended"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Extended (Short)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Short"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Short (Extended)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Short+Extended"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Month"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Month+Header"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Week"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Week+Header"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "no Calendar"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "no Dates"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Dates 1 Line"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Dates 3 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Dates 5 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Dates 9 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Dates compact 2 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Dates compact 3 Lines"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Frame"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "no Dates"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Underline"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Underline 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Frame"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Dates"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Dates compact"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Dates compact no Icon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Dates no Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "no Calls"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "no Icon, with Targetnumber"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "with Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "with Icon & Targetnumber"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "no"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "show run"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "show run+sleep"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Always All"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Always New"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Only New"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "All Informations"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Distance only"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Distance+Illumination"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Distance+Moonphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Illumination only"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Illumination+Moonphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Moonphase only"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Channel"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Channel+Title"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Channel"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Channel+Title"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "same color"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparent"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "yes"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "yes +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontally"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "yes"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "vertically"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontally"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "all"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Corner"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Corner+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "only Progress Bar"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "with Remaining Minutes"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "with Remaining Minutes (Size 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "with Remaining Minutes (Size 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "with Percent"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "with Percent (Size 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "with Percent (Size 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "with Remaining Minutes (above)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "with Remaining Minutes (above/Size 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "with Remaining Minutes (above/Size 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "with Percent (above)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "with Percent (above/Size 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "with Percent (above/Size 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "with Remaining Minutes (below)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "with Remaining Minutes (below/Size 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "with Remaining Minutes (below/Size 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "with Percent (below)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "with Percent (below/Size 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "with Percent (below/Size 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "with Current 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "with Current 00:00 (Size 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "with Current 00:00 (Size 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "with Current 00:00 (above)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "with Current 00:00 (above/Size 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "with Current 00:00 (above/Size 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "with Current 00:00 (below)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "with Current 00:00 (below/Size 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "with Current 00:00 (below/Size 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "with Percent Minutes / Total (above)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "with Percent Minutes / Total (above/Size 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "with Percent Minutes / Total (above/Size 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "with absolute Endtime"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "with absolute Endtime (Size 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "with absolute Endtime (Size 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "with Minutes Total / Endtime (above)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "with Minutes Total / Endtime (above/Size 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "with Minutes Total / Endtime (above/Size 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Fastmode (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5s)"
 
@@ -1824,3437 +1666,2467 @@ msgstr "Normal (5s)"
 msgid "last Screen"
 msgstr "last Screen"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alphabetic"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "random"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "better/slow"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "low/fast (Picture only)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "low/fast (all)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + adjustment (high quality, slow)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + adjustment (low quality, fast)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "no cache + no adjustment"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Plug Tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Now/Next"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "reduced"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript no Refresh"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Reload"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - side by side"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternative Copy-Mode/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "yes + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "yes, long"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "yes, short"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversearch"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "always"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "always"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Media+Standby"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Standby"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - color"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - grayscale/color"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x InfoKey"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Mute"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Long InfoKey"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x FastForwardKey"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x FastForwardKey Type 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Long FastForwardKey"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Long FastForwardKey Type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x InfoKey"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Mute"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Long InfoKey"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x FastBackwardKey"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x FastBackwardKey Type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Long FastBackwardKey"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Long FastBackwardKey Type 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "yes, extended"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Console normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Logfile extensive"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Logfile normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "disabled"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (full)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normal (full)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "trimmed (black)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "trimmed (transparent)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "MUTE or defined Keys"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "all"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Time+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Time+Duration+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Time+Length+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "half left"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "half right"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Frame x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Line"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "no Bar"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "no Frame"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradient"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Shadow Edges"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Name"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Position below"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Position left"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Position right"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Position"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Name"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Offline"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Online"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Online+Offline"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "only use Timer"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "use lead-time"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "no total Timer"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "show total Timer"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "one line"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "two lines"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Memory available"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Memory free"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "full Screen"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "yes except records"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ENE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "ESE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "Mute"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WSW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Load Active Config-File"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Load Defaults / Empty Config"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Save Config to File... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Load File : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Delete File?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "deleted"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "currently set : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Select"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux Settings"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Cancel"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Save"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Restart Displays"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Set On >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "no LCD1 Picture-File"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "no LCD2 Picture-File"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "no LCD3 Picture-File"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux enabled"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Type"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Rotate"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Background Color"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Background-Picture [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Brightness"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Night Reduction"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Refresh"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Type"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Rotate"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Background Color"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Background-Picture [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Brightness"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Night Reduction"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Refresh"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Type"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Rotate"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Background Color"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Background-Picture [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Brightness"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Night Reduction"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Refresh"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD Dimension"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD Color"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD Enable On-Mode"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD Enable Media-Mode"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD Enable Idle-Mode"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [display time]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- which LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Show in Mode"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- OSD Size"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Background/Transparency"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Fast Grab lower quality"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Popup Text"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Clear Key"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Font Size"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Position"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Alignment"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Color"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Background Color"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Font"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Active Screen"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Screen Switch Select - Screen"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Screen Default after mode change - Screen"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Screen Switch Select - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Screens used for Changing"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Screen 1 Changing Time"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Screen 2 Changing Time"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Screen 3 Changing Time"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Screen 4 Changing Time"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Screen 5 Changing Time"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Screen 6 Changing Time"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Screen 7 Changing Time"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Screen 8 Changing Time"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Screen 9 Changing Time"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Picture Changing Time"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Picture Sort"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Picture Directory Recursive"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Picture Quality for Resizing"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Picture Quick Update Time [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Picture Type [only Picture]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Background-Picture Type"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Weather API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Weather API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Weather City"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Weather City 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Weather-Icon-Path [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Weather-Icon Zoom"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Weather Low Temperature Color"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Weather High Temperature Color"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Weather Transparency"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Weather Wind speed unit"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Weather Wind Info Lines"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Weather Rain Chance"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Rain Zoom"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Rain Color"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Rain use Color 2 from"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Rain Color 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Weather Humidity Color"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Weather Lines"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Weather Trendarrows"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Weather Extra Infos"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra Zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Show chill temperature from difference"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra Color City"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra Color Chill"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Min Range"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Max Range"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteo URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Moon-Icon-Path [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Recording Picture [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Double-button switches"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Key for Screen Change"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Key for Screen On/Off"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall Picture Path [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Number of Lines per Entry"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Number of List Entries"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Number of Pictures"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall Picture Orientation"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall Picture Transparency"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall Pictures Search"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall remove Calls after hours"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Popup-Time"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall Popup LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Popup Color"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Frame Picture [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Calendar ics-Path [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Calendar ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Calendar planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Calendar Saturday Color"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Calendar Sunday Color"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Calendar Line Thickness"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Calendar Day Event Preview"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Calendar Timezone Correction"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Calendar Transparency"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Calendar Poll Interval"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Tuner Color"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Tuner Color Active"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Tuner Color On"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Service search first"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Signal-Quality Correction"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Font global [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Font 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Font 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Font 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Font 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Font 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 Connect"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 Server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Displayname:]Username"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 Password"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 Connect"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 Server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Displayname:]Username"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 Password"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 Connect"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Displayname:]Username"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 Password"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 Connect"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 Server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Displayname:]Username"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 Password"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 Connect"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 Server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Displayname:]Username"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 Password"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Mail Poll Interval"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP limit to last days"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail Show Empty Mailboxes"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Mail Show Date"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail Hide Mailadress"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Remote Box 1 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Remote Box 2 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Remote Box 3 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Remote Box 4 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Remote Box 5 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Remote Box Poll every Minutes"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Remote Box Timer [Displayname:]IP/Name"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Remote Box Timer Poll every Minutes"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Converter Poll Interval"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW Converter Usage"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey from cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey from convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF Refresh [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF Refresh Type"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Init Delay"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP Deny"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Design"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Save as Picture for WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 enable"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 Port"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 Virtual Brightness"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 enable"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 Port"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 Virtual Brightness"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 enable"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 Port"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 Virtual Brightness"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG Cycle"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Restart on Error"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG Header Mode"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Show Streams '4097; 5001...5003' in Mode"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Timeout [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Play Check"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Refresh [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping Timeout [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Play Check"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Refresh [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [optional]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Timeout [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Play Check"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Refresh [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Cover"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD Custom Width"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD Custom Height"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD Custom Width 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD Custom Height 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD Off when shutdown"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Display Delay [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Threads per LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Show Crash Corner"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Show 'no ....' Messages"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Storage-Devices: Force Read"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Storage-Devices: Color Back"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Storage-Devices: Color Bar"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Storage-Devices: Color Full"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Network Check active"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Switch FrameBuffer [if possible]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Config Backup Path [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Config Restore All Settings"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debug-Logging > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Backlight Off [disable set Off=On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Backlight On"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Backlight Weekend Off [disable set Off=On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Backlight Weekend On"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Auto-OFF"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Background"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Picture [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon Size"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Split Screen"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Full Screen"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Text Size"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparency"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon Path [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon Path 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache Path [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Clock"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Type"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analog Clock"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Spacing"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Size"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Shadow Edges"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Clock 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Program Name"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- maximum Lines"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Length"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Program Number"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Program Info"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Type"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Program Info 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Next Program Info"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Extended Description"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- use Info when empty"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Progress Bar"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Color Text"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Color Background"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Border"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Shaded"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Unit min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informations"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Tunerinfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensors"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informations 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Signal Quality Bar"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradient"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Bar Range Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Bar Range Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satellite"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Provider"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Used Tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- only active Tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Next Timer Event"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volume"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Mute"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Show State"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Timeout [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Online Name:Address"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "External IP Address"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- external IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Storage-Devices"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- free Warning"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- extra Info"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Device Name"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Weather Type"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Weather 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo-Weather Station"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Station"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Module"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Module userdefined"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Name"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Color 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Color 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Color 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Color 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Color 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Color 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Indicator"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Length [Bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Comfort Indicator"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Moonphase"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Infolines"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Trendarrows"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Sunrise"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Show oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- File [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Show ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Show Textfile"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Show Textfile 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Show Textfile 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Show HTTP Text"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-Internet Converter"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP Width"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP Height"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Cut from X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Cut from Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Cut Width [disable = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Cut Height [disable = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Show Picture"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- File or Path [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Size max Height"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Quick Update"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Show Picture 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Show Picture 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Show Picture 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Show Picture 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Show Picture 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Lines"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Mail Konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- max Width"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Remote Box Timer"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Picture Size"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Picture Position"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Picture Alignment"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Layout"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Current Day Background Color"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Caption Color"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Dates List"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Event Icon Bar"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popup Screen"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Show Text 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Text"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Show Text 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Position x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Position y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Size x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Size y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Recording"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Screens used for Changing"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Title"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Infos"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Show Cover"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Search Path [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Find Cover File [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Default Cover [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon First"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Trimmed"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Download Cover"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Download Type"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Display"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display-Mode On"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Set Media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Display-Mode MediaPlayer"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Set Idle >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display-Mode Idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Set Global >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Choose dir"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Choose file"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Choose font"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Current value: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5262,114 +4134,94 @@ msgstr ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Restart GUI now?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Indoor"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Outdoor"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Rain"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Wind"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "New Moon"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "First Quarter"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Waxing Moon"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Full Moon"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Waning Moon"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Last Quarter"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Picture not available"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "no Timer"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM not running"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "no Calls"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d New  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "no Netatmo-Plugin installed"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Screen Switch"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "yes (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "arrow + text"
-
-#~ msgid "only arrow"
-#~ msgstr "only arrow"
-
-#~ msgid "only text"
-#~ msgstr "only text"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Weather Wind direction"

--- a/LCD4linux/po/en_GB.po
+++ b/LCD4linux/po/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD 4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:38+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:28+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: none\n"
 "Language: en_GB\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -70,47 +70,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Screen"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Weather"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Remote Box"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Calendar"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP Allow"
 
@@ -118,8 +106,7 @@ msgstr "WebIF IP Allow"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "No or wrong File selected, try a correct File first !"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Mode"
 
@@ -135,7 +122,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Show"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Delete"
 
@@ -167,35 +154,24 @@ msgstr "Save Config"
 msgid "stop Screencycle"
 msgstr "show total Timer"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Global"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "On"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Idle"
 
@@ -243,253 +219,299 @@ msgstr "List of Storage Devices"
 msgid "Parent Directory"
 msgstr "Parent Directory"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Fri"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Mon"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sat"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Sun"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Thur"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Tue"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Wed"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "black"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "white"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "gray"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "silver"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "slategray"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aquamarine"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "gold"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "greenyellow"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "yellow"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "darkorange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "darkred"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indianred"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "orange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "orangered"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "red"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomato"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "darkgreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "green"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "lawngreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "lightgreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "lime"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "blue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "blueviolet"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "cadetblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "cornflowerblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "darkblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "lightblue"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cyan"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "darkorchid"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "deeppink"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violet"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "brown"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "moccasin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olive"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "rosybrown"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "sandybrown"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Screen 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Screen 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Screen 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Screen 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Screen 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Screen 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Screen 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Screen 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Screen 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Screen 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Screen 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Screen 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Screen 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Screen 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Screen 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Screen 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Screen 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Screen 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Screen 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Screen 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Screen 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Screen 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Screen 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Screen 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Screen 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Screen 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Screen 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Screen 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Screen 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Screen 9"
 
@@ -511,1312 +533,1131 @@ msgstr "Screen 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "off"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Screen 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Screen 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Screen 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Screen 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Screen 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Screen 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Screen 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Screen 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Screen 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Screen 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Screen 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Screen 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Screen 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Screen 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Screen 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Screen 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Screen 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Screen 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "on"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (or compatible LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (or compatible LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (or compatible LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (or compatible LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Internal Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Internal TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "only Picture 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "only Picture 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "only Picture 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "only Picture 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "only Picture Custom Size"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "only Picture Custom Size 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Internal Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Current"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 Days 2 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 Days 2 Lines"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 Days Vertical View"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Days 2 Lines"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 Days Vertical View"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Current Temperature (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Current Temperature (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Current"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Current Temperature"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "All"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperature"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperature+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperature+Co2+Pressure"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperature+Humidity"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Module 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Module 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Module 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Module 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Module 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Module 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Module 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Module 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Module 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Module 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Module 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Module 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Module 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Module 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Module 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Module 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Module 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Module 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Module 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Module 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Module 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Module 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Module 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "userdefined"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Bar"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Bar+Value"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Knob"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Knob+Value"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analog"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analog+Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analog+Date+Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analog+Date+Weekday 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Date+Time"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Date+Time+Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Flaps Design Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Flaps Design Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Time"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Time+Weekday"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Weekday"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "center"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "left"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "right"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "center"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Extended"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Extended (Short)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Short"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Short (Extended)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Short+Extended"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Month"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Month+Header"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Week"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Week+Header"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "no Calendar"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "no Dates"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Dates 1 Line"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Dates 3 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Dates 5 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Dates 9 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Dates compact 2 Lines"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Dates compact 3 Lines"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Frame"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "no Dates"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Underline"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Underline 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Frame"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Dates"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Dates compact"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Dates compact no Icon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Dates no Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "no Calls"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "no Icon, with Targetnumber"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "with Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "with Icon & Targetnumber"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "no"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "show run"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "show run+sleep"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Always All"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Always New"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Only New"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "All Informations"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Distance only"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Distance+Illumination"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Distance+Moonphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Illumination only"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Illumination+Moonphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Moonphase only"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Channel"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Channel+Title"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Channel"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Channel+Title"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "same color"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparent"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "yes"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "yes +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontally"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "yes"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "vertically"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontally"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "all"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Corner"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Corner+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "only Progress Bar"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "with Remaining Minutes"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "with Remaining Minutes (Size 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "with Remaining Minutes (Size 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "with Percent"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "with Percent (Size 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "with Percent (Size 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "with Remaining Minutes (above)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "with Remaining Minutes (above/Size 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "with Remaining Minutes (above/Size 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "with Percent (above)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "with Percent (above/Size 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "with Percent (above/Size 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "with Remaining Minutes (below)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "with Remaining Minutes (below/Size 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "with Remaining Minutes (below/Size 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "with Percent (below)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "with Percent (below/Size 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "with Percent (below/Size 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "with Current 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "with Current 00:00 (Size 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "with Current 00:00 (Size 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "with Current 00:00 (above)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "with Current 00:00 (above/Size 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "with Current 00:00 (above/Size 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "with Current 00:00 (below)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "with Current 00:00 (below/Size 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "with Current 00:00 (below/Size 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "with Percent Minutes / Total (above)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "with Percent Minutes / Total (above/Size 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "with Percent Minutes / Total (above/Size 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "with absolute Endtime"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "with absolute Endtime (Size 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "with absolute Endtime (Size 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "with Minutes Total / Endtime (above)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "with Minutes Total / Endtime (above/Size 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "with Minutes Total / Endtime (above/Size 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Fastmode (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5s)"
 
@@ -1824,3437 +1665,2467 @@ msgstr "Normal (5s)"
 msgid "last Screen"
 msgstr "last Screen"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alphabetic"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "random"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "better/slow"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "low/fast (Picture only)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "low/fast (all)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + adjustment (high quality, slow)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + adjustment (low quality, fast)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "no cache + no adjustment"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Plug Tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Now/Next"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "reduced"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript no Refresh"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Reload"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - side by side"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternative Copy-Mode/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "yes + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "yes, long"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "yes, short"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversearch"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "always"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "always"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Media+Standby"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Standby"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - color"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - grayscale/color"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x InfoKey"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Mute"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Long InfoKey"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x FastForwardKey"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x FastForwardKey Type 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Long FastForwardKey"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Long FastForwardKey Type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x InfoKey"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Mute"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Long InfoKey"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x FastBackwardKey"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x FastBackwardKey Type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Long FastBackwardKey"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Long FastBackwardKey Type 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "yes, extended"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Console normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Logfile extensive"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Logfile normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "disabled"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (full)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normal (full)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "trimmed (black)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "trimmed (transparent)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "MUTE or defined Keys"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "all"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Time+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Time+Duration+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Time+Length+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "half left"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "half right"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Frame x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Line"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "no Bar"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "no Frame"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradient"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Shadow Edges"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Name"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Position below"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Position left"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Position right"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Position"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Name"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Offline"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Online"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Online+Offline"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "only use Timer"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "use lead-time"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "no total Timer"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "show total Timer"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "one line"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "two lines"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Memory available"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Memory free"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "full Screen"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "yes except records"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ENE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "ESE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "Mute"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WSW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Load Active Config-File"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Load Defaults / Empty Config"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Save Config to File... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Load File : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Delete File?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "deleted"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "currently set : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Select"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux Settings"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Cancel"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Save"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Restart Displays"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Set On >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "no LCD1 Picture-File"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "no LCD2 Picture-File"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "no LCD3 Picture-File"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux enabled"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Type"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Rotate"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Background Color"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Background-Picture [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Brightness"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Night Reduction"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Refresh"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Type"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Rotate"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Background Color"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Background-Picture [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Brightness"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Night Reduction"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Refresh"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Type"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Rotate"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Background Color"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Background-Picture [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Brightness"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Night Reduction"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Refresh"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD Dimension"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD Color"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD Enable On-Mode"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD Enable Media-Mode"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD Enable Idle-Mode"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [display time]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- which LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Show in Mode"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- OSD Size"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Background/Transparency"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Fast Grab lower quality"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Popup Text"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Clear Key"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Font Size"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Position"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Alignment"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Color"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Background Color"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Font"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Active Screen"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Screen Switch Select - Screen"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Screen Default after mode change - Screen"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Screen Switch Select - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Screens used for Changing"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Screen 1 Changing Time"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Screen 2 Changing Time"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Screen 3 Changing Time"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Screen 4 Changing Time"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Screen 5 Changing Time"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Screen 6 Changing Time"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Screen 7 Changing Time"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Screen 8 Changing Time"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Screen 9 Changing Time"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Picture Changing Time"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Picture Sort"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Picture Directory Recursive"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Picture Quality for Resizing"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Picture Quick Update Time [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Picture Type [only Picture]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Background-Picture Type"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Weather API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Weather API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Weather City"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Weather City 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Weather-Icon-Path [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Weather-Icon Zoom"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Weather Low Temperature Color"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Weather High Temperature Color"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Weather Transparency"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Weather Wind speed unit"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Weather Wind Info Lines"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Weather Rain Chance"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Rain Zoom"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Rain Color"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Rain use Color 2 from"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Rain Color 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Weather Humidity Color"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Weather Lines"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Weather Trendarrows"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Weather Extra Infos"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra Zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Show chill temperature from difference"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra Color City"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra Color Chill"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Min Range"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Max Range"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteo URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Moon-Icon-Path [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Recording Picture [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Double-button switches"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Key for Screen Change"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Key for Screen On/Off"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall Picture Path [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Number of Lines per Entry"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Number of List Entries"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Number of Pictures"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall Picture Orientation"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall Picture Transparency"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall Pictures Search"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall remove Calls after hours"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Popup-Time"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall Popup LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Popup Color"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Frame Picture [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Calendar ics-Path [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Calendar ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Calendar planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Calendar Saturday Color"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Calendar Sunday Color"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Calendar Line Thickness"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Calendar Day Event Preview"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Calendar Timezone Correction"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Calendar Transparency"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Calendar Poll Interval"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Tuner Color"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Tuner Color Active"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Tuner Color On"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Service search first"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Signal-Quality Correction"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Font global [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Font 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Font 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Font 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Font 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Font 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 Connect"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 Server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Displayname:]Username"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 Password"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 Connect"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 Server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Displayname:]Username"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 Password"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 Connect"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Displayname:]Username"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 Password"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 Connect"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 Server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Displayname:]Username"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 Password"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 Connect"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 Server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Displayname:]Username"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 Password"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Mail Poll Interval"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP limit to last days"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail Show Empty Mailboxes"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Mail Show Date"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail Hide Mailadress"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Remote Box 1 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Remote Box 2 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Remote Box 3 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Remote Box 4 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Remote Box 5 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Remote Box Poll every Minutes"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Remote Box Timer [Displayname:]IP/Name"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Remote Box Timer Poll every Minutes"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Converter Poll Interval"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW Converter Usage"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey from cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey from convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF Refresh [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF Refresh Type"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Init Delay"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP Deny"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Design"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Save as Picture for WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 enable"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 Port"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 Virtual Brightness"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 enable"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 Port"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 Virtual Brightness"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 enable"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 Port"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 Virtual Brightness"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG Cycle"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Restart on Error"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG Header Mode"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Show Streams '4097; 5001...5003' in Mode"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Timeout [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Play Check"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Refresh [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping Timeout [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Play Check"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Refresh [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [optional]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Timeout [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Play Check"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Refresh [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Cover"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD Custom Width"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD Custom Height"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD Custom Width 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD Custom Height 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD Off when shutdown"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Display Delay [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Threads per LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Show Crash Corner"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Show 'no ....' Messages"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Storage-Devices: Force Read"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Storage-Devices: Color Back"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Storage-Devices: Color Bar"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Storage-Devices: Color Full"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Network Check active"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Switch FrameBuffer [if possible]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Config Backup Path [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Config Restore All Settings"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debug-Logging > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Backlight Off [disable set Off=On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Backlight On"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Backlight Weekend Off [disable set Off=On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Backlight Weekend On"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Auto-OFF"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Background"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Picture [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon Size"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Split Screen"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Full Screen"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Text Size"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparency"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon Path [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon Path 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache Path [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Clock"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Type"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analog Clock"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Spacing"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Size"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Shadow Edges"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Clock 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Program Name"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- maximum Lines"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Length"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Program Number"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Program Info"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Type"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Program Info 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Next Program Info"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Extended Description"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- use Info when empty"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Progress Bar"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Color Text"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Color Background"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Border"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Shaded"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Unit min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informations"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Tunerinfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensors"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informations 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Signal Quality Bar"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradient"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Bar Range Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Bar Range Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satellite"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Provider"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Used Tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- only active Tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Next Timer Event"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volume"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Mute"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Show State"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Timeout [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Online Name:Address"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "External IP Address"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- external IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Storage-Devices"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- free Warning"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- extra Info"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Device Name"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Weather Type"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Weather 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo-Weather Station"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Station"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Module"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Module userdefined"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Name"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Color 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Color 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Color 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Color 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Color 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Color 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Indicator"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Length [Bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Comfort Indicator"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Moonphase"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Infolines"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Trendarrows"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Sunrise"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Show oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- File [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Show ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Show Textfile"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Show Textfile 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Show Textfile 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Show HTTP Text"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-Internet Converter"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP Width"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP Height"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Cut from X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Cut from Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Cut Width [disable = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Cut Height [disable = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Show Picture"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- File or Path [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Size max Height"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Quick Update"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Show Picture 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Show Picture 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Show Picture 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Show Picture 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Show Picture 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Lines"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Mail Konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- max Width"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Remote Box Timer"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Picture Size"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Picture Position"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Picture Alignment"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Layout"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Current Day Background Color"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Caption Color"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Dates List"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Event Icon Bar"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popup Screen"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Show Text 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Text"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Show Text 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Position x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Position y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Size x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Size y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Recording"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Screens used for Changing"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Title"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Infos"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Show Cover"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Search Path [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Find Cover File [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Default Cover [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon First"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Trimmed"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Download Cover"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Download Type"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Display"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display-Mode On"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Set Media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Display-Mode MediaPlayer"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Set Idle >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display-Mode Idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Set Global >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Choose dir"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Choose file"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Choose font"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Current value: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5262,114 +4133,94 @@ msgstr ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Restart GUI now?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Indoor"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Outdoor"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Rain"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Wind"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "New Moon"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "First Quarter"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Waxing Moon"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Full Moon"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Waning Moon"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Last Quarter"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Picture not available"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "no Timer"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM not running"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "no Calls"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d New  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "no Netatmo-Plugin installed"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Screen Switch"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "yes (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "arrow + text"
-
-#~ msgid "only arrow"
-#~ msgstr "only arrow"
-
-#~ msgid "only text"
-#~ msgstr "only text"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Weather Wind direction"

--- a/LCD4linux/po/es.po
+++ b/LCD4linux/po/es.po
@@ -2,15 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:39+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:35+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: OpenPlus\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -64,47 +65,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Pantalla"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "El Tiempo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Correo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Dispositivo Remoto"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Calendario"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "IP Permitida WebIF"
 
@@ -113,8 +102,7 @@ msgid "No or wrong File selected, try a correct File first !"
 msgstr ""
 "No hay archivo seleccionado o es equivocado, trata de corregir esto primero!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Modo"
 
@@ -130,7 +118,7 @@ msgstr "Registro de Bloqueo"
 msgid "Show"
 msgstr "Mostrar"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Borrar"
 
@@ -162,35 +150,24 @@ msgstr "Salvar Configuración"
 msgid "stop Screencycle"
 msgstr "parar Ciclo de Pantalla"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Global"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "On"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "En Reposo"
 
@@ -238,253 +215,299 @@ msgstr "Lista de dispositivos de almacenamiento"
 msgid "Parent Directory"
 msgstr "Directorio de padres"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Vie"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Lun"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sáb"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Dom"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Jue"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Mar"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Mié"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "negro"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "blanco"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "gris"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "plateado"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "grispizarra"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aguamarina"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "dorado"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "verdeamarillo"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "amarillo"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "naranjaoscuro"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "rojooscuro"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "pielroja"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "naranja"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "rojoanaranjado"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "rojo"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomate"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "verdeoscuro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "verde"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "verdecésped"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "verdeclaro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "lima"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "azul"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "azulvioleta"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "azul cadete"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "azul aciano"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "azul oscuro"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "azul índigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "celeste"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cián"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "orquídea oscuro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "rosa oscuro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violeta"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "marrón"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "mocasín"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "verde oliva"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "marrón rosado"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "marrón arena"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Pantalla 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Pantallas 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Pantallas 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Pantallas 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Pantallas 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Pantallas 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Pantallas 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Pantallas 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Pantallas 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Pantallas 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Pantallas 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Pantallas 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Pantallas 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Pantallas 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Pantallas 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Pantallas 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Pantallas 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Pantallas 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Pantallas 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Pantallas 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Pantallas 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Pantalla 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Pantalla 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Pantalla 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Pantalla 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Pantalla 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Pantalla 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Pantalla 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Pantalla 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Pantalla 9"
 
@@ -506,1312 +529,1131 @@ msgstr "Pantalla 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "off"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Pantallas 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Pantallas 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Pantallas 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Pantallas 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Pantallas 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Pantallas 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Pantallas 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Pantallas 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Pantallas 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Pantallas 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Pantallas 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Pantallas 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Pantallas 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Pantallas 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Pantallas 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Pantallas 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Pantallas 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Pantallas 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "on"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (o LCD compatible) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (o LCD compatible) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (o LCD compatible) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (o LCD compatible) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "LCD Box-Skin interno"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "TFT-LCD interno 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "sólo Imágenes 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "sólo Imágenes 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "sólo Imágenes 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "sólo Imágenes 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "sólo Imágenes de tamaño configurable"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "sólo Imágenes de tamaño configurable"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "LCD interno Vu+ Duo2 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Ahora"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 Dias 1 Linea"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 Dias 2 Lineas"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 Dias 1 Linea"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 Dias 2 Lineas"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 días vista vertical"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 Dias 1 Linea"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Dias 2 Lineas"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 días vista vertical"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Temperatura actual (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Temperatura actual (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Ahora"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Temperatura actual"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Todo"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatura+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatura+Co2+Presión"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatura+Humedad"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Módulo 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Módulos 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Módulos 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Módulos 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Módulos 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Módulos 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Módulos 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Módulos 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Módulos 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Módulos 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Módulo 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Módulos 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Módulos 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Módulos 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Módulo 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Módulo 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Módulos 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Módulo 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Módulo 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Módulo 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Módulo 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Módulo 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Módulo 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "definido por el usuario"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Pre"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Pre+Valor"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Knob"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Knob+Valor"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analógico"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analógico+Fecha"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analógico+Fecha+Día de la Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analógico+Fecha+Día de la Semana 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Fecha"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Fecha+Hora"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Fecha+Hora+Día de la Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Diseño Etiqueta Fecha"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Diseño Etiqueta Dia de la Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Hora"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Hora+Día de la Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Día de la Semana"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "centro"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "izquierda"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "derecha"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "centro"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Extendido"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Extendido (Corto)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Corto"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Corto (Extendido)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Corto+Extendido"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Mes"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Mes+Cabecera"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Semana"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Semana+Cabecera"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "sin Calendario"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "sin Fechas"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Fechas 1 Línea"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Fechas 3 Líneas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Fechas 5 Líneas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Fechas 9 Líneas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Fechas compactas en 2 Líneas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Fechas compactas en 3 Líneas"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Marco"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "sin Fechas"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Debajo de Línea"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Debajo de Línea 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Marco"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Fechas"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Fechas compactas"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Fechas compactas sin icono"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Fechas sin icono"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "sin Icono"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "sin Icono, con Número de Destino"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "con Icono"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "con Icono & Número de Destino"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "no"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "mostrar carrera"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "mostrar carrera+sueño"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Siempre Todo"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Siempre lo Nuevo"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Sólo lo Nuevo"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Todas las Informaciones"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "solo distancia"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Distancia+Iluminación"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Distancia+Fase lunar"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "solo Iluminación"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Iluminación+Fase lunar"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "solo Fase lunar"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Canal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Canal+Título"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Canal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Canal+Título"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "el mismo color"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparente"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "sí"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "sí+25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontalmente"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "sí"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "verticalmente"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontalmente"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "todo"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Esquina"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Esquina+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "sólo Barra de Progreso"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "con Minutos Restantes"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "con Minutos Restantes (Tamaño 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "con Minutos Restantes (Tamaño 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "con Porcentaje"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "con Porcentaje (Tamaño 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "con Porcentaje (Tamaño 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "con Minutos Restantes (arriba)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "con Minutos Restantes (arriba/Tamaño 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "con Minutos Restantes (arriba/Tamaño 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "con Porcentaje (arriba)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "con Porcentaje (arriba/Tamaño 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "con Porcentaje (arriba/Tamaño 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "con Minutos Restantes (debajo)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "con Minutos Restantes (debajo/Tamaño 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "con Minutos Restantes (debajo/Tamaño 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "con Porcentaje (debajo)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "con Porcentaje (debajo/Tamaño 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "con Porcentaje (debajo/Tamaño 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "con el Actual 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "con el Actual 00:00 (Tamaño 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "con el Actual 00:00 (Tamaño 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "con el Actual 00:00 (arriba)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "con el Actual 00:00 (arriba/Tamaño 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "con el Actual 00:00 (arriba/Tamaño 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "con el Actual 00:00 (debajo)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "con el Actual 00:00 (debajo/Tamaño 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "con el Actual 00:00 (debajo/Tamaño 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "con Porcentaje de Minutos / Total (arriba)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "con Porcentaje de Minutos / Total (arriba/Tamaño 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "con Porcentaje de Minutos / Total (arriba/Tamaño 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "con el tiempo del fin absoluto"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "con el tiempo del fin absoluto (Tamaño 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "con el tiempo del fin absoluto (Tamaño 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "con Minutos Totales / Hora de finalización (arriba)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "con Minutos Totales / Hora de finalización (arriba/Tamaño 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "con Minutos Totales / Hora de finalización (arriba/Tamaño 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Modo Rápido (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5s)"
 
@@ -1819,3437 +1661,2467 @@ msgstr "Normal (5s)"
 msgid "last Screen"
 msgstr "última pantalla"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alfabético"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "aleatorio"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "mejor/lento"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "bajo/rápido (solo Fotos)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "bajo/rápido (todo)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + ajuste (alta calidad, lento)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + ajuste (baja calidad, rápido)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "sin cache + sin ajuste"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Sintonizador integrado"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "Sintonizador USB"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Ahora/Después"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "reducido"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript sin actualización"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Recarga"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - cara a cara"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "modo Copia alternativo/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "sí + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "sí, largo"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "sí, corto"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Búsqueda Cubrir"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "siempre"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "siempre"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Media+Reposo"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Reposo"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - color"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - gris/color"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Tecla Info"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Silencio"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Tecla Info Prolongada"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x Tecla Avance Rápido"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x Tecla Avance Rápido Tipo 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Tecla Avance Rápido Prolongada"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Tecla Avance Rápido Prolongada Tipo 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Tecla Info"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Silencio"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Tecla Info Prolongada"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x Tecla Retroceso Rápido"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x Tecla Retroceso Rápido Tipo 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Tecla Retroceso Rápido Prolongada"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Tecla Retroceso Rápido largo Tipo 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "sí, extendido"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Consola normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Archivo de log extenso"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Archivo de log normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (completo)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normal (completo)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "ajustado (negro)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "ajustado (transparente)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "Silencio o teclas definidas"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "cualquier Tecla"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Hora+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Hora+Duración+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Hora+Duración+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "mitad izquierda"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "mitad derecha"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Marco x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Línea"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "sin Barra"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "sin Marco"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradiente"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Bordes de Sombra"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Nombre"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Posición debajo"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Posición izquierda"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Posición derecha"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Posición"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Nombre"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Desconectado"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Conectado"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Conectado+Desconectado"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "usar sólo Temporizador"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "usar hora principal"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "sin Temporizador completo"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "mostrar Temporizador completo"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "una línea"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "dos líneas"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Memoria disponible"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Memoria libre"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "a toda pantalla"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "sí, excepto grabaciones"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ENE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "ESE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "O"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "ONO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "OSO"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Cargar Archivo de Configuración Activo"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Cargar por defecto / Configuración vacía"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Salvar Configuración al Archivo...(%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Cargar Archivo : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Borrar Archivo?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "borrado"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "ajuste actual : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Valige"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "Ajustes de LCD4linux"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menüü"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Salvar"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Reiniciar Pantallas"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Ir a On >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "no hay Archivo de Imagen de LCD1"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "no hay Archivo de Imagen de LCD2"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "no hay Archivo de Imagen de LCD3"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux activado"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "Tipo LCD 1"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- Rotar LCD 1"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- Color de Fondo LCD 1"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- Fondo-Imagen LCD 1 [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- Brillo LCD 1"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- Reducción Nocturna LCD 1"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- Refrescar LCD 1"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "Tipo LCD 2"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- Rotar LCD 2"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- Color de Fondo LCD 2"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- Fondo-Imagen LCD 2 [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- Brillo LCD 2"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- Reducción Nocturna LCD 2"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- Refrescar LCD 2"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "Tipo LCD 3"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- Rotar LCD 3"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- Color de Fondo LCD 3"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- Fondo-Imagen LCD 3 [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- Brillo LCD 3"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- Reducción Nocturna LCD 3"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- Refrescar LCD 3"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Tamaño LCD Box-Skin"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Color LCD Box-Skin"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Activar Modo On LCD Box-Skin"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Activar Modo Media LCD Box-Skin"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Activar Modo Apagado LCD Box-Skin"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [hora en pantalla]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- qué LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Mostrar en Modo"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Tamaño OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Fondo/Transparencia"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Grabador Rápido baja calidad"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Texto Emergente"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Clave clara"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Tamaño de Fuente"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Posición"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Alineamiento"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Color"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Color de Fondo"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Fuente"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Pantalla Activa"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Seleccionar pantalla a Cambiar - Pantalla"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Pantalla por defecto tras el cambio de modo - Pantalla"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Seleccionar pantalla a Cambiar - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Pantallas usadas para los cambios"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Tiempo de cambio Pantalla 1"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 2"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 3"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 4"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 5"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 6"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 7"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 8"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Tiempo de cambio Pantalla 9"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Tiempo de cambio Imagen"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Imágenes aleatorias"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Directorio Recursivo de Imágenes"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Calidad de Imagen para Redimensionar"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Tiempo de Actualización Rápida de Imagen [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Tipo de Imagen [solo Imagen]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Tipo de Fondel de Imagen"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "El Tiempo API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Clave del Tiempo API OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Ciudad para el Tiempo"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Ciudad para el Tiempo 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Ruta de Iconos del Tiempo [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Zoom de Iconos del Tiempo"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Color de Baja Temperatura del Tiempo"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Color de Alta Temperatura del Tiempo"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Transparencias del Tiempo"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Unidad de velocidad del viento meteorológico"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Líneas de información de viento meteorológico"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Posibilidad de Lluvia en el Tiempo"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Zoom de Lluvia"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Color de Lluvia"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- La Lluvia usa color 2 desde"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Color de Lluvia 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Tiempo Humedad Color"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Líneas del Tiempo"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Tiempo Flechas de Tendencia"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Informaciones Extras del Tiempo"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Zoom Extra"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Mostrar temperaturas más frías desde la diferencia"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Color Extra de Ciudad"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Color Extra del Frío"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Rango Mínimo"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Rango Máximo"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "URL Meteo"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Ruta Iconos Lunares [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Imagen de Grabación [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Cambios Doble Botón"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Tecla para Cambiar pantalla"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Tecla para Apagar/Encender Pantalla"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall Ruta Imagen [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Número de Líneas por Entrada"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Número de Entradas Listadas"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Número de Imágenes"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall Imagen de Orientación"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "Transparencia Imagen FritzCall"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall Búsqueda de Imágenes"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall Borrar Llamadas después de horas"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Hora Emergente"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall LCD Emergente"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Color Emergente"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Imagen de Marco [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Ruta Calendario ics [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "URL Calendario ics"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Calendario planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Calendario Color Sábado"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Calendario Color Domingo"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Calendario Líneas Finas"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Calendario Prevista Eventos Diarios"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Calendario Corrección Zona Horaria"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Calendario Transparencia"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Calendario Intervalo"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Color Sintonizador"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Color Sintonizador Activo"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Color Sintonizador Funcionando"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Primero Búsqueda de Canales"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "Corrección de Calidad de Señal DVB-T"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Fuente Global [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Fuente 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Fuente 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Fuente 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Fuente 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Fuente 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Conectar Correo 1"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Servidor Correo 1"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Correo 1 [NombrePantalla:]Usuario"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Contraseña Correo 1"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Conectar Correo 2"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Servidor Correo 2"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Correo 2 [NombrePantalla:]Usuario"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Contraseña Correo 2"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Conectar Correo 3"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Servidor Correo 3"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Correo 3 [NombrePantalla:]Usuario"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Contraseña Correo 3"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Conectar Correo 4"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Servidor Correo 4"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Correo 4 [NombrePantalla:]Usuario"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Contraseña Correo 4"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Conectar Correo 5"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Servidor Correo 5"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Correo 5 [NombrePantalla:]Usuario"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Contraseña Correo 5"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Intervalo Correo"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Correo IMAP limitado hasta los últimos días"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mostrar Carpetas Vacías del Correo"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Fecha de Muestra del Correo"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "El Correo Esconde la Dirección de Correo"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 1 [Nombrepantalla:]IP/Nombre"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 2 [Nombrepantalla:]IP/Nombre"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 3 [Nombrepantalla:]IP/Nombre"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 4 [Nombrepantalla:]IP/Nombre"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 5 [Nombrepantalla:]IP/Nombre"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Dispositivo Remoto Encuesta cada Minuto"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto Temporizador [Nombrepantalla:]IP/Nombre"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Dispositivo Remoto Temporizador Encuesta cada Minuto"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "Intervalo Convertidor WWW"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "Uso del Convertidor WWW"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "Llave Api WWW de cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "Llave Api WWW de convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "Refresco WebIF [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "Tipo de Refresco WebIF"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "Retraso de Inicio WebIF"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "IP Prohibida WebIF"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "Diseño WebIF"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Guardar como Imagen para WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Arroyo LCD 1 permitir"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Arroyo LCD 1 Puerto"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Arroyo LCD 1 Brillo virtual"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Arroyo LCD 2 permitir"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Arroyo LCD 2 Puerto"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Arroyo LCD 2 Brillo virtual"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Arroyo LCD 3 permitir"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Arroyo LCD 3 Puerto"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Arroyo LCD 3 Brillo virtual"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG Ciclo"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Reiniciar en caso de error"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "Modo de Cabecera MJPEG"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Mostrar Streams '4097; 5001...5003' en modo"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Descanso [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Tocar Cheque"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Refresco [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Descanso [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Tocar Cheque"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Refresco [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [optional]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Descanso [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Tocar Cheque"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Refresco [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Cover"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "Anchura Personalizada del LCD"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "Altura Personalizada del LCD"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "Anchura Personalizada 2 del LCD"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "Altura Personalizada 2 del LCD"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD apagado cuando se apaga"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Hora ! calcular todas las veces a hora/5*2 en Modo Rápido"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Retraso Pantalla [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Hilos por LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Mostrar Esquina Rota"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Mostrar Mensajes 'no...'"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Dispositivos de Almacenamiento: Forzar lectura"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Dispositivos de Almacenamiento: Color Fondo"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Dispositivos de Almacenamiento: Color Bar"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Dispositivos de Almacenamiento: Color Completo"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Comprobación de Red activa"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Poner contador de planos (si es posible)"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Ruta para Guardar Configuraciones [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Restaurar Configuración de Todos los Ajustes"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Registro de Depuración > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Luz de Fondo Desconectada [deshabilita ajuste Off=On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Luz de Fondo Conectada"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Luz de Fondo Fin de Semana desconectada [deshabilita ajuste Off=On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Luz de Fondo Fin de Semana Conectada"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Apagado automático"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Fondo"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Imagen [ok]"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Tamaño de Picon"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Pantalla Dividida"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- A Toda Pantalla"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Tamaño de Texto"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparencia"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Ruta de Picon [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Ruta de Picon 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Ruta Caché Picon [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Reloj"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
-msgstr "- Tipo"
+msgstr "-  Tipo"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Reloj Analógico"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Espaciado"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Tamaño"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Bordes de Sombra"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Reloj 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Nombre de Programa"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- máximo de Líneas"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Duracción"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Número de Programa"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Información de Programa"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Tipo"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Información Programa 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Información Próximo Programa"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Descripción Extendida"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- Usa la información cuando está vacío"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Barra de Progreso"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Color Texto"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Color de fondo"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Margen"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Sombreado"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Unidad min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informaciones"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Información Sintonizador"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensores"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informaciones 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Barra de Calidad de Señal"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradiente"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Barra rango Mínimo"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Barra Rango Máximo"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satélite"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Proveedor"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Sintonizador Usado"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- solo Sintonizador activo"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Próximo Evento Programado"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volumen"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Silencio"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "En Linea [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Mostrar Estado"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Descanso [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Nombre En Linea:Dirección"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Dirección IP Extendida"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- externo IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Dispositivos de Almacenamiento"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- Advertencia"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- información extra"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Nombre de Dispositivo"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Tipo de Tiempo"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "El Tiempo 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Estación Metereológica del Tiempo"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Estación"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Módulo"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Módulo definido por el usuario"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Nombre"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Color 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Color 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Color 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Color 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Color 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Color 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo Indicador de CO2"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Longitud [Barra]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Indicador de Comodidad"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Fases Lunares"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Líneas de información"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Flechas de Tendencia"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Amanecer"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Mostrar oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Archivo [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Mostrar ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Mostrar Archivo de Texto"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Mostrar Archivo de Texto 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Mostrar Archivo de Texto 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Mostrar Texto HTTP"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "Convertidor WWW-Internet"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- Ancho HTTP"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- Alto HTTP"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Cortar desde X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Cortar desde Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Cortar Ancho [deshabilitar = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Cortar Altura [deshabilitar = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Mostrar Imagen"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Archivo o Ruta [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Tamaño Altura Máxima"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Actualización Rápida"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Mostrar Imagen 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Mostrar Imagen 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Mostrar Imagen 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Mostrar Imagen 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Mostrar Imagen 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Líneas"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Correo Konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- Anchura máxima"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Dispositivo Remoto Temporizador"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Tamaño Imagen"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Posición Imagen"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Alineamiento Imagen"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Disposición"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Color de Fondo Día Actual"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Leyenda Color"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Lista de fechas"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Barra de icono de Evento"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Pantalla Aparición"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- LCD Aparición"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Mostrar Texto 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Texto"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Mostrar Texto 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rectángulo 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Posición x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Posición y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Tamaño x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Tamaño y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rectángulo 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Grabando"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Pantallas usadas para Cambios"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Título"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informaciones"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Mostrar Cubierta"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Buscar Ruta [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- - Buscar archivo de portada [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Cubierta por Defecto [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon Primero"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- recortado"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Descargar Cubierta"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Descargar Archivo de Depuración"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "Pantalla LCD"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "Modo de la Pantalla LCD4linux Encendido"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Ir a Reproductor >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "Modo de la Pantalla LCD4linux en Reproductor"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Ir a Espera >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "Modo de la Pantalla LCD4linux en Espera"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Ir a Global >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Elige Directorio"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Elige Archivo"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Elige Fuente"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Valor Actual: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5257,114 +4129,94 @@ msgstr ""
 "GUI necesita reiniciar para aplicar los cambios.\n"
 "¿Realmente quiere reiniciar el GUI ahora?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "¿Reiniciar el GUI ahora?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Interior"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Exterior"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Lluvia"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Viento"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Luna Nueva"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Cuarto Creciente"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Luna Creciente"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Luna Creciente"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Luna Llena"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Luna Menguante"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Creciente Menguante"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Cuarto Menguante"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Imagen no disponible"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "sin Temporizador"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM no está funcionando"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "sin Llamadas"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Correos %d Nuevo %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "no hay Plugin Netatmo instalado"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "Cambiar a Pantalla LCD4linux"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "sí (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "flecha + texto"
-
-#~ msgid "only arrow"
-#~ msgstr "sólo flecha"
-
-#~ msgid "only text"
-#~ msgstr "sólo texto"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Tiempo Dirección del viento"

--- a/LCD4linux/po/fi.po
+++ b/LCD4linux/po/fi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:40+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:35+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Kojo/Orlandox\n"
 "Language: fi\n"
@@ -16,7 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -70,47 +71,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Näyttö"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Sää"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo-sääasema"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "S-posti"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Etälaite"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalenteri"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF: Sallitut IP:t"
 
@@ -118,8 +107,7 @@ msgstr "WebIF: Sallitut IP:t"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "Ei lainkaan, tai väärä tiedosto valittu. Yritä uudelleen!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Tila"
 
@@ -135,7 +123,7 @@ msgstr "Kaatumisloki"
 msgid "Show"
 msgstr "Näytä"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Poista"
 
@@ -167,35 +155,24 @@ msgstr "Tallenna asetukset"
 msgid "stop Screencycle"
 msgstr "pysäytä Screencycle"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Globaali"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Päällä"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Valmiustila"
 
@@ -243,253 +220,299 @@ msgstr "Lista tallennusvälineistä"
 msgid "Parent Directory"
 msgstr "Kotihakemisto"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Pe"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Maa"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sat"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Aurinko"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "To"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Tii"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Kes"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "musta"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "valkoinen"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "harmaa"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "hopea"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "slategray"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "vedensininen"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "kulta"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "viherkeltainen"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "keltainen"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "tumma oranssi"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "tummanpunainen"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "intianpunainen"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "oranssi"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "oranssinpunainen"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "punainen"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomaatti"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "tummanvihreä"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "vihreä"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "ruohonvihreä"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "vaaleanvihreä"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "lime"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "sininen"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "sinivioletti"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "cadetblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "cornflowerblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "tummansininen"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigonsininen"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "vaaleansininen"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "sinivihreä"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "darkorchid"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "tumma vaaleanpunainen"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violetti"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "ruskea"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "ruskeahko"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "oliivi"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "punaruskea"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "hiekanruskea"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Näyttö 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Näytöt 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Näytöt 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Näytöt 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Näytöt 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Näytöt 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Näytöt 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Näytöt 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Näytöt 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Näyttö 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Näyttö 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Näyttö 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Näyttö 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Näyttö 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Näyttö 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Näyttö 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Näyttö 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Näyttö 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Näyttö 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Näyttö 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Näyttö 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Näyttö 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Näyttö 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Näyttö 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Näyttö 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Näyttö 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Näyttö 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Näyttö 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Näyttö 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Näyttö 9"
 
@@ -511,1312 +534,1131 @@ msgstr "Näyttö 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "pois päältä"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Näytöt 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Näytöt 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Näytöt 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Näytöt 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Näytöt 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Näytöt 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Näytöt 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Näytöt 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Näyttö 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Näyttö 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Näyttö 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Näyttö 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Näyttö 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Näyttö 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Näyttö 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Näyttö 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Näyttö 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Näyttö 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "päällä"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (tai yhteensopiva LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (tai yhteensopiva nestekidenäyttö) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (tai yhteensopiva LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (tai yhteensopiva LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Sisäinen VDF-näyttö"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Sisäinen TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "vain 1024x600 -kuva"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "vain 320x240 -kuva"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "vain 800x480 -kuva"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "vain 800x600 -kuva"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "vain muokatun koon kuva"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "vain muokatun koon kuva 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Sisäinen Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Nykyinen"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 päivää, 1 rivi"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 päivää, 2 riviä"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 päivää, 1 rivi"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 päivää, 2 riviä"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 päivää, vertikaalinen näkymä"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 päivää, 1 rivi"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 päivää, 2 riviä"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 päivää, vertikaalinen näkymä"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Nykyinen lämpötila [+C]"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Nykyinen lämpötila [-C]"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Nykyinen"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Nykyinen lämpötila"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Kaikki"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Lämpötila"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Lämpötila+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Lämpötila+Co2+Ilmanpaine"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Lämpötila+Kosteus"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Moduli 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Moduli 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Moduli 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Moduli 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Moduli 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Moduli 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Moduli 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Moduli 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Moduli 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Moduli 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Moduli 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Moduli 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Moduli 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Moduli 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Moduli 2+6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Moduli 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Moduli 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Moduli 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Moduli 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Moduli 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Moduli 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Moduli 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Moduli 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "käyttäjän valitsema"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Palkki"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Palkki+Arvo"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Nuppi"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Nuppi+Arvo"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analoginen"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analoginen+Päivämäärä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analoginen+Päivämäärä+Viikonpäivä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analoginen+Päivämäärä+Viikonpäivä 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Päivämäärä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Päivämäärä+Aika"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Päivämäärä+Aika+Viikonpäivä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "\"Läppä\"-mallinen päivämäärä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "\"Läppä\"-mallinen viikonpäivä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Aika"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Aika+Viikonpäivä"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Viikonpäivä"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "keskellä"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "vasen"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "oikea"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "keskellä"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Laajennettu"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Laajennettu (lyhyt)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Lyhyt"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Lyhyt (laajennettu)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Lyhyt+Laajennettu"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Kuukausi"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Kuukausi+Otsikko"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Viikko"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Viikko+Otsikko"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "ei Kalenteria"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "ei Päivämääriä"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Päivämäärät: 1 rivi"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Päivämäärät: 3 riviä"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Päivämäärät: 5 riviä"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Päivämäärät: 9 riviä"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Päivämäärät: suppea, 2 riviä"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Päivämäärät: suppea, 3 riviä"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Kehys"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "ei Päivämääriä"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Alleviiva"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Alleviiva 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Kehys"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Päivämäärät"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Päivämäärät: suppea"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Päivämäärät: suppea, ei ikonia"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Päivämäärät: ei ikonia"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "ei Ikonia"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "ei ikonia, kohdenumeroiden kanssa"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "ikonin kanssa"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "ikonin ja kohdenumeron kanssa"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "ei"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Kuorma@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Kuorma@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "näytä käynnissä"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "näytä käynnissä+lepotilassa"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Aina kaikki"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Aina uusin"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Vain uusin"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Kaikki tiedot"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Vain etäisyys"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Etäisyys + valaistu %"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Etäisyys + kuuvaihe"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Vain valaistu %"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Valaistu % + kuuvaihe"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Vain kuuvaihe"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanava"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanava+Otsikko"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Kanava"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Kanava+Otsikko"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "sama väri"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "läpinäkyvä"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "kyllä"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "kyllä +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horisontaalinen"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "kyllä"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "vertikaalinen"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horisontaalinen"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "kaikki"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Kulma"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Kulma+Ajansiirto"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Ajansiirto"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "vain etenemispalkki"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "jäljellä oleva aika minuutteina"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "jäljellä oleva aika minuutteina (Koko 1,5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "jäljellä oleva aika minuutteina (Koko 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "prosentteina"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "prosentteina (Koko 1,5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "prosentteina (Koko 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "jäljellä oleva aika minuutteina (yläpuolella)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "jäljellä oleva aika minuutteina (Koko 1,5/yläpuolella)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "jäljellä oleva aika minuutteina (Koko 2/yläpuolella)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "prosentteina (yläpuolella)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "prosentteina (yläpuolella/Koko 1,5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "prosentteina (yläpuolella/Koko 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "jäljellä oleva aika minuutteina (alapuolella)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "jäljellä oleva aika minuutteina (Koko 1,5/alapuolella)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "jäljellä oleva aika minuutteina (Koko 2/alapuolella)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "prosentteina (alapuolella)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "prosentteina (alapuolella/Koko 1,5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "prosentteina (alapuolella/Koko 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "nykyinen 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "nykyinen 00:00 (Koko 1,5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "nykyinen 00:00 (Koko 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "nykyinen 00:00 (yläpuolella)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "nykyinen 00:00 (yläpuolella/koko 1,5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "nykyinen 00:00 (yläpuolella/koko 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "nykyinen 00:00 (alapuolella)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "nykyinen 00:00 (alapuolella/koko 1,5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "nykyinen 00:00 (alapuolella/koko 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella/koko 1,5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "minuutit prosentteina / Kokonaisaika (yläpuolella/koko 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "absoluuttinen loppuaika"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "absoluuttinen loppuaika (Koko 1,5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "absoluuttinen loppuaika (Koko 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella/koko 1,5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "kokonaisaika minuutteina / Loppuaika (yläpuolella/koko 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Nopea (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normaali (5s)"
 
@@ -1824,3437 +1666,2467 @@ msgstr "Normaali (5s)"
 msgid "last Screen"
 msgstr "viimeinen näyttö"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alphabetic"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "sekalainen"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "parempi/hidas"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "huonompi/nopea (vain kuva)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "huonompi/nopea (kaikki)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + sovitus (korkea laatu, hidas)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + sovitus (huonompi laatu, nopea)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "ei cachea + ei sovitusta"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Sisäinen viritin"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB-viritin"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Nyt/Seuraava"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normaali"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "pelkistetty"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript, ei virkistystä"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Uudelleenlataus"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normaali"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - vierekkäin"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "vaihtoehtoinen Kopio-tila/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "kyllä + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "kyllä, pitkä"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "kyllä, lyhyt"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversearch"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "aina"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "aina"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "Päällä+Media+Valmiustila"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Valmiustila"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - väri"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - harmaasävy/väri"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Info-näppäin"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Mykistys"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Pitkä Info-painike"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x eteenpäinkelaus"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x eteenpäinkelaus, tyyppi 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Pitkä eteenpäinkelaus"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Pitkä eteenpäinkelaus tyyppi 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Info-näppäin"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Mykistys"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Pitkä Info-painike"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x taaksepäinkelaus"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x taaksepäinkelaus, tyyppi 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Pitkä taaksepäinkelaus"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Pitkä taaksepäinkelaus tyyppi 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "kyllä, laajennettu"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Normaali konsoli"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Laajennettu lokitiedosto"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Normaali lokitiedosto"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "pois päältä"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (täysi)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normaali (täysi)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "säädetty (musta)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "säädetty (läpinäkyvä)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "Mykistä, tai määritelty painike"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "mikä tahansa painike"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Aika+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Aika+Kesto+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Aika+Pituus+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "half left"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "half right"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Kehys x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Line"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "ei Palkkia"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "ei Reunusta"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normaali"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Liukuväri"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Varjostetut reunat"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Nimi"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normaali"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Positio alla"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Positio vasemmalla"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Positio oikealla"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Sijainti"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Nimi"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Ei yhteyttä"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Verkkoyhteys"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Päällä ja pois päältä"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "vain ajastimen käyttö"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "käytä aloitusaikaa"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "ei koko ajastusta"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "näytä koko ajastus"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "yksi rivi"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "kaksi riviä"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Muistia saatavilla"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Muistia vapaana"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "kokonäyttö"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "kyllä, paitsi tiedot"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "Itä"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "Itäkoillinen"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "Itäkaakko"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "Pohjoinen"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "Koillinen"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "Pohjoiskoillinen"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "Pohjoisluode"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "Luode"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "Etelä"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "Kaakko"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "Eteläkaakko"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "Etelälounas"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "Lounas"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "Länsi"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "Länsiluode"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "Länsiluode"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Lataa aktiivinen asetustiedosto"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Lataa oletukset / Tyhjennä konfiguraatio"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Tallenna tiedostoon... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Lataa tiedosto : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Poista tiedosto?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "poistettu"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "nyt asetettu : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Valitse"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux Asetukset"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Valikko"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Tallenna"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Käynnistä näytöt uudelleen"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Aseta Päällä >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "ei LCD1 -kuvatiedostoa"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "ei LCD2 -kuvatiedostoa"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "ei LCD3 -kuvatiedostoa"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux päällä"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Tyyppi"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Kierto"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Taustaväri"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Taustakuva [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Kirkkaus"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Yövalaistus"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Virkistys"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Tyyppi"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Kierto"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Taustaväri"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Taustakuva [ok]"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Kirkkaus"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Yövalaistus"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Virkistys"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Tyyppi"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Kierto"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Taustaväri"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Taustakuva [ok]"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Kirkkaus"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Yövalaistus"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Virkistys"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "VDF-näytön mitat"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "VDF-näyttön  poikkeama"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "VDF-näytön väri"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "VDF-näyttö, aktivoi Käynnissä -tilassa"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "VDF-näyttö, aktivoi Media -tilassa"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "VDF-näyttö, aktivoi valmiustilassa"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [näytettävä aika]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- mikä LCD-näyttö"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Näytä tilassa"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- OSD:n koko"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Tausta/Läpinäkyvyys"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Fast Grab lower quality"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Popup-Teksti"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Poistu-painike"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Fontin koko"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Positio"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Kohdistus"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Tekstin väri"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Taustaväri"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Fontti"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Aktiivinen näyttö"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Valitse vaihdettava näyttö - Näyttö"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Näyttö Oletusarvo tilan vaihdon jälkeen - Näyttö"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Valitse vaihdettava näyttö - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Valitse kierrätettävät näytöt"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Näytön 1 vaihtumisaika"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Näyttö 2 vaihtumisaika"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Näyttö 3 vaihtumisaika"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Näyttö 4 vaihtumisaika"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Näyttö 5 vaihtumisaika"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Näyttö 6 vaihtumisaika"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Näyttö 7 vaihtumisaika"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Näyttö 8 vaihtumisaika"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Näyttö 9 vaihtumisaika"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Kuvan vaihtumisaika"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Kuvien järjestys"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Rekursiivinen kuvahakemisto"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Kuvakoon muokkauksen kuvanlaatu"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Kuvan nopea päivitysaika [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Kuvan formaatti [vain kuva]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Taustakuvan tyyppi"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Sää-API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Sää: API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Sää: API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Sää: Kaupunki"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Sää: Kaupunki 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Sää-ikonin polku [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Sää-ikoni zoom"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Sää: Alhaisen lämpötilan väri"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Sää: Korkean lämpötilan väri"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Sää: Läpiväkyvyys"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Sää: Tuulen nopeusyksikkö"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Sää: Tuuli tietorivit"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Sää: Sateen mahdollisuus"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Sade Zoom"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Sateen väri"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Sade: Käytä väriä 2 paikasta"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Sateen väri 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Sää Kosteus Väri"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Sää: Erotin"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Sään: Trendinuolet"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Sää: Lisätiedot"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra Zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Näytä viileän lämpötilan ero paikasta"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Kaupungin lisäväri"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Viileän lisäväri"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Pienin arvo"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Suurin arvo"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteo URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Kuu-ikonin polku [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Tallennuskuva [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Kaksoispainallus vaihtaa näyttöä"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Painike näytön vaihtamiseen"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Painike, näyttö päälle/pois"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall: Kuvien polku"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall: Rivien määrä"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall: Listojen määrä"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall: Kuvien määrä"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall: Kuvien asettelu"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall: Kuvan läpinäkyvyys"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall: Kuvahaku"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall: Tuntimäärä, jonka jälkeen puhelut poistetaan"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall: Popup-aika"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall: Popup-LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall: Popup-väri"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall: Kuva [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kalenteri: ics-polku [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalenteri: ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalenteri: planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Kalenteri: Lauantain väri"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Kalenteri: Sunnuntain väri"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalenteri: Reunojen paksuus"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Kalenteri: Päivän tapahtumien esikatselu"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalenteri: Aikavyöhykkeen korjaus"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Kalenteri: Läpinäkyvyys"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Kalenteri: Kyselyiden aikaväli"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Viritin: Väri"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Viritin: Väri aktiivisena"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Viritin: Väri, kun laite päällä"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Palvelunhaku ensin"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Signaalitason korjaus"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Globaali Fontti [ok]"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Fontti 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Fontti 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Fontti 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Fontti 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Fontti 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Posti 1 Yhteystapa"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Posti 1 Palvelin"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Posti 1 [Näyttönimi:] Käyttäjätunnus"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Posti 1 Salasana"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Posti 2 Yhteystapa"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Posti 2 Palvelin"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Posti 2 [Näyttönimi:] Käyttäjätunnus"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Posti 2 Salasana"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Posti 3 Yhteystapa"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Posti 3 Palvelin"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Posti 3 [Näyttönimi:] Käyttäjätunnus"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Posti 3 Salasana"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Posti 4 Yhteystapa"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Posti 4 Palvelin"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Posti 4 [Näyttönimi:] Käyttäjätunnus"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Posti 4 Salasana"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Posti 5 Yhteystapa"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Posti 5 Palvelin"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Posti 5 [Näyttönimi:] Käyttäjätunnus"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Posti 5 Salasana"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Posti: Kyselyväli"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Posti: IMAP-rajan kesto päivissä"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Posti: Näytä \"Tyhjennä postilaatikot\""
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Posti: Näytä paivämäärä"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Posti: Piilota s-postiosoite"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Etälaite 1 [Näyttönimi:]IP/Nimi"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Etälaite 2 [Näyttönimi:]IP/Nimi"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Etälaite 3 [Näyttönimi:]IP/Nimi"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Etälaite 4 [Näyttönimi:]IP/Nimi"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Etälaite 5 [Näyttönimi:]IP/Nimi"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Etälaitteen pollaus joka minuutti"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Etälaitteen ajastus [Näyttönimi:]IP/Nimi"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Etälaitteen ajastuksen pollaus joka minuutti"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW-muuntimen kyselyväli"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW-muuntimen osoite"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "Cloudconvert.org WWW ApiKey"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "Convertapi.com WWW ApiKey"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF: Virkistä [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF: Virkistystyyppi"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF: Viive"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF: Estä IP:(t)"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF: Ulkoasu"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Tallenna kuva WebIF:lle"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG: Syöte LCD 1 Päälle"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG: Syöte LCD 1 Portti"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG: Syöte LCD 1 Virtuaalinen kirkkaus"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG: Syöte LCD 2 Päälle"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG: Syöte LCD 2 Portti"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG: Syöte LCD 2 Virtuaalinen kirkkaus"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG: Syöte LCD 3 Päälle"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG: Syöte LCD 3 Portti"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG: Syöte LCD 3 Virtuaalinen kirkkaus"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG: Kierto"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG: Virheen sattuessa, uudelleenkäynnistys"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG: Otsikkotila"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Näytä streamit '4097; 5001...5003' tilassa"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos: IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos: Ping Aikakatkaisu [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos: Play-tarkistus"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos: Virkistä [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound: Ping Aikakatkaisu [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound: Toisto-tarkistus"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound: Virkistä [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast: IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast: Palvelimen IP [valinnainen]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast: Ping-aikakatkaisu [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast: Play-tarkistus"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast: Virkistä [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast: Kansikuva"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD: Mukautettu leveys"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD: Mukautettu korkeus"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD: Mukautettu leveys 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD: Mukautettu korkeus 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD: pois päältä kun sammutettuna"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing ! calc all Times to Time/5*2 in Fastmode"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Näytön viive [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Ketjut per LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Show Crash Corner"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Näytä 'ei ....' Viestejä"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Tallennusväline: Pakota luku"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Tallennusväline: Taustaväri"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Tallennusväline: Palkin väri"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Tallennusväline: Väri, kun tilaa on vähän jäljellä"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Verkkotarkistus aktiivinen"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Vaihda ruutubufferia [jos mahdollista]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Asetukset: Varmuuskopion polku [ok]"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Asetukset: Palauta kaikki asetukset"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debug-Lokit > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Ei taustavaloa"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Taustavalo päällä"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Ei taustavaloa viikonloppuisin"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Taustavalo Viikkonloppuisin päällä"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Automaattisesti pois päältä"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Tausta"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Kuva [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Piconin koko"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Jaettu näyttö"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Kokonäyttö"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Tekstin koko"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Läpinäkyvyys"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Piconien polku [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Piconien polku 2[ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Piconien cachen polku [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Kello"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
-msgstr "- Tyyppi"
+msgstr "-  Tyyppi"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analoginen kello"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Kellon ja pvm väli"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Koko"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Varjoreunat"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Kello 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Kanavan nimi"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- suurin määrä rivejä"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Pituus"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Ohjelman numero"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Ohjelmainfo"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Tyyppi"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Ohjelmainfo 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Seuraavan ohjelman info"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Laajennettu kuvaus"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- näytä Info kun tämä on tyhjä"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Etenemispalkki"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Tekstin väri"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Väri Tausta"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Reunat"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Varjostettu"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Yksikkö min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Laitteen tekniset tiedot"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Viritininfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensorit"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Laitteen tekniset tiedot 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Signaalitason palkki"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Liukuväri"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Palkin pienin vaihteluväli"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Palkin suurin vaihteluväli"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satelliitti"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Tarjoaja"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Käytetty viritin"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- vain aktiivinen Viritin"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Seuraava ajastus"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Äänenvoimakkuus"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Mykistä"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bittinopeus"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Verkkoyhteys [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Näytä tila"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Aikakatkaisu [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Verkkonimi:Osoite"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Ulkoinen IP-osoite"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- ulkoinen IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Tallennusvälineet"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- Vapaan tilan varoitus"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- Lisätietoa"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Tallennusväline"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "Kiintolevy"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Miten sää-tiedot näytetään"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Sää 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo-Sääasema"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Asema"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Moduli"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Käyttäjän asettama moduli"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Nimi"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Väri 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Väri 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Väri 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Väri 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Väri 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Väri 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo-sääasema 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Indikaattori"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Palkin pituus"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo \"Tuntuu kuin\""
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Kuuvaihe"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Tietorivit"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Trendinuolet"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Auringonnousu"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Näytä oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Tiedosto [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Näytä ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Näytä Tekstitiedosto"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Näytä Tekstitiedosto 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Näytä Tekstitiedosto 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Näytä HTTP-teksti"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW Internet-muunnin"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP Leveys"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP Korkeus"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Leikkaa kohdasta X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Leikkaa kohdasta Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Leikkaa leveyttä [0=pois päältä]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Leikkaa korkeutta [0=pois päältä]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Näytä kuva"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Tiedosto tai polku [ok]"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Suurin korkeus"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Nopea päivitys"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Näytä kuva 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Näytä kuva 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Näytä kuva 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Näytä kuva 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Näytä kuva 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Rajat"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- S-posti tilit"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- Suurin leveys"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Etälaitteen ajastin"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Kuvakoko"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Kuvan positio"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Kuvan kohdistus"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Ulkoasu"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Kuluvan päivän taustaväri"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Selosteen väri"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Päivämäärät: Lista"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Tapatumapalkki"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popup Näyttö"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Näytä Teksti 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Teksti"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Näytä Teksti 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Positio x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Positio y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Koko x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Koko y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Tallentaa"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Vaihdossa käytettävä näyttö"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Otsikko"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Infot"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Näytä kansikuva"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Hakupolku [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Etsi kansikuva [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Oletus Kansikuva [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon ensin"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Leikattu"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Lataa kansikuva"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Lataa tyyppi"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD-näyttö"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Näyttötila: Päällä"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Aseta Media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Näyttötila: Media"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Aseta Valmiustila >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Näyttötila: Valmiustilassa"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Aseta Globaali >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Valitse hakemisto"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Valitse tiedosto"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Valitse fontti"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Nykyinen arvo: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5262,114 +4134,94 @@ msgstr ""
 "Käyttöliittymä pitää käynnistää uudelleen jotta asetukset astuvat voimaan.\n"
 "Haluatko uudelleenkäynnistää?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Käyttöliittymän uudelleenkäynnisty nyt?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Sisätila"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Ulkoilma"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Sadetta"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Tuuli"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Uusikuu"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Kasvava Kuunsirppi"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Ensimmäinen Neljännes"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Kasvava Kuu"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Täysikuu"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Vähenevä Kuu"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Kolmas Neljännes"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Vähenevä Kuunsirppi"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Kuva ei ole saatavilla"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "ei Ajastusta"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM ei ole päällä"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "ei Puheluita"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Postia  %d Uusia  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "nessun plug-in Netatmo installato"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Näytönvaihto"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "kyllä (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "nuoli + teksti"
-
-#~ msgid "only arrow"
-#~ msgstr "ainoa nuoli"
-
-#~ msgid "only text"
-#~ msgstr "vain teksti"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Sää Tuulen suunta"

--- a/LCD4linux/po/fr.po
+++ b/LCD4linux/po/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:40+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:28+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -13,7 +13,7 @@ msgstr ""
 "X-Poedit-KeywordsList: _;gettext;gettext_noop\n"
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -67,47 +67,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Ecran"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Météo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Boite distante"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Calendrier"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF autoriser IP"
 
@@ -116,8 +104,7 @@ msgid "No or wrong File selected, try a correct File first !"
 msgstr ""
 "Aucun ou mauvais fichier sélectionné, essayer un fichier correct d'abord!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Mode"
 
@@ -133,7 +120,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Afficher"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Effacer"
 
@@ -165,35 +152,24 @@ msgstr "Sauver configuration"
 msgid "stop Screencycle"
 msgstr "stopper cycle écran"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Global"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "En"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Média"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Veille"
 
@@ -241,253 +217,299 @@ msgstr "Liste des périphériques de stockage"
 msgid "Parent Directory"
 msgstr "Dossier parent"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Ven"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Lun"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sam"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Dim"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Jeu"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Mar"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Mer"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "noir"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "blanc"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "gris"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "argent"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "gris ardoise"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "bleu-vert"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "or"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "jaune-vert"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "jaune"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "orange foncé"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "rouge foncé"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "rouge indien"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "orange"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "orangé"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "rouge"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomate"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "vert foncé"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "vert"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "vert prairie"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "vert clair"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "citron vert"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "bleu"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "bleu violet"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "bleu de cadet"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "bleu fleur de maïs"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "bleu foncé"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "bleu clair"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cyan"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "orchidée noire"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "rose intense"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violet"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "brun"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "moccasin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olive"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "brun rosé"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "brun sable"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Écran 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Écran 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Écran 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Écran 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Écran 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Écran 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Écran 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Écran 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Écran 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Écran 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Écran 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Écran 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Écran 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Écran 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Écran 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Écran 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Écran 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Écran 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Écran 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Écran 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Écran 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Écran 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Écran 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Écran 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Écran 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Écran 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Écran 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Écran 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Écran 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Écran 9"
 
@@ -509,1312 +531,1131 @@ msgstr "Écran 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "hors"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Écran 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Écran 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Écran 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Écran 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Écran 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Écran 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Écran 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Écran 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Écran 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Écran 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Écran 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Écran 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Écran 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Écran 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Écran 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Écran 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Écran 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Écran 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "en"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2 h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3 h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5 h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2 h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3 h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5 h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (ou compatible LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (ou LCD compatible) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (ou compatible LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (ou compatible LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H ancien 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Interne Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Interne TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "seulement image 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "seulement image 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "seulement image 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "seulement image 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "seulement image taille personnalisée"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "seulement image de taille personnalisée 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "InterneVu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Actuel"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 jours 1 Ligne"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 jours 2 Lignes"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 Jours 1 Ligne"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 Jours 2 Lignes"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 Jours Vue Verticale"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 Days 1 Line"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Days 2 Lines"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 Days Vertical View"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "TempErature actuelle (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Température actuelle (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Actuel"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Température actuelle"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Tout"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Température"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Température+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Température+Co2+Pression"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Températur+Humidité"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modul 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Modul 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Modul 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Modul 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Modul 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Modul 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Modul 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Modul 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Modul 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Module 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modul 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Modul 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Modul 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Modul 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Module 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modul 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Modul 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Module 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modul 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Module 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modul 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Module 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Module 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "défini par l'utilisateur"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Bar"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Bar+Valeur"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Boutton"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Boutton+Valeur"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analogique"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analogique+Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analogique+Date+jour de la semaine"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analogique+Date+Joursemaine 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Date"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Date+Heure"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Date+Heure+jour de la semaine"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Date de conception des volets"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Flaps Design Jour de semaine"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Heure"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Heure+Jour de la semaine"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Jour semaine"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "centre"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "gauche"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "droit"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "centre"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Etendu"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Etendu (court)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Court"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Court (Etendu)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Court+Etendu"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Mois"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Mois+entête"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Semaine"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Semaine+entête"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "pas de Calendrier"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "pas de Dates"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Dates 1 Ligne"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Dates 3 Lignes"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Dates 5 Lignes"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Dates 9 Lignes"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Dates compactes 2 Lignes"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Dates compactes 3 Lignes"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Cadre"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "pas de Dates"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Sous-ligné"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Sous-ligné 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Cadre"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Dates"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Dates compactes"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Dates compactes pas d'icône"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Dates pas d'icône"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "pas d'icône"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "pas d'icône, avec numéro cible"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "avec Icône"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "avec Icône & Numméro cible"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "tpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "non"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "tpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Charge@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Charge@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "afficher actif"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "afficher actif+dormant"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Toujours tout"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Toujours nouveau"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Seulement nouveau"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Toutes les Informations"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Distance seulement"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Distance+Éclairage"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Distance+Moonphase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Éclairage seulement"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Illumination+Phase de Lune"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Phase de lune uniquement"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Chaîne"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Chaîne+Titre"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Chaîne"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Chaîne+Titre"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "même couleur"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparent"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "oui"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "oui +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontallement"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "oui"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "verticalement"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontallement"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "tous"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Coin"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Corner+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+PauseDirect"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "seulement barre de progression"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "avec les minutes restantes"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "avec les minutes restantes (taille 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "avec les minutes restantes (taille 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "avec pourcentage"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "avec pourcentage (taille 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "avec pourcentage (taille 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "avec les minutes restantes (au-dessus)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "avec les minutes restantes (au-dessus/taille 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "avec les minutes restantes (au-dessus/taille 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "avec pourcentage (au-dessus)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "avec pourcentage (au-dessus/taille 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "avec pourcentage (au-dessus/taille 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "avec les minutes restantes (en-dessous)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "avec les minutes restantes (en-dessous/taille 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "avec les minutes restantes (en-dessous/taille 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "avec pourcentage (en-dessous)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "avec pourcentage (en-dessous/taille 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "avec pourcentage (en-dessous/taille 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "avec actuel 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "avec actuel 00:00 (taille 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "avec actuel 00:00 (taille 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "avec actuel 00:00 (au-dessus)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "avec actuel 00:00 (au-dessus/taille 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "avec actuel 00:00 (au-dessus/taille 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "avec actuel 00:00 (en-dessous)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "avec actuel 00:00 (en-dessous/taille 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "avec actuel 00:00 (en-dessous/taille 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "avec pourcentage minutes / Total (dessus)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "avec poucentage minutes / Total (dessus/Taille 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "avec pourcentage minutes / Total (dessus/Taille 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "avec heure de fin absolue"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "avec heure de fin absolue (taille 1,5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "avec heure de fin absolue (taille 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "avec Minutes Total / Heure de fin (ci-dessus)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "avec Minutes Total / Heure de fin (ci-dessus / Taille 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "avec Minutes Total / Heure de fin (ci-dessus/Taille 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Mode rapide (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5s)"
 
@@ -1822,3437 +1663,2467 @@ msgstr "Normal (5s)"
 msgid "last Screen"
 msgstr "dernier écran"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alphabétique"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "aléatoire"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "meilleur/lent"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "bas/rapide (image seulement)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "bas/rapide (tout)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + ajustement (haute qualité, lent)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + ajustement (basse qualité, rapide)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "pas de cache + pas d'ajustement"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Insérer Tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Actuellement/suivant"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "reduit"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript pas de Rafraîchissement"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Recharger"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - cote à cote"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OuvrirMapMétéo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "MétéoDévérouillée"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternatif Mode-Copie/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "oui + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "oui, long"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "oui, court"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Recherche couverture"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "toujours"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "toujours"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "En+Média+Veille"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Veille"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - couleur"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - échelle de gris/couleur"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x touche Info"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x mute"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Long touche info"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x touche avance rapide"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x touche avance rapide type 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Long touche avance rapide"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Long touche avance rapide Type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x touche Info"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x mute"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Long touche info"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x touche retour rapide"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x touche retour rapide type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Long touche retour rapide"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Long touche retour rapide Type 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "oui, étendu"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Console normale"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Logfile étendu"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Logfile normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "désactivé"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Média"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Média"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (complet)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normal (complet)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "rogné (noir)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "rogné (transparent)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "MUTE ou touches définies"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "n'importe quelle Clé"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Heure+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Heure+Durée+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Heure+Longueur+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "moitié gauche"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "moitié droite"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Cadre x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Ligne"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "pas de Bar"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "pas de cadre"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Dégradé"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Bords ombrés"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Nom"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Position en dessous"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Position gauche"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Position droite"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Position"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Nom"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Hors-ligne"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "En ligne"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "En ligne+Hors ligne"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "seulement utiliser prog"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "utiliser délai"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "pas d'enregistrement complet"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "afficher programmation total"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "en ligne"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "deux lignes"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Mémoire disponible"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Mémoire libre"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "plein écran"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "oui excepté les enregistrements"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "O"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ONO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "OSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WSW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Charger fichier configuration actif"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Charger les valeurs par défaut / Config vide"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Sauvegarder fichier de configuration... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Charger fichier : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Effacer fichier?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "effacé"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "actuellement défini : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Sélectionner"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "Paramètres LCD4linux"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Fermer"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Sauver"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Relancer affichages"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Réglages en >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "pas de fichier image LCD1"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "pas de fichier image LCD2"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "pas de fichier image LCD3"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux activé"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Type"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Rotation"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Couleur du fond"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Image de fond [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Luminosité"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Mode nuit"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Rafraîchir"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Type"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Rotation"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Couleur de fond"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Image de fond [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Luminosité"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Mode nuit"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Rafraîchir"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Type"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Rotation"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Couleur du fond"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Image de fond [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Luminosité"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Mode nuit"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Rafraîchir"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD Dimension"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Décalage"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD Couleur"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD Activer le mode-En"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD Activer le mode-Média"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD Activer le mode-Veille"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [afficher l'heure]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- Quel LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Afficher en mode"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Taille OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Fond/Transparence"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Saisie rapide qualité plus faible"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Texte popup"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Effacer la clé"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Taille Police"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Position"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Alignement"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Couleur"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Couleur du fond"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Police"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Ecran actif"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Ecran sélection commutation  - Ecran"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Écran Défaut après changement de mode - Écran"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Ecran sélection commutation  - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Ecran utilisé pour changer"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Durée de changement écran 1"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Ecran 2 Temps de changement"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Ecran 3 Temps de changement"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Ecran 4 Temps de changement"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Ecran 5 Temps de changement"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Ecran 6 Temps de changement"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Ecran 7 Temps de changement"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Ecran 8 Temps de changement"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Ecran 9 Temps de changement"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Vitesse de changement des images"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Trier image"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Répertoire image récursive"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Image qualité de la mise à l'échelle"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Image mise à jour rapide [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Type photo [seulement photo]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Type photo arrière plan"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Météo API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Météo API-Touche OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key MétéoDévérouillée"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Ville météo"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Ville météo 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Chemin vers les icônes météo [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Zoom icône météo"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Météo couleur des températures basses"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Météo couleur des températures hautes"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Météo transparence"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Météo unité vitesse vent"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Météo Vent Lignes d'informations"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Météo risque de pluie"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Zoom Pluie"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Couleur Pluie"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Couleur de pluie 2 de"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Couleur Pluie 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Météo Humidité Couleur"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Météo lignes"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Météo Flèches de Tendance"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Météo Infos extra"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Zoom Extra"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Afficher différence température ressentie"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Couleur ville extra"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Couleur froide extra"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo plage min CO2"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo plage max CO2"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "URL météo"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Chemin des icônes de lune [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Enregistrement photo [OK]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Interrupteurs double-boutons"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Touche pour changer d'écran"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Touche pour écran En/Hors"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall chemin des images [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall nombre de ligne par entrée"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall nombre d'entrées de la liste"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall nombre d'images"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall orientation image"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall transparence photo"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall recherche photos"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall supprimer les appels après heures"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall durée du popup"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall popup LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall couleur popup"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall image du cadre [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Calendrier chemin-ics [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Calendrier URL-ics"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Calendrier PlanerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Calendrier couleur samedi"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Calendrier couleur dimanche"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Calendrier épaisseur ligne"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Calendrier prévisualisation de l'événement du jour"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Calendrier correction fuseau horaire"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Calendrier transparence"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Calendrier interval requête"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Couleur tuner"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Couleur tuner actif"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Activer la couleur du tuner"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Recherche service en premier"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Signal-Correction qualité"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Police global [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Police 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Police 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Police 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Police 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Police 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 Connection"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 Serveur"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Nom affiché:]Nom utilisateur"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 Mot de passe"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 Connection"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 Serveur"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Nom affiché:]Nom utilisateur"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 Mot de passe"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 Connection"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Serveur"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Nom affiché:]Nom utilisateur"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 Mot de passe"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 Connection"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 Serveur"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Nom affiché:]Nom utilisateur"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 Mot de passe"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 Connection"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 Serveur"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Nom affiché:]Nom utilisateur"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 Mot de passe"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Interval requête mail"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP limiter aux dernier jours"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail Afficher les boîtes vides"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Mail Afficher les dates"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail Cacher adresse mail"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Boite 1 distante [AfficherNom:]IP/Nom"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Boite 2 distante [AfficherNom:]IP/Nom"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Boite 3 distante [AfficherNom:]IP/Nom"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Boite 4 distante [AfficherNom:]IP/Nom"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Boite 5 distante [AfficherNom:]IP/Nom"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Boite distante requête toutes les minutes"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Remote Box Timer [NomAffiché:]IP/Nom"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Remote Box Timer Sondage toutes les minutes"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW convertisseur interval requête"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW utilisation convertisseur"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey depuis cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey depuis convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF rafraîchissement [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF type de rafraîchissement"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF délai d'init"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF rejeter IP"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Design"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Sauver comme image pour WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 activé"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 Port"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 Luminosité virtuelle"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 activé"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 Port"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 Luminosité virtuelle"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 activé"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 Port"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 Luminosité virtuelle"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "Cycle MJPEG"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "Redémarrage de MJPEG en cas d'erreur"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG mode Header"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Afficher les Streams '4097 ; 5001...5003' en mode"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Timeout[ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Play Check"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Rafraîchissement[s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping Timeout [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Play Check (en)"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Rafraîchir [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Serveur IP [optionnel]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Timeout[ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Play Check"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Rafraîchissement[s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Pochette"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD largeur personnalisée"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD hauteur personnalisée"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD Largeur personnalisée 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD Hauteur personnalisée 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "Écran LCD éteint lors de l'arrêt"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing! calc tous temps comme temps/5*2 mode rapide"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Délai d'affichage [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Processus par LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Afficher Couverture Crash"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Afficher 'non ...' messages"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Périphérique-Stockage: Forcer la lecture"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Dispositifs de stockage : Couleur arrière"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Dispositifs de stockage : Barre de couleurs"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Dispositifs de stockage : Couleur Pleine"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Contrôle réseau actif"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Commuter TamponFram [si possible"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Config chemin sauvegarde [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Config restauration tous les paramètres"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Journal-Debug > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Rétro-éclairage hors [définir hors=en]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Rétro-éclairage On"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Rétro-éclairage Weekend hors [définir hors=en]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Rétro-Eclairage Weekend On"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Auto-OFF"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Arrière plan"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Photo [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Taille Picon"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Ecran partagé"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Plein écran"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Taille du texte"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparence"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Chemin Picon [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Chemin Picon 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Chemin du cache Picon [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Horloge"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Type"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Horloge analogique"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Espacement"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Taille"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Bords ombrés"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Horloge 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Nom du programme"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- Lignes maximum"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Longueur"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Numéro du programme"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Info programme"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Type"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Programme Info 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Info programme suivant"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Description étendue"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- utiliser Info lorsqu'il est vide"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Barre de progression"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Couleur Texte"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Couleur de fond"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Entourage"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Ombré"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Unité min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informations"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Info Tuner"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Senseurs"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informations 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Afficher Barre de qualité"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Dégradé"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Bar plage Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Bar plage Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satellite"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Opérateur"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Tuner utilisé"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- Seulement le tuner actif"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Evénement prog suivant"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volume"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Mute"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Vidéo"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "En ligne [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Afficher état"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Temps dépassé [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- En ligne Nom:Adresse"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Adresse IP externe"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- URL IP externe"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Périphériques-Stockages"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- avertissement libre"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- Info extra"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Nom du périphérique"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Type Météo"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Météo 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Météo-Station Météo"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Station"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Module"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Module défini par l'utilisateur"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Nom"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Couleur 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Couleur 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Couleur 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Couleur 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Couleur 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Couleur 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo indicateur CO2"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Longueur [Bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Indicateur confort"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Phase de lune"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Lignes d'information"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Flèches de Tendance"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Levé du soleil"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Afficher oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Fichier [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Afficher ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Afficher fichier texte"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Afficher fichier texte 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Afficher fichier texte 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Afficher texte HTTP"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-Internet convertisseur"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- Largeur HTTP"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- Hauteur HTTP"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Couper à partir de X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Couper à partir de Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Couper Largeur [désactiver = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Couper Hauteur [désactiver = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Afficher image"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Fichier ou Chemin [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Taille max Hauteur"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Mise-à-jour rapide"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Afficher image 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Afficher image 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Afficher image 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Afficher image 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Afficher image 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Lignes"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Compteur Mail"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- Largeur max"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Minuterie de boîte à distance"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Taille Image"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Position Image"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Alignement Image"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Disposition"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Couleur arrière plan jour actuel"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Couleur sous titre"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Liste des dates"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Evénement icône barre"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popup écran"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Afficher le texte 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Texte"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Afficher le texte 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rectangle 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Position x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Position y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Taille x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Taille y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rectangle 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Enregistrement"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Sacades TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Ecrans utilisés pour le changement"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Titre"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Infos"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Afficher couverture"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Chemin de recherche [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Trouver le fichier de couverture [ok]"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Couverture par défaut [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon d'abord"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Coupé"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Télécharger la couverture"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Type de téléchargement"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD affichage"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux - Affichage 'En'"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Réglages média >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux - Affichage 'Lecteur médias'"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Réglages veille >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux - Affichage 'Veille'"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Réglages globaux >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Choisir un répertoire"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Choisir fichier"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Choisir police"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Valeur actuelle: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5260,114 +4131,94 @@ msgstr ""
 "IGU doit être relancée pour appliquer les changements.\n"
 "Voulez-vous relancer l'IGU maintenant?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Redémarrer l'IGU maintenant?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Intérieur"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Extérieure"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Pluie"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Vent"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Nouvelle lune"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Premier quart"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Croissant de cire"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Lune croissante"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Pleine lune"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Lune décroissante"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Croissant décroissant"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Dernier Quart"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Photo non disponible"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "pas de programmation"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM ne fonctionne pas"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "pas d'appel"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d Neu  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "pas de plugiciel Netatmo installé"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "Commutateur d'écran LCD4linux"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "oui (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "flèche + texte"
-
-#~ msgid "only arrow"
-#~ msgstr "seule flèche"
-
-#~ msgid "only text"
-#~ msgstr "seule texte"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Météo Direction du vent"

--- a/LCD4linux/po/it.po
+++ b/LCD4linux/po/it.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:41+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:28+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Italian <>\n"
 "Language: it\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
@@ -72,47 +72,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Display"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Meteo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Ricevitore remoto"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Calendario"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP consentito"
 
@@ -120,8 +108,7 @@ msgstr "WebIF IP consentito"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "Nessun file selezionato o sbagliato, prova prima un file corretto!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Modalità"
 
@@ -137,7 +124,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Mostra"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Elimina"
 
@@ -169,35 +156,24 @@ msgstr "Salva configurazione"
 msgid "stop Screencycle"
 msgstr "interrompere ciclo display"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Globale"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "On"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Idle"
 
@@ -245,253 +221,299 @@ msgstr "Elenco dei dispositivi di archiviazione"
 msgid "Parent Directory"
 msgstr "Directory Superiore"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Ven"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Lun"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sat"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Dom"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Gio"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Mar"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Mer"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "nero"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "bianco"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "grigio"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "argento"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "ardesia"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "acqua marina"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "oro"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "verde giallo"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "giallo"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "arancione scuro"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "rosso scuro"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "rosso indiano"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "arancione"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "rosso arancio"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "rosso"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "pomodoro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "verde scuro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "verde"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "verde prato"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "verde chiaro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "limetta"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "blu"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "blu viola"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "blu cadetto"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "blu fiordaliso"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "blu scuro"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indaco"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "blu chiaro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "ciano"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "orchidea scuro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "rosa scuro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violetta"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "marrone"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "mocassino"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "oliva"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "marrone rosato"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "marrone sabbia"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Display 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Display 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Display 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Display 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Display 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Display 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Display 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Display 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Display 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Display 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Display 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Display 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Display 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Display 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Display 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Display 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Display 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Display 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Display 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Display 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Display 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Display 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Display 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Display 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Display 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Display 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Display 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Display 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Display 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Display 9"
 
@@ -513,1312 +535,1131 @@ msgstr "Display 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "off"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Display 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Display 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Display 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Display 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Display 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Display 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Display 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Display 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Display 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Display 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Display 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Display 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Display 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Display 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Display 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Display 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Display 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Display 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "on"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (o LCD compatibili) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (o LCD compatibile) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (o LCD compatibili) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (o LCD compatibili) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H alt 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H vecchio 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Box-Skin-LCD interno"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "TFT-LCD 400x240 interno"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "solo formato 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "solo formato 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "solo formato 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "solo formato 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "solo formato immagine personalizzato"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "solo formato immagine personalizzato 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Vu+Duo2 LCD 400x240 interno"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Corrente"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 giorni 1 linea"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 giorni 2 linee"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 giorni 1 linea"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 giorni 2 linee"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 giorni vista verticale"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 giorni 1 linea"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 giorni 2 linee"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 giorni vista verticale"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Temperatura corrente (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Temperatura corrente (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Corrente"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Temperatura corrente"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Tutti"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatura+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatura+Co2+Pressione"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatura+Umidità"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modulo 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Modulo 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Modulo 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Modulo 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Modulo 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Modulo 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Modulo 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Modulo 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Modulo 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Modulo 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modulo 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Modulo 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Modulo 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Modulo 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Modulo 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modulo 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Modulo 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Modulo 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modulo 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Modulo 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modulo 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Modulo 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Modulo 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "definito dall'utente"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Barra"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Barra+Valore"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Percepita"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Percepita+Valore"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analogico"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analogico+Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analogico+Data+Giorno feriale"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analogico+Data+Giorno feriale 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Data+Ora"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Data+Ora+Giorni feriali"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Data di progettazione dei lembi"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Design dei lembi nei giorni feriali"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Ora"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Orario+Giorni feriali"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Feriale"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "centro"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "sinistra"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "destra"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "centro"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Esteso"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Esteso (breve)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Breve"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Breve (esteso)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Breve+Esteso"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Mese"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Mese+Intestazione"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Settimana"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Settimana+Intestazione"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "no calendario"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "no data"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Appuntamenti 1 linea"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Appuntamenti 3 linee"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Appuntamenti 5 linee"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Appuntamenti 9 linee"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Appuntamenti compatto 2 linee"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Appuntamenti compatto 3 linee"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Riquadro"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "no data"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Sottolineato"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Sottolineato 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Riquadro"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Appuntamenti"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Appuntamenti compatto"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Appuntamenti compatto no icona"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Appuntamenti no icona"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "no icona"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "no icona, con numero di destinazione"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "con icona"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "con icona e numero di destinazione"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "no"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Carica@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Carica@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "visualizza esecuzione"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "visualizza esecuzione+standby"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Sempre tutto"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Sempre nuovo"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Solo nuovo"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Tutte le informazioni"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Solo distanza"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Distanza+Illuminazione"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Distanza+Fase lunare"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Solo illuminazione"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Illuminazione+Fase lunare"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Solo Fasi lunari"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Canale"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Canale+Titolo"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Canale"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Canale+Titolo"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "stesso colore"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "trasparente"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "si"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "sì + 25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "orizzontale"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "si"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "verticale"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "orizzontale"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "tutti"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Angolo"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Angolo+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "solo barra avanzamento"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "con minuti restanti"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "con minuti restanti (dimensione 1,5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "con minuti restanti (dimensione 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "con percentuale"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "con percentuale (dimensione 1,5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "con percentuale (dimensione 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "con minuti restanti (sopra)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "con minuti restanti (sopra/dimensione 1,5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "con minuti restanti (sopra/dimensioni 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "con percentuale (sopra)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "con percentuale (sopra/dimensione 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "con percentuale (sopra/dimensione 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "con minuti restanti (sotto)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "con minuti restanti (sotto/dimensione 1,5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "con minuti restanti (sotto/dimensione 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "con percentuale (sotto)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "con percentuale (sotto/dimensione 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "con percentuale (sotto/dimensione 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "con corrente 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "con corrente 00:00 (dimensione 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "con corrente 00:00 (dimensione 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "con corrente 00:00 (sopra)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "con corrente 00:00 (sopra/dimensione 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "con corrente 00:00 (sopra/dimensione 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "con corrente 00:00 (sotto)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "con corrente 00:00 (sotto/dimensione 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "con corrente 00:00 (sotto/taglia 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "con percentuale minuti / totale (sopra)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "con percentuale minuti / totale (sopra/dimensione 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "con percentuale minuti / totale (sopra/dimensione 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "con assoluto orario fine"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "con assoluto orario fine (Size 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "con assoluto orario fine (Size 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "con minuti totale / orario fine (sopra)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "con minuti totale /orario fine (sopra/dimensione 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "con minuti totale / orario fine (sopra/taglia 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Fastmode (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normale (5s)"
 
@@ -1826,3437 +1667,2467 @@ msgstr "Normale (5s)"
 msgid "last Screen"
 msgstr "ultimo schermo"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alfabetico"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "casuale"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "migliore/lento"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "basso/veloce (solo immagine)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "basso/veloce (tutti)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + regolazione (alta qualità, lento)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + regolazione (bassa qualità, veloce)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "no cache + no regolazioni"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Spina sintonizzatore"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "Sintonizzatore USB"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Ora/Successivo"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normale"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "ridotto"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript nessun aggiornamento"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Ricarica"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normale"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - affiancati"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "copia modalità alternativa/DM800hd (24 bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "sì + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "sì, lungo"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "sì, breve"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Ricerca cover"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "sempre"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "sempre"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Media+Standby"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Standby"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "Colore - 32bit"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - scala di grigi/colori"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Tasto Info"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Muto"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Tasto lungo info"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x Tasto avanzamento veloce"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x Tasto avanzamento veloce tipo 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Tasto lungo avanti veloce"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Tasto lungo avanti veloce tipo 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Tasto Info"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Muto"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Tasto lungo info"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x Tasto indietro veloce"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x Tasto indietro veloce tipo 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Tasto lungo indietro veloce"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Tasto lungo indietro veloce tipo 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "sì, esteso"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Console normale"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "File di registro esteso"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "File di registro normale"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "disabilitato"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (completo)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normale (completo)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "profilati (nero)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "profilati (trasparenti)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "MUTE o tasti definiti"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "qualsiasi tasto"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Orario+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Orario+Durata+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini - EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Orario+Durata+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "metà sinistra"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "metà destra"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Riquadro x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Linea"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "no barra"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "no riquadro"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normale"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradiente"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Bordi ombrati"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Nome"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normale"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Posizione sotto"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Posizione sinistra"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Posizione destra"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Posizione"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Nome"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Offline"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Online"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Online+Offline"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "utilizzare solo Timer"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "utilizzare lasso di tempo"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "no Timer totale"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "visualizza timer totale"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "una riga"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "due linee"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Memoria disponibile"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Memoria libera"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "display intero"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "sì tranne registrazioni"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ENE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "ESE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "O"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "ONO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "OSO"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Carica file di configurazione attivo"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Carica predefiniti/Configurazione vuota"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Salva configurazione nel file... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Carica il file: %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Eliminare il file?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "eliminato"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "impostato attualmente: %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Selezionare"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux impostazioni"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Salva"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Riavvia LCD"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Imposta On >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "no LCD1 Tema-File"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "no LCD2 Tema-File"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "no LCD3 Tema-File"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux abilitato"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 tipo"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 ruotare"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 colore sfondo"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 tema sfondo [OK] >"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 luminosità"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 riduzione notturna"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 aggiornamento"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 tipo"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 ruotare"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 colore sfondo"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 tema sfondo [OK] >"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 luminosità"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 riduzione notturna"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 aggiornamento"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 tipo"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 ruotare"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 colore sfondo"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 tema sfondo [OK] >"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 luminosità"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 riduzione notturna"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 aggiornamento"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD dimensioni"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD colore"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD abilita modalità On"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD abilita modalità Media"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD abilita modalità Idle"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [mostra orario]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- quale LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Mostra in modalità"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Dimensioni OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Trasparenza sfondo"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Grab veloce qualità inferiore"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Testo popup"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Tasto Cancella"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Dimensioni testo"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Posizione"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Allineamento"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Colore"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Colore sfondo"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Carattere"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Display attivo"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Display selettore - Display"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Schermo Predefinito dopo il cambio di modalità - Schermo"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Display selettore - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Display utilizzati per cambiare"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Display 1 cambio tempo"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Schermata 2 modifica ora"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Schermata 3 modifica ora"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Schermata 4 modifica ora"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Schermata 5 modifica ora"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Schermata 6 modifica ora"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Schermata 7 modifica ora"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Schermata 8 modifica ora"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Schermata 9 modifica ora"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Tempo cambio immagini"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Ordina immagini"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Directory immagini ricorsiva"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Qualità immagine per il ridimensionamento"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Aggiornamento immagine Quick Time [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Tipo di immagine [solo immagine]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Formato immagine sfondo"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Meteo API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Meteo API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Meteo API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Meteo città"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Meteo città 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Meteo - Percorso icona [OK] >"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Meteo - Zoom icona"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Meteo bassa temperatura colore"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Meteo alta temperatura colore"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Meteo trasparenza"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Meteo unità di velocità vento"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Meteo linee informative sul vento"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Possibilità di pioggia"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Zoom pioggia"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Colore pioggia"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Pioggia utilizza colore 2 da"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Colore pioggia 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Tempo Umidità Colore"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Meteo linee"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Meteo frecce di tendenza"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Meteo informazioni extra"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra Zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Mostra differenza temperatura percepita"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra color City"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra colore Chill"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Stazione meteo CO2 campo min"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Stazione meteo CO2 campo max"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteo URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Luna-Percorso-Icona [OK] >"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Registrazione immagine [OK] >"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Interruttori a doppio pulsante"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Tasto per cambiare schermo"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Tasto per schermo On/Off"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall percorso immagini [OK] >"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall numero di linee per voce"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall numero di voci di elenco"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall numero di immagini"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall orientamento immagini"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall trasparenza immagini"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall cerca immagini"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall elimina chiamate dopo ore"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall popup-ora"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall LCD popup"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall colore popup"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall riquadro [OK] >"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Calendario percorso ics [OK] >"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Calendario URL ics"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Calendario planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Calendario colore Sabato"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Calendario colore Domenica"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Spessore linea calendario"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Anteprima calendario giorno evento"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Correzione calendario fuso orario"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Trasparenza calendario"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Intervallo di polling del calendario"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Colore sintonizzatore"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Colore attivo sintonizzatore"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Colore sintonizzatore On"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Ricerca prima servizio"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Segnale - correzione qualità"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Carattere globale [OK] >"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Carattere 1 [OK] >"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Carattere 2 [OK] >"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Carattere 3 [OK] >"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Carattere 4 [OK] >"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Carattere 5 [OK] >"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 connessione"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 Server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Displayname:] Nome utente"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 password"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 connessione"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 Server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Displayname:] Nome utente"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 password"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 connessione"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Displayname:] Nome utente"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 password"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 connessione"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 Server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Displayname:] Nome utente"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 password"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 connessione"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 Server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Displayname:] Nome utente"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 password"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Mail intervallo sondaggio"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP limite per ultimi giorni"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail mostra mailbox vuote"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Mail mostra data"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail nascondere mailadress"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Ricevitore remoto 1 [Displayname:] IP/Nome"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Ricevitore remoto 2 [Displayname:] IP/Nome"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Ricevitore remoto 3 [Displayname:] IP/Nome"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Ricevitore remoto 4 [Displayname:] IP/Nome"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Ricevitore remoto 5 [Displayname:] IP/Nome"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Sondaggio ricevitore remoto ogni minuti"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Timer ricevitore remoto [Displayname:] IP/Nome"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Timer sondaggio ricevitore remoto ogni minuti"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "Intervallo sondaggio convertitore WWW"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "Utilizzo convertitore WWW"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey da cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey da convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF aggiornamento [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF tipo aggiornamento"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF ritardo inizio"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP negato"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Design"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Salva come immagine per WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 abilita"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 porta"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 luminosità virtuale"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 abilita"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 porta"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 luminosità virtuale"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 abilitato"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 porta"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 luminosità virtuale"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG cicli"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG riavvia in caso di errore"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG modalità intestazione"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Mostra Stream '4097; 5001...5003' in modalità"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Timeout [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos test riproduzione"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos aggiornamento [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "Timeout ping BlueSound [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound test riproduzione"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound aggiornamento [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast IP del Server [opzionale]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast ping timeout [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast test riproduzione"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast aggiornamento [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast cover"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD larghezza personalizzata"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD altezza personalizzata"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD larghezza personalizzata 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD altezza personalizzata 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD off quando spegni"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing ! Calcola tutti in Time/5*2 in Fastmode"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Ritardo di visualizzazione [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Righe per LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Mostra angolo crash"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Mostra 'nessun ....' messaggio"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Dispositivi di archiviazione: Forza lettura"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Dispositivi di archiviazione: Colore sfondo"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Dispositivi di archiviazione: Colore barra"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Dispositivi di archiviazione: Colore pieno"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Test della rete attivato"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Cambia FrameBuffer [se possibile]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Configurazione percorso Backup [OK] >"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Ripristina tutte le impostazioni"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debug-Logging > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Retroilluminazione Off [Off -> On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Retroilluminazione ON"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Retroilluminazione week end OFF"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Retroilluminazione week end ON"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Auto-OFF"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Sfondo"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Immagine [OK] >"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Dimensioni picon"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Display sdoppiato"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Display intero"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Dimensioni testo"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Trasparenza"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Percorso picon [OK] >"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Percorso picon 2 [OK] >"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Percorso cache picon [OK] >"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Orologio"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
-msgstr "- Tipo"
+msgstr "-  Tipo"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Orologio analogico"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Spaziatura"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Dimensioni"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Bordi ombrati"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Orologio 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Nome del programma"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- massimo righe"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Lunghezza"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Numero del programma"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Informazioni programma"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Tipo"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Informazioni programma 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Successiva info programma"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Descrizione estesa"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- utilizzare info quando vuoto"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Barra di avanzamento"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Testo a colori"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Sfondo a colori"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Bordi"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Ombreggiato"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Unità min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informazioni"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Informazioni sintonizzatore"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensori"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informazioni 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Barra qualità segnale"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradiente"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Barra campo Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Barra campo Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satellite"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Provider"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Sintonizzatore usato"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- solo sintonizzatore attivo"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Prossimo evento timer"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volume"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Muto"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Mostra stato"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Timeout [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Nome in linea:Indirizzo"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Indirizzo IP esterno"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- external IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Dispositivi di archiviazione"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- senza avviso"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- informazioni extra"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Nome dispositivo"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Tipo meteo"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Meteo 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo - Stazione meteo"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Stazione"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Modulo"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Modulo definito dall'utente"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Nome"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Colore 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Colore 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Colore 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Colore 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Colore 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Colore 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Stazione meteo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Stazione meteo indicatore CO2"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Lunghezza [Barra]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Stazione meteo indicatore comfort"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Fase lunare"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Linee informative"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Frecce di tendenza"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Alba"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Mostra oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- File [OK] >"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Mostra ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Mostra file di testo"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Mostra file di testo 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Mostra file di testo 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Mostra testo HTTP"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "Convertitore WWW-Internet"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- Larghezza HTTP"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- Altezza HTTP"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Taglio da X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Taglio da Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Larghezza di taglio [disattivare = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Altezza di taglio [disattivare = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Mostra immagine"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- File o percorso [OK] >"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Dimensioni max altezza"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Aggiornamento rapido"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Mostra immagine 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Mostra immagine 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Mostra immagine 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Mostra immagine 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Mostra immagine 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Linee"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Conto E-Mail"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- larghezza max"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Timer ricevitore remoto"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Dimensione immagine"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Posizione immagine"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Allineamento immagine"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Layout"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Colore sfondo giorno attuale"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Colore didascalia"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Lista appuntamenti"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Icona barra evento"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Display popup"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- LCD popup"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Mostra testo 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Testo"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Mostra testo 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rettangolo 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Posizione x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Posizione y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Dimensioni x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Dimensioni y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rettangolo 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Registrazione"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Schermi utilizzati per la modifica"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Titolo"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informazioni"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Mostra cover"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Ricerca percorso [OK] >"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Trova file di copertina [ok]"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Copertina predefinita [OK] >"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Prima picon"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Rifilata"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Scarica la copertina"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Tipo di download"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "Display LCD"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux modalità display On"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Imposta Media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux lettore multimediale in modalità display"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Imposta Idle >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux in modalità di visualizzazione Idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Imposta globale >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Scegli cartella"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Scegli file"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Scegli carattere"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - valore corrente: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5264,114 +4135,94 @@ msgstr ""
 "La GUI necessita di un riavvio per applicare le modifiche.\n"
 "Vuoi riavviare la GUI ora?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Riavviare la GUI?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Interno"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Esterni"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Pioggia"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Vento"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Luna nuova"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Primo quarto"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Mezzaluna crescente"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Luna crescente"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Luna piena"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Luna calante"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Pericolo crescente"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Ultimo quarto"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Immagine non disponibile"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "no Timer"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM non in esecuzione"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "no chiamate"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mails  %d Nuovo  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "no installato Netatmo-Plugin"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux interruttore schermo"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "sì (32 bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "freccia + testo"
-
-#~ msgid "only arrow"
-#~ msgstr "solo freccia"
-
-#~ msgid "only text"
-#~ msgstr "solo testo"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Meteo Direzione del vento"

--- a/LCD4linux/po/lt.po
+++ b/LCD4linux/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: Vytenis P. vyteniui@gmail.com\n"
@@ -12,7 +12,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -66,47 +67,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Ekranas"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Orai"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Paštas"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Nuotolinis aparatas"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalendorius"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF leidžiami IP"
 
@@ -114,8 +103,7 @@ msgstr "WebIF leidžiami IP"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "Failas nepasirinktas, arba neteisingas, bandykite pasirinkti teisingą!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Režimas"
 
@@ -131,7 +119,7 @@ msgstr "Lūžio žurnalas"
 msgid "Show"
 msgstr "Rodyti"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Pašalinti"
 
@@ -163,35 +151,24 @@ msgstr "Išsaugoti nustatymus"
 msgid "stop Screencycle"
 msgstr "stabdyti ekranų kaitą"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Visuotinis"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Įjungta"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Multimedija"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Neveikla"
 
@@ -239,253 +216,299 @@ msgstr "Saugojimo įrenginių sąrašas"
 msgid "Parent Directory"
 msgstr "Tėvų katalogas"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Pen"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Pir"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Šeš"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Sek"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Ket"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Ant"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Tre"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "juoda"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "balta"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "pilka"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "sidabrinė"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "melsvai pilka"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "akvamarinas"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "auksinė"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "žaliai geltona"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "geltona"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "tamsiai oranžinė"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "tamsiai raudona"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "rusvai raudona"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "oranžinė"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "raudonai oranžinė"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "raudona"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomato"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "tamsiai žalia"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "žalia"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "žolės žalia"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "šviesiai žalia"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "laimo žalia"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "mėlyna"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "mėlynai violetinė"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "kariška žydra"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "rugiagėlių mėlyna"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "tamsiai mėlyna"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "šviesiai mėlyna"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cianas"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "tamsi orchidėjų"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "sodriai rožinė"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "purpurinė"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violetinė"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "ruda"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "smėlio"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "alyvų žalia"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "rausvai ruda"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "smėlio ruda"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Ekranas 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Ekranai 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Ekranai 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Ekranai 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Ekranai 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Ekranai 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Ekranai 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Ekranai 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Ekranai 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Ekranai 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Ekranai 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Ekranai 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Ekranai 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Ekranai 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Ekranai 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Ekranai 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Ekranai 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Ekranai 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Ekranai 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Ekranai 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Ekranai 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Ekranas 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Ekranas 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Ekranas 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Ekranas 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Ekranas 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Ekranas 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Ekranas 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Ekranas 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Ekranas 9"
 
@@ -507,1312 +530,1131 @@ msgstr "Ekranas 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "išjungta"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Ekranai 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Ekranai 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Ekranai 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Ekranai 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Ekranai 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Ekranai 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Ekranai 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Ekranai 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Ekranai 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Ekranai 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Ekranai 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Ekranai 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Ekranai 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Ekranai 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Ekranai 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Ekranai 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Ekranai 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Ekranai 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "įjungta"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2val"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3val"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40sek"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50sek"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5val"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5sek"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10sek"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15sek"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20sek"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30sek"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2val"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3val"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40sek"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50sek"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5val"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5sek"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (arba suderinamas LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (arba suderinamas LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (arba suderinamas LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (arba suderinamas LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Vidinis aparato LCD ekranas"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Vidinis TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "tik vaizdas 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "tik vaizdas 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "tik vaizdas 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "tik vaizdas 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "tik pasirinkto dydžio vaizdas"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "tik savo dydžio paveikslėlis 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Vidinis Vu+ Duo2 400x240 LCD"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Dabartinis"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 dienos  1 eilute"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 dienos  2 eilutėmis"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 dienos  1 eilute"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 dienos  2 eilutėmis"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 dienos vertikaliai"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 dienos  1 eilute"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 dienos  2 eilutėmis"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 dienos vertikaliai"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Temperatūra dabar (+°C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Temperatūra dabar (-°C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Dabartinis"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Temperatūra dabar"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Visi"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatūra"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatūra+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatūra+Co2+slėgis"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatūra+drėgnumas"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modulis 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Moduliai 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Moduliai 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Moduliai 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Moduliai 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Moduliai 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Moduliai 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Moduliai 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Moduliai 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Moduliai 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modulis 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Moduliai 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Moduliai 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Moduliai 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Moduliai 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modulis 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Moduliai 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Moduliai 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modulis 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Moduliai 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modulis 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Moduliai 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Modulis 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "pasirinktas"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Juosta"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Juosta + reikšmė"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Mygtukas"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Mygtukas+skaitmuo"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analoginis"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analoginis+data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analoginis +data+savaitės diena"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analoginis+data+savaitės diena 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Data+laikas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Data+laikas+savaitės diena"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Datos dizainas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Savaitės dienos dizainas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Laikas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Laikas+savaitės diena"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Savaitės diena"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "centras"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "kairė"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "dešinė"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "centras"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Išplėstinis"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Išplėstinis (trumpas)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Trumpas"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Trumpas (išplėstinis)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Trumpas+išplėstinis"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Mėnuo"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Mėnuo+antraštė"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Savaitė"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Savaitė+antraštė"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "be kalendoriaus"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "be datų"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Datos 1 eilutė"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Datos 3 eilutės"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Datos 5 eilutės"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Datos 9 eilutės"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Datos glaustai 2 eilutės"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Datos glaustai 3 eilutės"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Rėmelis"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "be datų"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Pabraukti"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Pabraukti 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Rėmelis"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Datos"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Datos glaustai"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Datos glaustai be piktogramų"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Datos be piktogramų"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "be piktogramos"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "be piktogramos, su užduoties numeriu"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "su piktograma"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "su piktograma ir užduoties numeriu"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "°C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "°C + apsukos"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "°C + apsukos 2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "aps/min"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "aps./min. 2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "ne"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "°C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "°C + apsukos"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "°C + apsukos 2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "aps/min"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "aps./min. 2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Apkrova@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Apkrova@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "rodyti paleistį"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "rodyti paleistį+budėjimą"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Visada visi"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Visada nauji"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Tik naujus"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Visa Informacija"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Tik Atstumas"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Atstumas+Apšvietimas"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Atstumas+Mėnulio fazė"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Tik Apšvietimas"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Apšvietimas+Mėnulio fazė"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Tik Mėnulio fazė"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Piktograma"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanalas"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanalas+pavadinimas"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Piktograma+kanalas"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Piktograma+kanalas+pavadinimas"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Piktograma"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "tos pačios spalvos"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "skaidrus"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "taip"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "taip +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontaliai"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "taip"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "vertikaliai"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontaliai"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "visi"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Kampas"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Kampas+laiko poslinkis"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Piktograma+laiko poslinkis"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "tik eigos juosta"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "su likusiom minutėm"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "su likusiom minutėm (dydis 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "su likusiom minutėm (dydis 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "su procentais"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "su procentais (dydis 1,5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "su procentais (dydis 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "su likusiom minutėm (virš)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "su likusiom minutėm (virš/dydis 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "su likusiom minutėm (virš/dydis 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "su procentais (virš)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "su procentais (virš/dydis 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "su procentais (virš/dydis 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "su likusiom minutėm (žemiau)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "su likusiom minutėm (žemiau/dydis 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "su likusiom minutėm (žemiau/dydis 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "su procentais (žemiau)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "su procentais (žemiau/dydis 1,5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "su procentais (žemiau/dydis 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "su dabartiniu 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "su dabartiniu 00:00 (dydis 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "su dabartiniu 00:00 (dydis 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "su dabartiniu 00:00 (virš)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "su dabartiniu 00:00 (virš/dydis 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "su dabartiniu 00:00 (virš/dydis 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "su dabartiniu 00:00 (žemiau)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "su dabartiniu 00:00 (žemiau/dydis 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "su dabartiniu 00:00 (žemiau/dydis 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "su procentais minutės/Iš viso (virš)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "su procentais minutės/Iš viso (virš/dydis 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "su procentais minutės/Iš viso (virš/dydis 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "su absoliučiu pabaigos laiku"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "su absoliučiu pabaigos laiku (dydis 1,5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "su absoliučiu pabaigos laiku (dydis 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "su minutėmis Iš viso/pab.laikas (virš)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "su minutėmis Iš viso/pab.laikas (virš/dydis 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "su minutėmis Iš viso/pab.laikas (virš/dydis2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Greitasis režimas (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normalus (5s)"
 
@@ -1820,3437 +1662,2467 @@ msgstr "Normalus (5s)"
 msgid "last Screen"
 msgstr "paskutinis ekranas"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "pagal abėcėlę"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "atsitiktinis"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "geriau / lėčiau"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "mažas/greitas (tik vaizdams)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "mažas/greitas (viskam)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "podėlis+nustatymas (aukšta kokybė, lėtai)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "podėlis+nustatymas (žema kokybė, greitai)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "be podėlio + be nustatymų"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Prijungtas imtuvas"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB imtuvas"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Dabar/sekantis"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "įprastas"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "sumažintas"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Java skriptas"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Java scenarijus neatnaujinant"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Įkelti iš naujo"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normalus"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - sugretinimas"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternatyvus kopijavimo režimas/DM800HD (24bitų)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "taip + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "taip, ilgos"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "taip, trumpos"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/val"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Viršelių paieška"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "visada"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "visada"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "Įjungta+multimedija+budėjimas"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Budėjimo režimas"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bitų spalvos"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bitų juodai-balta/spalvota"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x 'Info' mygtukas"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x 'Mute' mygtukas"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Ilgas 'Info' paspaudimas"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x '>>' mygtukas"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x '>>' mygtukas, 2 tipas"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Ilgas '>>' paspaudimas"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Ilgas '>>' paspaudimas 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x 'Info' mygtukas"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x 'Mute' mygtukas"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Ilgas 'Info' paspaudimas"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x '<<' mygtukas"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x '<<' mygtukas, 2 tipas"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Ilgas '<<' paspaudimas"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Ilgas '<<' paspaudimas 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "taip, išplėstas"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Konsolė"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Išsamus žurnalas"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Normalus žurnalas"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "išjungta"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radijas"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radijas+multimedija"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+radijas"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+radijas+multimedija"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (visas)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "įprastas (visas)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "apkirpta (juodas)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "apkirpta (skaidrus)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "'MUTE', arba priskirti mygtukai"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "bet kuris mygtukas"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Informacija"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Laikas+informacija"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Laikas+trukmė+informacija"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "MiniEPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Laikas+ilgis+informacija"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "pusiau kairėn"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "pusiau dešinėn"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Rėmelis x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Eilutė"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "be juostos"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "be rėmelio"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normalus"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradientas"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Tamsinti kraštus"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Pavadinimas"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normalus"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Piktograma+pozicija žemiau"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Piktograma+pozicija kairėje"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Piktograma+pozicija dešinėje"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Padėtis"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Pavadinimas"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Atsijungus"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Prisijungus"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Prisijungus+atsijungus"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "naudoti tik laikmatį"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "naudoti įvado laiką"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "be galutinio laikmačio"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "rodyti galutinį laikmatį"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "viena eilutė"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "dvi eilutės"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Prieinama atmintis"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Laisva atmintis"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "visas ekranas"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+Ekrano meniu"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "taip, išskyrus įrašus"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "R"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "RŠR"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "RPR"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "Š"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "ŠR"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "ŠŠR"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "ŠŠV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "ŠV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "P"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "PR"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "PPR"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "PPV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "PV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "V"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "VŠV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "VPV"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%Y-%b-%d"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Įkelti aktyvų konfigūracijos failą"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Atkurti numatytas reikšmes / Valyti konfigūraciją"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Išsaugoti nustatymus į failą... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Įkelti failą : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Pašalinti failą?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "pašalinta"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "dabar nustatyta: %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Pasirinkite"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux nustatymai"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Meniu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Išsaugoti"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Paleisti iš naujo"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Įjungtas >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "nėra LCD 1 vaizdo failo"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "nėra LCD 2 vaizdo failo"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "nėra LCD 3 vaizdo failo"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "ĮJUNGTI  LCD4linux"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 tipas"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 pasukti"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 fono spalva"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 fono paveikslėlis [Ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 šviesumas"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 pritemdymas nakčiai"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 atnaujinti"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 tipas"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 pasukti"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 fono spalva"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 fono paveikslėlis [Ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 šviesumas"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 pritemdymas nakčiai"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 atnaujinti"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 tipas"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 pasukti"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 fono spalva"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 fono paveikslėlis [Ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 šviesumas"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 pritemdymas nakčiai"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 atnaujinti"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Aparato LCD matmenys"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Aparato LCD poslinkis"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Aparato LCD spalva"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Įjungtame režime aparato LCD įjungtas"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Multimedijos režime aparato LCD įjungtas"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Neveiklos režime aparato LCD įjungtas"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "Ekrano meniu [kiek laiko rodyti]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- Kuriame LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Rodyti režimuose"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Ekrano meniu dydis"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Fonas / skaidrumas"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Greitesnis, žemesnės kokybės"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Iškylantis tekstas"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Išvalyti"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Šrifto dydis"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Vertikali pozicija"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Horizontalus lygiavimas"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Spalva"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Fono spalva"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Šriftas"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Aktyvus ekranas"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Ekranų perjungimas - Ekranas"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Numatytoji ekrano reikšmė pakeitus režimą - Ekranas"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Ekranų perjungimas - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Ekranai, naudojami keitimui"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "1 ekrano rodymo laikas"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- 2 ekrano rodymo laikas"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- 3 ekrano rodymo laikas"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- 4 ekrano rodymo laikas"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- 5 ekrano rodymo laikas"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- 6 ekrano rodymo laikas"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- 7 ekrano rodymo laikas"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- 8 ekrano rodymo laikas"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- 9 ekrano rodymo laikas"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Vaizdų keitimosi laikas"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Vaizdų rūšiavimas"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Vaizdų rekursinis katalogas"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Vaizdų kokybė mažinant"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Vaizdų atnaujinimo intervalas [sek.]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Vaizdo failų tipas [tik vaizdai]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Fono paveikslėlio tipas"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Orų API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Orų API raktas OpenWeatherMap puslapyje"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Miestas, kurio orus rodyti"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "2 miestas, kurio orus rodyti"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Kelias į orų piktogramas [Ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Orų piktogramos dydis"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Neigiamos temperatūros spalva"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Teigiamos temperatūros spalva"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Orų lango skaidrumas"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Vėjo greičio matavimo vienetai"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Oras Vėjas Informacijos linijos"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Lietaus tikimybė"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Lietaus piešinio dydis"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Lietaus spalva"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Lietaus naudojama spalva 2 iš"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Lietaus spalva 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Orai Drėgmė Spalva"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Orų linijos"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Orų tendencijų rodyklės"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Papildoma orų informacija"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Papildomos informacijos dydis"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Rodyti temperatūrų skirtumą"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Papildoma spalva miestui"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Papildoma spalva šalčiui"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 min. lygis"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 maks. lygis"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteotarnybos internetinis adresas"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Kelias į mėnulio piktogramą [Ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Užfiksuotą vaizdą išsaugoti į [Ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Dvigubo paspaudimo perjungimai"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Ekranų kaitos mygtukas"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Ekrano įjungimo/išjungimo mygtukas"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall paveikslėlių kelias [Ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall įrašo eilučių skaičius"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall sąrašo įrašų skaičius"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall paveikslėlių skaičius"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall paveikslėlių kryptis"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall paveikslėlių skaidrumas"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall paveikslėlių  paieška"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall pašalinti kvietimus po (val.)"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall iškylančio lango rodymo laikas"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall iškylantį langą rodyti"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall iškylančio lango spalva"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall lango paveikslėlis [Ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kelias į kalendoriaus piktogramas [Ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalendoriaus piktogramų internetinis adresas"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalendoriaus-planuotojo FS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Šeštadienio spalva kalendoriuje"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Sekmadienio spalva kalendoriuje"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalendoriaus  eilutės storis"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Renginių peržiūra-kalendorinių dienų"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalendoriaus korekcija pagal laiko juostą"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Kalendoriaus skaidrumas"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Kalendoriaus užklausos intervalas"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Imtuvo raidės spalva"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Aktyvaus imtuvo raidės spalva"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Veikiančio imtuvo raidės spalva"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Kanalų paieška"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T signalo kokybės korekcija"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Visuotinis šriftas [Ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Šriftas 1 [Ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Šriftas 2 [Ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Šriftas 3 [Ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Šriftas 4 [Ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Šriftas 5 [Ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Paštas 1 - prisijungti"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Paštas 1 - serveris"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Paštas 1 [vardas:] vartotojas"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Paštas 1 - slaptažodis"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Paštas 2 - prisijungti"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Paštas 2 - serveris"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Paštas 2 [vardas:] vartotojas"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Paštas 2 - slaptažodis"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Paštas 3 - prisijungti"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Paštas 3 - serveris"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Paštas 3 [vardas:] vartotojas"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Paštas 3 - slaptažodis"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Paštas 4 - prisijungti"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Paštas 4 - serveris"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Paštas 4 [vardas:] vartotojas"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Paštas 4 - slaptažodis"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Paštas 5 - prisijungti"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Paštas 5 - serveris"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Paštas 5 [vardas:] vartotojas"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Paštas 5 - slaptažodis"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Pašto tikrinimo intervalas"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "IMAP pašto rodymo apribojimas (X paskutinių dienų)"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Paštas - rodyti ir tuščias dėžutes"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Paštas - rodyti datą"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Paštas - slėpti el. pašto adresą"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Nuotolinis aparatas 1 [vardas:]IP/vartotojas"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Nuotolinis aparatas 2 [vardas:]IP/vartotojas"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Nuotolinis aparatas 3 [vardas:]IP/vartotojas"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Nuotolinis aparatas 4 [vardas:]IP/vartotojas"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Nuotolinis aparatas 5 [vardas:]IP/vartotojas"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Nuotolinio aparato užklausa kas [min.]"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Nuotolinio aparato laikmatis [vardas:]IP/vartotojas"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Nuotolinio aparato laikmačio užklausa kas [min.]"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW keitiklio užklausų intervalas"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW keitiklio naudojimas"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW API raktas iš cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW API raktas iš convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF atnaujinti kas [sek.]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF atnaujinimo būdas"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF inicijavimo delsa"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF uždrausti IP"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF išvaizda"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Išsaugoti, kaip WebIF paveikslėlį"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG srautas į LCD 1 įjungtas"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG srauto į LCD 1 prievadas"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG srauto į LCD 1 virtualus šviesumas"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG srautas į LCD 2 įjungtas"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG srauto į LCD 2 prievadas"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG srauto į LCD 2 virtualus šviesumas"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG srautas į LCD 3 įjungtas"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG srauto į LCD 3 prievadas"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG srauto į LCD 3 virtualus šviesumas"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG ciklai"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG paleistas iš naujo po klaidos"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG antraštės dydis"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Rodyti srautus '4097; 5001...5003' režimu"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP adresas"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos ping intervalas [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos veiklos tikrinimas"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos atnaujinimo intervalas [sek.]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound ping intervalas [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound veiklos tikrinimas"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound atnaujinimo intervalas [sek.]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast serverio IP [pasirinktinai]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast 'ping' atsakas [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast tikrinimas"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast atnaujinimas [sek.]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast viršelis"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD pasirinktinis plotis"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD pasirinktinis aukštis"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD pasirinktinis plotis 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD pasirinktinis aukštis 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "Išjungti LCD, išjungus aparatą"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Greitąjame režime laiką skaičiuoti pagal 'laiką/5*2'"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Delsa [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Gijų viename LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Rodyti gedimo kampelį"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Rodyti 'ne ....' pranešimus"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Priverstinai skaityti prijungtas laikmenas"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Laikmenos - fono spalva"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Laikmenos - juosta (spalva)"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Laikmenos - užpildyta (spalva)"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Tikrinti prisijungimą prie tinklo"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Kadrų įkėlimas į podėlį [jei įmanoma]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Nustatymų atsarginės kopijos kelias [Ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Atkurti visus nustatymus"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Klaidų žurnalas > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Pašvietimo išjungimas [Off = įjungta]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Pašvietimo įjungimas"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Pašvietimo išjungimas savaitgaliais [Off = įjungta]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Pašvietimo įjungimas savaitgaliais"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD automatinis išjungimas"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Fonas"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Kelias iki paveikslėlio [Ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Piktogramos dydis"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Ekrano perskyrimas"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Pilnas ekranas"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Teksto dydis"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Skaidrumas"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Kelias į piktogramas [Ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Kelias į piktogramas 2 [Ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Piktogramų podėlio kelias [Ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Piktograma 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Laikrodis"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Tipas"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analoginis laikrodis"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Tarpai"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Dydis"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Tamsinti kraštus"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Laikrodis 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Programos pavadinimas"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- Daugiausiai eilučių"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Ilgis"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Programos numeris"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Programos informacija"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Tipas"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Programos informacija 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Sekančios programos informacija"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Išsamus aprašymas"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- Nesant aprašymo, rodyti informaciją"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Eigos juosta"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Spalvotas tekstas"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Spalvotas fonas"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Kraštinė"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Užtamsinta"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Vienetai - min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Sistemos informacija"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Informacija apie imtuvą"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Jutikliai"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Sistemos informacija 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Signalo kokybės juosta"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradientas"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Min. diapazonas"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Maks. diapazonas"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Palydovas"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Tiekėjas"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Naudojamas imtuvas"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- Tik aktyvus imtuvas"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Sekančio įvykio laikmatis"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Garsas"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Nutildyti"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Garsas / Vaizdas"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitų dažnis"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Prisijungimas [ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Rodyti būklę"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Intervalas [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Tinklo vardas: adresas"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Išorinis IP adresas"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- išorinis IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Laikmenos"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- Perspėjimas, likus laisvos vietos"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- Papildoma informacija"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Įrenginio pavadinimas"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Padidinti"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Orų tipas"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Orai 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteorologinė stotis"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Stotis"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Modulis"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Vartotojo pasirinktas modulis"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Bazinė"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Pavadinimas"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Spalva 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Spalva 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Spalva 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Spalva 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Spalva 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Spalva 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 kiekio rodiklis"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Ilgis [juosta]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo komforto rodiklis"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Mėnulio fazė"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Informacijos eilutės"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Tendencijų rodyklės"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Saulėtekis"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Rodyti Oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Kelias į failą [Ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Rodyti ECM informaciją"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Rodyti tekstinį failą"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Rodyti tekstinį failą 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Rodyti tekstinį failą 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Rodyti HTTP tekstą"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- Internetinis adresas"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-internetinis keitiklis"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP plotis"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP aukštis"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Kirpti nuo X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Kirpti nuo Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Pločio apkirpimas [išjungti = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Aukščio apkirpimas [išjungti = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Rodyti vaizdą"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Kelias iki failo [Ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Dydis maks. aukštis"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Greitas atnaujinimas"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Rodyti vaizdą 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Rodyti vaizdą 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Rodyti vaizdą 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Rodyti vaizdą 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Rodyti vaizdą 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Eilutės"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Pašto paskyra"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- Maksimalus plotis"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Nuotolinio aparato laikmatis"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Paveikslo dydis"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Paveikslo pozicija"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Paveikslo lygiavimas"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Išdėstymas"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Šios dienos fono spalva"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Antraštės spalva"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Datų sąrašas"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Įvykio piktogramų juosta"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Iškylantis vaizdas"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Iškylantis LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Rodyti tekstą 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Tekstas"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Rodyti tekstą 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Stačiakampis 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Pozicija X"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Pozicija Y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Dydis X"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Dydis Y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Stačiakampis 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Įrašymas"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Ekranai, naudojami keitimui"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Antraštė"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informacijos"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Rodyti viršelį"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Paieškos kelias [Ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Raskite viršelio failą"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Numatytasis viršelis [Ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Pirmiausiai piktograma"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Apipjaustytas"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Parsisiųsti viršelius"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Parsisiuntimo būdas"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API raktas console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD ekranas"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Ekranas-'Įjungta' režimas"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Multimedija >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Ekranas-Mediagrotuvo režimas"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Neveikla >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Ekranas-Neveiklos režimas"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "VISUOTINIS >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Pasirinkite katalogą"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Pasirinkite failą"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Pasirinkite šriftą"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - dabartinė reikšmė: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5258,114 +4130,94 @@ msgstr ""
 "Kad pakeitimai įsigaliotų, grafinę aplinką reikia paleisti iš naujo.\n"
 "Ar norite paleisti iš naujo dabar?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Paleisti grafinę aplinką iš naujo dabar?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Viduje"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Lauke"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Lietus"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Vėjas"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Jaunatis"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Pirmasis ketvirtis"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Vaškuojantis pusmėnulis"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Augantis mėnulis"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Pilnatis"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Mažėjantis mėnulis"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Mažėjantis pusmėnulis"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Paskutinis ketvirtis"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%Y.%m.%d"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Paveikslėlis neprieinamas"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "be laikmačio"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM neveikia"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "be skambučių"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d laiškų %d naujų %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "neįdiegtas Netatmo-Plugin"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Ekranų perjungimas"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "taip (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "rodyklė + tekstas"
-
-#~ msgid "only arrow"
-#~ msgstr "tik rodyklė"
-
-#~ msgid "only text"
-#~ msgstr "tik tekstas"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Orai Vėjo kryptis"

--- a/LCD4linux/po/nl.po
+++ b/LCD4linux/po/nl.po
@@ -2,16 +2,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:55+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:35+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 "X-Poedit-Basepath: .\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: ..\n"
 
 #: ..\WebConfigSite.py:34
@@ -66,47 +67,35 @@ msgstr "Web-IF"
 msgid "Screen"
 msgstr "Scherm"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Weer"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Remote box"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalender"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WEB-IF IP toegestaan"
 
@@ -115,8 +104,7 @@ msgid "No or wrong File selected, try a correct File first !"
 msgstr ""
 "Geen of verkeer bestand geselecteerd; probeer eerst een correct bestand!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Modus"
 
@@ -132,7 +120,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Toon"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Verwijder"
 
@@ -164,35 +152,24 @@ msgstr "Sla configuratie op"
 msgid "stop Screencycle"
 msgstr "stop schermcyclus"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Globaal"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Aan"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Idle"
 
@@ -240,253 +217,299 @@ msgstr "Lijst van opslagmedia"
 msgid "Parent Directory"
 msgstr "Bovengelegen map"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Vr"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Ma"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Za"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Zo"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Do"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Di"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Wo"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "zwart"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "wit"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "grijs"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "zilver"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "leigrijs"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "zeegroen"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "goud"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "groengeel"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "geel"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "donker oranje"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "donker rood"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indianred"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "oranje"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "oranjerood"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "rood"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomaat"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "donker groen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "groen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "grasgroen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "licht groen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "limoen"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "blauw"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "blauw paars"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "blauw-grijs"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "korenbloem blauw"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "donker blauw"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "licht blauw"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "groenblauw"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "donker paars"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "diep paars"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "paars"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "bruin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "moccasin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olijf"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "roze bruin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "zandbruin"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Scherm 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Scherm 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Scherm 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Scherm 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Scherm 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Scherm 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Scherm 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Scherm 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Scherm 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Scherm 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Scherm 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Scherm 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Scherm 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Scherm 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Scherm 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Scherm 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Scherm 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Scherm 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Scherm 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Scherm 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Scherm 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Scherm 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Scherm 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Scherm 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Scherm 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Scherm 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Scherm 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Scherm 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Scherm 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Scherm9"
 
@@ -508,1312 +531,1131 @@ msgstr "Scherm9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "uit"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Scherm 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Scherm 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Scherm 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Scherm 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Scherm 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Scherm 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Scherm 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Scherm 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Scherm 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Scherm 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Scherm 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Scherm 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Scherm 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Scherm 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Scherm 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Scherm 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Scherm1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Scherm 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "aan"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2 uur"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3 uur"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5 uur"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2 uur"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3 uur"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5 uur"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (of compatible LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (of compatibel LCD-scherm) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (of compatible LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (of compatible LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Intern Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Intern TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "alleen foto1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "alleen foto 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "alleen foto 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "alleen foto 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "alleen foto aangepaste grootte"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "alleen foto aangepaste grootte 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Intern Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Huidige"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 dagen 1 regel"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 dagen 2 regels"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 dagen 1 regel"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 dagen 2 regels"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 dagen verticaal aanzicht"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 dagen 1 regel"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 dagen 2 regels"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 dagen verticaal aanzicht"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Huidige temperatuur (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Huidige temperatuur (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Huidige"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Huidige temperatuur"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Alle"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatuur"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatuur+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatuur+Co2+Druk"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatuur+vochtigheid"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Module 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Module 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Module 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Module 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Module 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Module 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Module 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Module 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Module 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Module 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Module 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Module 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Module 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Module 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Module 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Module 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Module 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Module 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Module 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Module 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Module 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Module 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Module 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "gebruiker gedefinieerd"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Balk"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Balk+waarde"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Schakelaar"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Schakelaar+waarde"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analoog"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analoog+Datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analoog+Datum+Dag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analoog+datum+dag 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Datum+Tijd"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Datum+Tijd+ Dag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Flapsontwerp datum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Flapsontwerp weekdg"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Tijd"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Tijd+Dag"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Weekdag"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "midden"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "links"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "rechts"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "midden"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Uitgebreid"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Uitgebreid (kort)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Kort"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Kort (verlengd)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Kort+verlengd"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Maand"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Maand+hoofd"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Week"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Week+hoofd"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "geen kalender"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "geen datums"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Data 1 regel"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Data 3 regels"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Data 5 regels"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Data 9 regels"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Datum compact 2 regels"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Datum compact 3 regels"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Frame"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "geen datums"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Onderlijnen"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Onderlijnen 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Frame"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Data"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Datum compact"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Datum compact geen icoon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Datum geen icoon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "geen ikoon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "geen ikoon, met doelnummer"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "met ikoon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "met ikoon & doelnummer"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + omw"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + omw/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "omw/min"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "omw/min/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "nee"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + omw"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + omw/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "omw/min"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "omw/min/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Laad@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Laad@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "toon actief"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "toon actief + slaap"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Altijd alle"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Altijd nieuw"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Alleen nieuw"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Alle Informatie"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "alleen afstand"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Afstand + Verlichting"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Afstand + Maanfase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "alleen Verlichting"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Verlichting + Maanfase"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "alleen Maanfase"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanaal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanaal+titel"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+kanaal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+kanaal+titel"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "zelfde kleur"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparant"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "ja"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "ja +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontaal"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "ja"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "vertikaal"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontaal"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "alle"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Hoek"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Hoek + timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "alleen voortgangsbalk"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "met resterende minuten"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "met resterende minuten (maat 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "met resterende minuten (maat 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "met percentage"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "met percentage (maat 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "met percentage (maat 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "met resterende minuten (boven)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "met resterende minuten (boven/maat 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "met resterende minuten (boven/maat 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "met percentage (boven)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "met percentage (boven/maat 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "met percentage (boven/maat 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "met resterende minuten (onder)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "met resterende minuten (onder/maat 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "met resterende minuten (onder/maat 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "met percentage (onder)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "met percentage (onder/maat 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "met percentage (onder/maat 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "met huidige 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "met huidige 00:00 (maat 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "met huidige 00:00 (maat 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "met huidige 00:00 (boven)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "met huidige 00:00 (boven/maat 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "met huidige 00:00 (boven/maat 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "met huidige 00:00 (onder)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "met huidige 00:00 (onder/maat 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "met huidige 00:00 (onder/maat 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "met percentage minuten / totaal (boven)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "met percentage minuten / totaal (boven/maat 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "met percentage minuten / totaal (boven/maat 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "met absolute eindtijd"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "met absolute eindtijd (maat 1,5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "met absolute eindtijd (maat 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "met 'Totaal minuten' / Eindtijd (boven)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "met minuten Totaal/Eindtijd (boven/maat 1,5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "met minuten Totaal/Eindtijd (boven/maat 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Snelle modus (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normaal (5s)"
 
@@ -1821,3437 +1663,2467 @@ msgstr "Normaal (5s)"
 msgid "last Screen"
 msgstr "laatste scherm"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alfabetisch"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "willekeurig"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "beter/langzaam"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "laag/langzaam (alleen foto)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "laag/snel (alle)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0,5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0,5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + aanpassing (hoge kwaliteit, langzaam)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + aanpassing (lage kwaliteit, snel)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "geen cache + geen aanpassing"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Plug tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Nu/Straks"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normaal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "beperkt"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript niet verversen"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Herlaad"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normaal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - Zij-aan-zij"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeather kaart"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternatieve kopieermode/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "ja + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "ja, lang"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "ja, kort"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Cover zoeken"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "altijd"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "altijd"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "Aan+media+stand-by"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Stand-by"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - kleur"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - grijsschaal/kleur"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Info-toets"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Mute"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Info toets-lang"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x snel vooruit toets"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x snel vooruit toets type 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Snel voorwaards toets-lang"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Snel voorwaards toets-lang type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Info-toets"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Mute"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Info toets-lang"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x snel achteruit toets"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x snel achteruit toets type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Snel achterwaards toets-lang"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Snel achterwaards toets-lang type 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "ja, verlengd"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Console normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Logbestand uitgebreid"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Logbestand normaal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (vol)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normaal (vol)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "getrimd (zwart)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "getrimd (doorzichtig)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "MUTE of definieer toetsen"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "elke toets"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Tijd+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Tijd+Duur+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Tijd+Lengte+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "half links"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "half rechts"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Frame x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Regel"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "geen balk"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "geen rand"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normaal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradiënt"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Schaduw hoeken"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Naam"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normaal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+positie beneden"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+positie links"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+positie rechts"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Positie"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Naam"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Offline"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Online"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Online+Offline"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "gebruik alleen timer"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "gebruik voorlooptijd"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "geen totaal timer"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "toon totale timer"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "één regel"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "twee regels"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Beschikbaar geheugen"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Vrij geheugen"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "vol scherm"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "ja behalve opnames"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "O"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ONO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "EZE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "Z"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "ZO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "ZZO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "ZZW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "ZW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WZW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Laad actieve configuratiebestand"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Laad standaard waardes / lege configuratie"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Sla configuratiebestand op ,,,(%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Laad bestand: %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Verwijder bestand?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "verwijderd"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "momenteel ingesteld: %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Selecteer"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux instellingen"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Bevestigen"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Herstart displays"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Aan instellingen >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "geen LCD1 foto bestand"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "geen LCD2 foto bestand"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "geen LCD3 foto bestand"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux ingeschakeld"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Type"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Roteer"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Achtergrondkleur"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Achtergrond-Foto [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 helderheid"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 nachtreductie"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 ververs"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Type"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Roteer"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Achtergrondkleur"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Achtergrond-Foto [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 helderheid"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 nachtreductie"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 verversen"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Type"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Roteer"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Achtergrondkleur"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Achtergrond-Foto [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 helderheid"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 nachtreductie"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 verversen"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD afmetingen"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD afwijking"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD kleur"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD schakel aan-modus in"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD schakel mediamode in"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD schakel idle-modus in"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [vertoon tijd]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- Welk LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Toon in mode"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- OSD-maat"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Achtergrond/Tranparantie"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Snel binnenhalen lagere kwaliteit"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Popuptekst"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Verwijder toets"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Letter grootte"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Positie"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Uitlijning"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Kleur"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Achtergrondkleur"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Lettertype"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Actief scherm"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Schermschakelkeuze - scherm"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Scherm Standaard na moduswijziging - Scherm"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Schermschakelkeuze - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Schermen gebruikt voor veranderen"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Scherm 1 Verander tijd"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Scherm 2 verandert tijd"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Scherm 3 verandert tijd"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Scherm 4 verandert tijd"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Scherm 5 verandert tijd"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Scherm 6 verandert tijd"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Scherm 7 verandert tijd"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Scherm 8 verandert tijd"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Scherm 9 verandert tijd"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Plaatje verandertijd"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Plaatje volgorde"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Plaatje map omgekeerd"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Plaatje kwaliteit voor herschalen"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Plaatje snelle update-tijd [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Type plaatje [alleen plaatje]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Achtergrond-type plaatje"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Weer-API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Weer API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Weer stad"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Weer stad 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Weer-ikoon-Pad [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Weer-ikoon zoom"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Weer lage temperatuur kleur"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Weer hoge temperatuur kleur"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Weer transparantie"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Weer windsnelheid eenheid"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Weer Wind Infolijnen"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Weer regenkans"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Regen zoom"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Kleur regen"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Regen gebruik kleur 2 van"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Kleur regen 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Weer Vochtigheid Kleur"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Weer regels"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Weer trend pijlen"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Weer Extra Info"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra Zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Toon gevoelstemperatuur van verschil"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra kleur stad"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra kleur gevoelstemperatuur"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 min bereik"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 max bereik"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Meteo URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Maan-ikoonpad [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Opnameplaatje [OK]"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Dubbele toets schakelaars"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Sleutel voor scherm veranderen"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Sleutel voor scherm aan/uit"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall pad voor plaatjes [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall aantal lijnen per ingang"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall aantal lijstingangen"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall aantal plaatjes"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall orientatie van plaatjes"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall transparantie van plaatjes"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall plaatjes zoeken"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall verwijder oproepen na uren"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Popup tijd"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall Popup LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Popup kleur"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Frame Picture [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kalender ics-pad [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalender ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalender planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Kalender kleur zaterdag"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Kalender kleur zondag"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalenderlijn dikte"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Kalenderdag gebeurtenis preview"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalender tijdzonecorrectie"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Kalender doorzichtigheid"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Kalender Poll Interval"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Tuner kleur"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Tuner kleur actief"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Tuner kleur aan"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Eerst kanaalzoeken"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T signaalkwaliteit correctie"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Lettertype globaal [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Lettertype 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Lettertype 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Lettertype 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Lettertype 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Lettertype 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Mail 1 verbinden"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Mail 1 Server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Mail 1 [Displayname:]Gebruikersnaam"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Mail 1 Wachtwoord"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 verbinden"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Mail 2 Server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Mail 2 [Displayname:]Gebruikersnaam"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Mail 2 wachtwoord"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Mail 3 verbinden"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Mail 3 Server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Mail 3 [Displayname:]Gebruikersnaam"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Mail 3 wachtwoord"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 verbinden"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Mail 4 Server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Mail 4 [Displayname:]Gebruikersnaam"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 wachtwoord"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Mail 5 verbinden"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Mail 5 Server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Mail 5 [Displayname:]Gebruikersnaam"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Mail 5 wachtwoord"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Mail Poll Interval"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP beperk tot laatste dagen"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mail toon lege mailboxen"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Mail toon datum"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail verberg mailadres"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Remote box 1 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Remote box 2 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Remote box 3 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Remote box 4 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Remote box 5 [Displayname:]IP/Name"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Remote box elke minuut controleren"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Remote box timer [Displayname:]IP/Name"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Remote box Timer elke minuut controleren"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Converter Poll Interval"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW converter gebruik"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey van cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey van convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WEB-IF verversing [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WEB-IF verversings type"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WEB-IF Initiële vertraging"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WEB-IF IP verboden"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "Web-IF ontwerp"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Sla op als plaatje voor WEB-IF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Stream LCD 1 inschakelen"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 poort"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG-stream LCD 1 virtuele helderheid"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Stream LCD 2 inschakelen"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 poort"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG-stream LCD 2 virtuele helderheid"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Stream LCD 3 inschakelen"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 poort"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG-stream LCD 3 virtuele helderheid"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG cyclus"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG herstarten bij fout"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG headermode"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Toon streams '4097; 5001...5003' in modus"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Timeout [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos afspeelcontrole"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos verversen [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound ping timeout [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound play check"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound ververs [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [optioneel]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Timeout [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast afspeelcontrole"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast verversen [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Cover"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD aangepaste breedte"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD aangepaste hoogte"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD aangepaste breedte 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD aangepaste hoogte 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD uit wanneer uitgeschakeld"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Timing! Alle tijden naar tijd/5*2 in snelle mode omrekenen"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Toon vertraging [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Draden per LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Toon Crash hoek"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Toon 'nee ...' berichten"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Opslagmedia: force read"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Opslagmedia: kleur achter"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Opslagmedia: kleur balk"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Opslagmedia: kleur volledig"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Netwerkcontrole aktief"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Schakel framebuffer [indien mogelijk)"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Config backuppad [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Config herstel alle instellingen"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debuglogs > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Achtergrondverlichting Uit"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Achtergrondverlichting Aan"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Achtergrondverlichting weekeinde uit"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Achtergrondverlichting  Weekeinde Aan"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Auto-UIT"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Achtergrond"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Plaatje [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon grootte"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Gedeeld scherm"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Vol scherm"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Tekst grootte"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparantie"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon-pad [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon-pad 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon cache-pad [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Klok"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Type"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analoge klok"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Spatie"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "-Grootte"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Shaduwhoeken"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Klok 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Programmanaam"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- Maximum aantal lijnen"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Lengte"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Programmanummer"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Programma-info"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Type"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Programma-info 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Info volgende programma"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Uitgebreide beschrijving"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- gebruik info indien leeg"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Voortgangsbalk"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Kleur tekst"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Kleur Achtergrond"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Rand"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Schaduw"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Eenheid min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informatie"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Tunerinfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensors"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informatie 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Signaalkwaliteit balk"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradiënt"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Balkbereik min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Balkbereik max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satelliet"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Provider"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Gebruikte tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- Alleen actieve tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Volgende timer"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volume"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Mute"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Toon status"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Timeout [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Online Naam:Adres"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Extern IP adres"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- extern IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Opslagmedia"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- Vrij waarschuwing"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- extra info"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Apparaatnaam"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Weertype"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Weer 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo-weerstation"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Station"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Module"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Module gebruiker gedefinieerd"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Basis"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Naam"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Kleur 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Kleur 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Kleur 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Kleur 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Kleur 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Kleur 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2-indicator"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Lengte [Balk]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo comfortindicator"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Maanfase"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Infolijnen"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Trend pijlen"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Zonsopkomst"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Toon oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Bestand [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Toon  ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Toon tekstbestand"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Toon tekstbestand 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Toon tekstbestand 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Toon HTTP tekst"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-Internet Converter"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP Breedte"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP Hoogte"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Knippen vanaf X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Knippen vanaf Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Knip-breedte (uitschakelen = 0)"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Knip-hoogte (uitschakelen = 0)"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Toon foto"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Bestand of pad [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Maximale hoogte"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Snell update"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Toon foto 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Toon foto 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Toon foto 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Toon foto 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Toon foto 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Lijnen"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Mail account"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- Maximale breedte"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Remote box Timer"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Foto grootte"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Foto positie"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Foto uitlijning"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Lay-out"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Huidige achtergrondkleur overdag"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Hoofdletterkleur"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Datumlijst"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Gebeurtenissen ikoon balk"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popupscherm"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Toon tekst 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Tekst"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Toon tekst 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Rechthoek 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Positie x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Positie y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Waarde X"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Waarde Y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Rechthoek 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Neemt op"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stotter-TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Schermen gebruikt voor veranderen"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Titel"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Infos"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Toon Cover"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Zoekpad [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Vind cover-bestand [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Default cover [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon eerst"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Bijgesneden"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Download Cover"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Download Type"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Display"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux display-modus aan"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Media instellingen >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux display-modus mediaspeler"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Idle instellingen >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux display-modus idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Algemene instellingen >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Kies map"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Kies bestand"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Kies lettertype"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Huidige waarde: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5259,114 +4131,94 @@ msgstr ""
 "Er is een GUI-herstart nodig om de veranderingen toe te passen.\n"
 "Wilt u nu de GUI hertarten?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "GUI nu herstarten?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Binnenshuis"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Buitenshuis"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Regen"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Wind"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Nieuwe maan"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Eerste kwartier"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Wassende halve maan"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Wassende maan"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Volle maan"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Afnemende maan"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Afnemende halve maan"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Laatste kwartier"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Afbeelding niet beschikbaar"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "geen timer"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM draait niet"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "geen oproepen"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Mail  %d Nieuw  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "geen Netatmo-Plugin geïnstalleerd"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux schermschakelaar"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "ja (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "pijl + tekst"
-
-#~ msgid "only arrow"
-#~ msgstr "alleen pijl"
-
-#~ msgid "only text"
-#~ msgstr "alleen tekst"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Weer Wind richting"

--- a/LCD4linux/po/pl.po
+++ b/LCD4linux/po/pl.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:57+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:36+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: pl\n"
@@ -14,7 +14,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -68,47 +69,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Ekran"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Pogoda"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Zdalny odbiornik"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalendarz"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP Dozwolone"
 
@@ -118,8 +107,7 @@ msgstr ""
 "Nie wybrano pliku lub wybrano nieprawidłowy plik, spróbuj najpierw wybrać "
 "prawidłowy plik!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Tryb"
 
@@ -135,7 +123,7 @@ msgstr "Crashlog"
 msgid "Show"
 msgstr "Pokaż"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Usuń"
 
@@ -167,35 +155,24 @@ msgstr "Zapisz konfigurację"
 msgid "stop Screencycle"
 msgstr "zatrzymaj zmianę ekranów"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Globalne"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Wł"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Media"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Bezczynny"
 
@@ -243,253 +220,299 @@ msgstr "Lista zapamiętanych urządzeń"
 msgid "Parent Directory"
 msgstr "Katalog nadrzędny"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Pią"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Pon"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sob"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Nie"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Czw"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Wto"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Śro"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "czarny"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "biały"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "szary"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "srebro"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "Niebiesko szary"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aquamarine"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "złoto"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "greenyellow"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "żółty"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "Ciemno pomarańczowy"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "Ciemno czerwony"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indianred"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "pomarańczowy"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "pomarańczowy"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "czerwony"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "pomidor"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "ciemnozielony"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "zielony"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "lawngreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "jasnozielony"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "limonka"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "niebieski"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "Niebiesko fioletowy"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "cadetblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "cornflowerblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "ciemnoniebieski"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indygo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "jasnoniebieski"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "cyan"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "Ciemna orchidea"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "Głęboki róż"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "malinowy"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "fioletowy"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "brąz"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "mokasyn"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "oliwka"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "Różowo brązowy"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "Piaskowo brązowy"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Ekran 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Ekran 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Ekran 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Ekran 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Ekran 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Ekran 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Ekran 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Ekran 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Ekran 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Ekran 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Ekran 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Ekran 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Ekran 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Ekran 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Ekran 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Ekran 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Ekran 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Ekran 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Ekran 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Ekran 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Ekran 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Ekran 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Ekran 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Ekran 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Ekran 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Ekran 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Ekran 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Ekran 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Ekran 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Ekran 9"
 
@@ -511,1312 +534,1131 @@ msgstr "Ekran 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "wył"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Ekran 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Ekran 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Ekran 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Ekran 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Ekran 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Ekran 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Ekran 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Ekran 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Ekran 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Ekran 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Ekran 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Ekran 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Ekran 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Ekran 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Ekran 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Ekran 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Ekran 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Ekran 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "włączony"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2 godz"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3 godz"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3 min."
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40 sek."
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4 min."
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50 sek."
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5 godz"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15 sek."
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1 min."
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20 sek."
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2 min."
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30 sek."
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10 min."
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5 min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20 min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30 min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60 min."
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20 min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10 min."
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5 min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2 godz"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3 godz"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3 min."
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40 sek."
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4 min."
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50 sek."
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5 godz"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (lub kompatybilny LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (lub kompatybilny LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (lub kompatybilny LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (lub kompatybilny LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Wewnętrzny Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Wewnętrzny TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "tylko obraz 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "tylko obraz 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "tylko obraz 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "tylko obraz 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "tylko obraz własny rozmiar"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "tylko obraz Rozmiar niestandardowy 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Wewnętrzny Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Aktualne"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 dni 1 linia"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 dni 2 linie"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 dni 1 linia"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 dni 2 linie"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 dni Widok pionowy"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 dni 1 linia"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Dni 2 Linie"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 dni Widok pionowy"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Bieżąca temperatura (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Bieżąca temperatura (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Aktualne"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Bieżąca temperatura"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Wszystkie"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatura+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatura+Co2+ciśnienie"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatura+Wilgotność"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Moduł 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Moduł 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Moduł 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Moduł 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Moduł 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Moduł 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Moduł 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Moduł 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Moduł 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Moduł 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Moduł 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Moduł 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Moduł 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Moduł 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Moduł 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Moduł 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Moduł 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Moduł 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Moduł 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Moduł 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Moduł 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Moduł 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Moduł 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "zdefiniowany przez użytkownika"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Pasek"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Pasek+Wartość"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Pokrętło"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Pokrętło+Wartość"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analog"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analogowy+Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analogowy+Data+Dzień tygodnia"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analogowy+Data+2 dzień tygodnia"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Data+Czas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Data+Czas+Dzień tygodnia"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Klapy Data projektu"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Klapy Dzień tygodnia projektu"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Czas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Czas+Dzień tygodnia"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Dzień tygodnia"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "środek"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "lewo"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "prawo"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "środek"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Rozszerzony"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Rozszerzony (Krótkometrażowy)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Krótkie"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Krótki (Rozszerzony)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Short+Extended"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Miesiąc"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Miesiąc+Nagłówek"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Tydzien"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Tydzień + nagłówek"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "brak kalendarza"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "brak dat"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Daty 1 Linia"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Daty 3 linie"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Daty 5 linii"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Daty 9 linii"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Daty 2 linie kompaktowe"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Daty 3 linie kompaktowe"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Ramka"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "brak dat"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Podkreślenie"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Podkreślenie 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Ramka"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Daty"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Daty kompaktowe"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Prosta data bez ikon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Daty i ikony"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "brak ikony"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "bez ikony, z numerem docelowym"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "z ikoną"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "z ikoną i numerem docelowym"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + obr"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + obr/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "obr"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "nie"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + obr"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + obr/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "obr"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "Db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + obciążenie@1 min."
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + obciążenie@5 min."
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Ładuj@1 min."
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Ładuj@5 min."
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "Pokaż uruchomione"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "pokaż uruchom+uśpij"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Zawsze wszystko"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Zawsze nowy"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Tylko nowy"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Wszystkie informacje"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Tylko odległość"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Odległość+oświetlenie"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Odległość + faza księżyca"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Tylko podświetlenie"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Podświetlenie+faza księżyca"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Tylko tryb księżycowy"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanał"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanał+Tytuł"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Pikona+Kanał"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Pikona+Kanał+Tytuł"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "ten sam kolor"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "przejrzysty"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "tak"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "tak +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "poziomo"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "tak"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "pionowo"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "poziomo"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "wszystkie"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Narożnik"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Narożnik+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "tylko pasek postępu"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "z pozostałymi minutami"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "z pozostałymi minutami (rozmiar 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "z pozostałymi minutami (rozmiar 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "z procentem"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "z procentem (rozmiar 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "z procentem (rozmiar 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "z pozostałymi minutami (powyżej)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "z pozostałymi minutami (powyżej/rozmiar 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "z pozostałymi minutami (powyżej/rozmiar 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "z procentem (powyżej)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "z procentem (powyżej/rozmiar 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "z procentem (powyżej/rozmiar 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "z pozostałymi minutami (poniżej)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "z pozostałymi minutami (poniżej/rozmiar 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "z pozostałymi minutami (poniżej/rozmiar 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "z procentem (poniżej)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "z procentem (poniżej/rozmiar 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "z procentem (poniżej/rozmiar 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "z aktualną godziną 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "z bieżącym 00:00 (rozmiar 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "z bieżącym 00:00 (rozmiar 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "z bieżącym 00:00 (powyżej)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "z bieżącym 00:00 (powyżej/rozmiar 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "z bieżącym 00:00 (powyżej/rozmiar 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "z bieżącym 00:00 (poniżej)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "z bieżącym 00:00 (poniżej/rozmiar 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "z bieżącą godziną 00:00 (poniżej/rozmiar 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "z procentem minut / całość (powyżej)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "z procentem minut / całość (powyżej/rozmiar 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "z procentem minut / całość (powyżej/rozmiar 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "z całkowitym czasem zakończenia"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "z całkowitym czasem zakończenia (rozmiar 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "z całkowitym czasem zakończenia (rozmiar 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "z całością minut / czas końcowy (powyżej)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "z całością minut / czas końcowy (powyżej/rozmiar 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "z całością minut / czas końcowy (powyżej/rozmiar 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Tryb szybki (2 s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normalny (5 s)"
 
@@ -1824,3437 +1666,2467 @@ msgstr "Normalny (5 s)"
 msgid "last Screen"
 msgstr "ostatni ekran"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alfabetyczny"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "losowe"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "lepiej/wolno"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "wolno/szybko (tylko obraz)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "wolno/szybko (wszystko)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0,5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0,5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPEG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "bufor + regulacja (wysoka jakość, powoli)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "bufor + regulacja (niska jakość, szybko)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "brak bufora + brak regulacji"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Plug Tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "Tuner USB"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Teraz/Następnie"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normalny"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "zmniejszony"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript bez odświeżania"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Przeładuj"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normalny"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - obok siebie"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "Alternatywny tryb kopiowania/DM800hd (24-bitowy)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "tak + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "tak, długo"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "tak, krótki"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversearch"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180 KM"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270°"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "zawsze"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1/min."
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "zawsze"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "Załącz+Media+Uśpij"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Tryb Czuwania"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - kolor"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - skala szarości/kolor"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x InfoKey"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Wyciszenie"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Long InfoKey"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x FastForwardKey"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x FastForwardKey Typ 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Long FastForwardKey"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Long FastForwardKey Type 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x InfoKey"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Wyciszenie"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Long InfoKey"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x FastBackwardKey"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x FastBackwardKey Typ 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Long FastBackwardKey"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Long FastBackwardKey Type 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15 min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "tak, rozszerzony"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Konsola działa normalnie"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Plik dziennika"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Normalny plik dziennika"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "wyłączony"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radio+Media"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radio+Media"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (pełny)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normalny (pełny)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "przycięty (czarny)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "Zablokowany (przeźroczysty)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "Wyciszenie lub zdefiniowane klawisze"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "dowolny klucz"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Czas+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Czas+Długość+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Czas+Długość+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "połowa w lewo"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "pół w prawo"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Rama x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Linia"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "bez Paska"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "brak ramki"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normalny"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradient"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Krawędzie cienia"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Nazwa"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normalny"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Pikona+Pozycja obok"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Pikona+Pozycja lewa"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Pikona+pozycjia prawa"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Pozycja"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Nazwa"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Rozłącz"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Online"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Online+Offline"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "używaj tylko Timera"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "użyj czasu realizacji"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "brak całkowitego Timera"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "show total Timer"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "jedna linia"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "dwa numery"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Dostępna pamięć"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Bez pamięci"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "pełny ekran"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "tak, z wyjątkiem zapisów"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ENE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "ESE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "Nnw"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "ZZW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SW: Miesięczne archiwa"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW (WNW)"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WSW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Załaduj aktywny plik konfiguracyjny"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Załaduj ustawienia domyślne / pusta konfiguracja"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Zapis pliku konfiguracji do… (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Załaduj plik : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Usunąć plik?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "usunięte"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "aktualnie ustawiony : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Wybierz"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "Ustawienia LCD4linux"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Zapisz"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Restart wyświetlaczy"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Ustaw na >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "Brak pliku obrazu LCD1"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "Brak pliku obrazu LCD2"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "Brak pliku obrazu LCD3"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux włączony"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "Typ LCD 1"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 Obrót"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- Kolor tła LCD 1"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "-LCD 1 obraz tła [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Jasność"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Redukcja nocna"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Odświeżanie"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "Typ LCD 2"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Obrót"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- Kolor tła LCD 2"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "-LCD 2 obraz tła [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Jasność"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Redukcja nocna"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Odświeżanie"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "Typ LCD 3"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Obróć"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Kolor tła"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "-LCD 3 obraz tła [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Jasność"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Redukcja nocna"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Odświeżanie"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD Dimension"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Offset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD Kolor"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD włącza tryb załączenia"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD Załącz tryb mediów"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD Załącz tryb uśpienia"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [czas wyświetlania]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- który LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Pokaż w trybie"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Rozmiar OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Tło/Przeźroczystość"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Niższa jakość Fast Grab"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Tekst popup-a"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Wyczyść klucz"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Rozmiar czcionki"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Pozycja"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Wyrównanie"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Kolor"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Kolor tła"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Czcionka"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Aktywny ekran"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Ekran Przełącznik wyboru - Ekran"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Ekran domyślny po zmianie trybu - Ekran"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Ekran Przełącznik wyboru - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Ekranów używanych dla zmiany"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Ekran 1 czas zmiany"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Ekran 2 czas zmiany"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Ekran 3 czas zmiany"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Ekran 4 czas zmiany"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Ekran 5 czas zmiany"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Ekran 6 czas zmiany"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Ekran 7 czas zmiany"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Ekran 8 czas zmiany"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Ekran 9 czas zmiany"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Czas zmiany zdjęć"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Sortowanie zdjęć"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Katalog zdjęć cykliczny"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Jakość obrazu skalowania"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Szybka aktualizacja obraz [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Typ obrazu [tylko zdjęcie]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Tło - typ obrazu"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Weather API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Pogoda Klucz-API OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Weather City"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Weather City 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Pogoda-Ikona-Ścieżka [ok] >"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Pogoda-Ikona Powiększenie"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Pogoda kolor niskiej temperatury"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Pogoda kolor wysokiej temperatury"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Przejrzystość pogody"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Pogoda jednostka prędkości wiatru"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Linie informacyjne o pogodzie i wietrze"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Szansa na deszcz"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Rain Zoom"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Kolor deszczu"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Deszcz używa kolor 2 z"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Kolor deszczu 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Pogoda Wilgotność Kolor"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Linie pogodowe"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Trendy pogodowe"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Pogoda informacje dodatkowe"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Dodatkowy zoom"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Pokaż temperaturę chłodzenia z różnicy"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra Color City"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra Color Chill"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Min. zakres"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Maks. zakres"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Adres URL stacji meteo"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "-Księżyc-Ikona-Ścieżka [ok] >"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Nagrywanie obrazu [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Podwójny-przycisk przełączniki"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Przycisk zmiany ekranu"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Przycisk wyłączenia/włączenia ekranu"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall ścieżka do zdjęć [ok] >"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall liczba lini we wpisie"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Liczba wpisów na liście"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Liczba zdjęć"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall orientacja zdjęć"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall przeźroczystość zdjęć"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall wyszukiwarka zdjęć"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall usuń rozmowy po"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall czas wyświetlania"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall kolor LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall kolor okna"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Frame Picture [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kalendarz ics-ścieżka [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalendarz ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalendarz planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Kalendarz yolor sobotz"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Kalendarz kolor niedzieli"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalendarz grubość lini"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Kalendarza dzień podgląd wydarzenia"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalendarz korekcja strefy czasowej"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Przejrzystość kalendarza"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Interwał odpytywania kalendarza"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Kolor tunera"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Kolor aktywnego tunera"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Kolor tunera włączony"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Najpierw przeszukaj serwisy"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "Poprawa jakości sygnału DVB-T"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Czcionka globalna [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Czcionka 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Czcionka 2 [ok] >"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Czcionka 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Czcionka 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Czcionka 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Poczta 1 połącz"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Serwer poczty 1"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Poczta 1 [Nazwa wyświetlana:]Użytkownik"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Poczta 1 Hasło"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Mail 2 Connect"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Serwer poczty 2"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Poczta 2 [Nazwa wyświetlana:]Użytkownik"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Hasło Mail 2"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Poczta 3 połącz"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Serwer poczty 3"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Poczta 3 [Nazwa wyświetlana:]Użytkownik"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Hasło Mail 3"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Mail 4 Connect"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Serwer poczty 4"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Poczta 4 [Nazwa wyświetlana:]Użytkownik"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Mail 4 Password"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Poczta 5 połącz"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Serwer poczty 5"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Poczta 5 [Nazwa wyświetlana:]Użytkownik"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Hasło Mail 5"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Interwał odpytywania poczty"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Mail IMAP limit dni"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Poczta Pokaż puste skrzynki pocztowe"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Data pokazu poczty"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Mail Ukryj adres"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Zdalny odbiornik 1 [Nazwa wyświetlana:]IP/Nazwa"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Zdalny odbiornik 2 [Nazwa wyświetlana:]IP/Nazwa"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Zdalny odbiornik 3 [Nazwa wyświetlana:]IP/Nazwa"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Zdalny odbiornik 4 [Nazwa wyświetlana:]IP/Nazwa"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Zdalny odbiornik 5 [Nazwa wyświetlana:]IP/Nazwa"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Zdalny odbiornik sprawdź co minutę"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Zdalny odbiornik Timer[Nazwa wyświetlana:]IP/Nazwa"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Zdalny odbiornik sprawdź timer co minutę"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW konwerter interwał próbkowania"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW użycie konwertera"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey z cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey z convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "Odświeżanie WebIF [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "Typ odświeżania WebIF"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Opóźnienie inicjalizacji"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP Zabronione"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Wygląd"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Zapisz jako obraz dla WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "Strumień MJPEG LCD 1 załącz"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "Strumień MJPEG LCD 1 Port"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "Strumień MJPEG dla LCD1 wirtualna jasność"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "Strumień MJPEG LCD 2 załącz"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "Strumień MJPEG LCD 2 Port"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "Strumień MJPEG dla LCD2 wirtualna jasność"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "Strumień MJPEG LCD 3 załącz"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "Strumień MJPEG LCD 3 Port"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "Strumień MJPEG dla LCD3 wirtualna jasność"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "Cykl MJPEG"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "Restart MJPEG przy błędzie"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "Tryb nagłówka MJPEG"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Pokaż strumienie '4097; 5001...5003' w trybie"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos adres IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos limit czasu [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Play Check"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos odświeżanie [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping Timeout [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Play Check"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Refresh [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "Adres IP serwera MusicCast [opcjonalnie]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Timeout [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Play Check"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Refresh [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "Okładka MusicCast"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "Niestandardowa szerokość wyświetlacza LCD"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "Niestandardowa wysokość wyświetlacza LCD"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "Niestandardowa szerokość wyświetlacza LCD 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "Niestandardowa wysokość wyświetlacza LCD 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD wyłączony po wyłączeniu"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Czas! Przelicz cały czas do czas/5*2 w szybkim trybie"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Opóźnienie wyświetlania [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Zadań na LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Pokaż Crash Corner"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Pokaż \"nie ... Wiadomości"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Menadżer urządzeń: Wymuś odczyt"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Urządzenia pamięci masowej: Kolorowy tył"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Urządzenia pamięci masowej: Color Bar"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Urządzenia pamięci masowej: Kolor Pełny"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Sprawdzanie sieci aktywne"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Przełącz FrameBuffer [jeśli możliwy]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Konfiguracja zapisu kopii zapasowej [ok] >"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Konfiguracja przywracania ustawień"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debugowanie > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "-Podświetlenie wyłączone [wyłącz Off=On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Podświetlenie włączone"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "-Podświetlenie w weekend wyłączone [wyłącz Off=On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "-Podświetlenie w weekend włączone"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD automatyczne wyłączenie"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Tło"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Obraz[ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Rozmiar Picon"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Podzielony ekran"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Pełny ekran"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Rozmiar tekstu"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Przejrzystość"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Ścieżka Picon [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Ścieżka pikon 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "-Ścieżka buforowania pikon[ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Zegar"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Typ"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Zegar analogowy"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Rozstaw"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Rozmiar"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Krawędzie cienia"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Zegar 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Nazwa programu"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- maksymalne linie"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Długość"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Numer programu"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Informacje o programie"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Typ"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Informacje o programie 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Informacje o następnym programie"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Rozszerzony opis"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- użyj informacji kiedy jest pusty"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Pasek postępu"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Kolorowy tekst"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Kolor tła"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Obramowanie"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Zacieniony"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Jednostka min."
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informacje"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Tunerinfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Czujniki"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informacje 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Pasek jakości sygnału"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradient"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Zakres paska min."
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Zakres paska maks."
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satelita"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Nadawca"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Używany tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- tylko aktywny tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Następne zdarzenie timera"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Głośność"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Wycisz"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Wideo"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Pokaż stan"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Timeout [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Nazwa online:Adres"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Zewnętrzny adres IP"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- zewnętrzny adres URL IP"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Urządzenia pamięci masowej"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- bezpłatne ostrzeżenie"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- dodatkowe informacje"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Nazwa urządzenia"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Typ pogody"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Pogoda 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Stacja meteorologiczna"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Stacja"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Moduł"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Moduł zdefiniowany przez użytkownika"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Podstawa"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Nazwa"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Kolor 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Kolor 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Kolor 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Kolor 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Kolor 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Kolor 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Wskaźnik"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Długość [bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo CO2 Komfortowy wskaźnik"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Moonphase"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Infolinie"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Trendarrows"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Wschód słońca"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Pokaż oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Plik [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Pokaż ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Pokaż plik tekstowy"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Pokaż plik tekstowy 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Pokaż plik tekstowy 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Pokaż tekst HTTP"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "Konwerter WWW-Internet"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- Szerokość HTTP"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- Wysokość HTTP"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Cięcie od X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Odcięcie od Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Szerokość cięcia [disable = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Wysokość cięcia [disable = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Pokaż zdjęcie"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Plik lub ścieżka [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Rozmiar maks. Wysokość"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Szybka aktualizacja"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Pokaż zdjęcie 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Pokaż zdjęcie 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Pokaż zdjęcie 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Pokaż zdjęcie 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Pokaż zdjęcie 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Linie"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Konto pocztowe"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- maks. szerokość"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Zdalny wyłącznik czasowy"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Rozmiar obrazu"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Pozycja na zdjęciu"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Wyrównanie obrazu"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Układ"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Kolor tła bieżącego dnia"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Kolor napisów"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Lista dat"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Pasek ikon zdarzeń"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Ekran wyskakujący"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Wyskakujący wyświetlacz LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Pokaż tekst 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Tekst"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Pokaż tekst 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Prostokąt 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Pozycja x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Pozycja y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Rozmiar x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Rozmiar y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Prostokąt 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Nagrywanie"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Ekrany używane do zmiany"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Tytuł"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informacje"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Pokaż Okładkę"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Ścieżka wyszukiwania [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Znajdź plik okładki [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Domyślna osłona [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon First"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Przycięte"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Pobierz okładki"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Pobierz typy"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "-API-Key Google console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "Wyświetlacz LCD"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Tryb wyświetlania On"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Ustaw media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Tryb wyświetlania MediaPlayer"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Ustaw zajętość >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Tryb wyświetlania Idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Ustaw globalnie >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Wybrać reż"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Proszę wybrać plik"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Wybierz czcionkę"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - bieżąca wartość: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5262,99 +4134,94 @@ msgstr ""
 "GUI musi być uruchomione, aby zastosować zmiany.\n"
 "Czy chcesz uruchomić GUI teraz ?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Zrestartować GUI teraz?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Kryty"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Na zewnątrz"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Deszcz"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Wiatr"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Księżyc w nowiu"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Pierwszy kwartał"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Księżyc w pełni"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Pełnia Księżyca"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Ubywający Księżyc"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Słabnący półksiężyc"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Ostatni kwartał"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Obraz niedostępny"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "brak Timera"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM nie działa"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "Brak połączeń"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Wiadomości %d Nowe %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "Nie zainstalowano wtyczki Netatmo."
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "Przełącznik ekranu LCD4linux"

--- a/LCD4linux/po/pt.po
+++ b/LCD4linux/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: BH Team\n"
@@ -15,7 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
@@ -70,47 +70,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Ecrã"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "O Tempo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "E-Mail"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Dispositivo Remoto"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Calendário"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "IP Permitido WebIF"
 
@@ -118,8 +106,7 @@ msgstr "IP Permitido WebIF"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "Inexistente ou arquivo não selecionado, corrigir isto primeiro!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Modo"
 
@@ -135,7 +122,7 @@ msgstr "Registo de Bloqueio"
 msgid "Show"
 msgstr "Mostrar"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Apagar"
 
@@ -167,35 +154,24 @@ msgstr "Salvar Configuração"
 msgid "stop Screencycle"
 msgstr "parar Ciclo de Ecrã"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Global"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "On"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Mídia"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Idle"
 
@@ -243,253 +219,299 @@ msgstr "Lista de Dispositivos de Armazenamento"
 msgid "Parent Directory"
 msgstr "Diretório Parental"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Sex"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Seg"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Sáb"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Dom"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Qui"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Ter"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Qua"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "preto"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "branco"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "cinzento"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "prateado"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "cinzento pizarra"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "agua-marinha"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "dourado"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "verde amarelo"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "amarelo"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "laranja escuro"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "roxo escuro"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "pele vermelha"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "laranja"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "alaranjado"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "vermelho"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomate"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "verde escuro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "verde"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "verde relva"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "verde claro"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "lima"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "azul"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "azul violeta"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "azul cadete"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "azul ciano"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "azul escuro"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "azul indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "celeste"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "ciano"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "orquídea escuro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "rosa escuro"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "magenta"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "violeta"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "castanho"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "mocasín"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "verde oliva"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "castanho rosado"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "castanho areia"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Ecrã 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Ecrãs 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Ecrãs 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Ecrãs 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Ecrãs 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Ecrãs 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Ecrãs 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Ecrãs 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Ecrãs 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Ecrãs 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Ecrãs 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Ecrãs 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Ecrãs 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Ecrãs 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Ecrã 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Ecrãs 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Ecrãs 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Ecrãs 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Ecrãs 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Ecrãs 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Ecrãs 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Ecrã 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Ecrã 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Ecrã 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Ecrã 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Ecrã 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Ecrã 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Ecrã 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Ecrã 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Ecrã 9"
 
@@ -511,1312 +533,1131 @@ msgstr "Ecrã 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "off"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Ecrãs 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Ecrãs 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Ecrãs 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Ecrãs 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Ecrãs 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Ecrãs 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Ecrãs 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Ecrãs 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Ecrãs 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Ecrãs 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Ecrãs 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Ecrãs 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Ecrãs 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Ecrã 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Ecrãs 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Ecrãs 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Ecrãs 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Ecrãs 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "on"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (ou LCD compatível) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (ou LCD compatível) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (ou LCD compatível) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (ou LCD compatível) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "LCD Box-Skin interno"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "TFT-LCD interno 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "só Imagens 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "só Imagens 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "só Imagens 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "só Imagens 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "só Imagens de tamanho configurável"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "só Imagem Personalizada Tamanho 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "LCD interno Vu+ Duo2 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Atual"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 Dias 1 Linha"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 Dias 2 Linhas"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 Dias 1 Linha"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 Dias 2 Linhas"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 dias vista vertical"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 Dias 1 Linha"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 Dias 2 Linhas"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 dias vista vertical"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Temperatura atual (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Temperatura atual (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Atual"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Temperatura atual"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Tudo"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Temperatura+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Temperatura+Co2+Pressão"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Temperatura+Humidade"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Módulo 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Módulos 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Módulos 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Módulos 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Módulos 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Módulos 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Módulos 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Módulos 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Módulos 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Móduloa 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Módulo 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Módulos 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Módulos 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Módulos 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Módulo 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Módulo 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Módulos 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Módulo 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Módulo 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Módulo 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Módulo 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Módulo 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Módulo 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "definido pelo usuário"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Pre"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Pre+Valor"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Botão"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Botão+Valor"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analógico"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analógico+Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analógico+Data+Dia da Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analógico+Data+Dia da Semana 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Data"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Data+Hora"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Data+Hora+Dia da Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Data no Desenho Flaps"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Dia da Semana no Desenho Flaps"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Hora"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Hora+Dia da Semana"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Dia da Semana"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "centro"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "esquerda"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "direita"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "centro"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Extendido"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Extendido (Curto)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Curto"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Curto (Extendido)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Curto+Extendido"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Mês"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Mes+Cabeçalho"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Semana"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Semana+Cabeçalho"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "sem Calendário"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "sem Datas"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Datas 1 Linha"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Datas 3 Linhas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Datas 5 Linhas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Datas 9 Linhas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Datas compatas en 2 Linhas"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Datas compatas en 3 Linhas"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Quadro"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "sem Datas"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Sublinhado"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Sublinhado 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Quadro"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Datas"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Datas compatas"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Datas compatas sem Icon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Datas sem Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "sem Icons"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "sem Icon, com Número de Destino"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "com Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "com Icono & Número de Destino"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + rpm"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + rpm/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "não"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + rpm/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "mostrar execução"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "mostrar execução+repouso"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Sempre Tudo"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Sempre Novo"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Só os Novos"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Todas as Informações"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Distância apenas"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Distância+Iluminação"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Distância + Fases da Lua"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Iluminação apenas"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Iluminação+Fase da Lua"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Fase da lua apenas"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Canal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Canal+Título"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+Canal"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+Canal+Título"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "mesma cor"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "transparente"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "sim"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "sim+25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "horizontalmente"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "sim"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "verticalmente"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "horizontalmente"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "tudo"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Esquina"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Canto+Timeshift"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Timeshift"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "só Barra de Progreso"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "com Minutos Restantes"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "com Minutos Restantes (Tamanho 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "com Minutos Restantes (Tamanho 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "com Percentagem"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "com Percentagem (tamanho 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "con Percentagem (tamanho 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "com Minutos Restantes (acima)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "com Minutos Restantes (acima/Tamanho 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "com Minutos Restantes (acima/Tamanho 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "con Percentagem (acima)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "com Percentagem (acima/Tamanho 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "com Percentagem (acima/Tamanho 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "com Minutos Restantes (abaixo)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "com Minutos Restantes (abaixo/Tamanho 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "com Minutos Restantes (abaixo/Tamanho 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "con Percentagem (abaixo)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "com Percentagem (abaixo/Tamanho 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "com Percentagem (abaixo/Tamanho 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "com o Atual 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "com o Atual 00:00 (Tamanho 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "com o Atual 00:00 (Tamanho 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "com o Atual 00:00 (acima)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "com o Atual 00:00 (acima/Tamanho 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "com o Atual 00:00 (acima/Tamanho 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "com o Atual 00:00 (abaixo)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "com o Atual 00:00 (abaixo/Tamanho 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "com o Atual 00:00 (abaixo/Tamanho 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "com Percentagem de Minutos / Total (acima)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "com Percentagem de Minutos / Total (acima/Tamanho 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "com Percentagem de Minutos / Total (arriba/Tamanho 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "com tempo final absoluto"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "com tempo final absoluto (Tamanho 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "com tempo final absoluto (Tamanho 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "com Total de minutos / Tempo final (superior)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "com Total de minutos / Tempo final (superior/Tamanho 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "com Total de minutos / Tempo final (superior/Tamanho 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Modo Rápido (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5s)"
 
@@ -1824,3437 +1665,2467 @@ msgstr "Normal (5s)"
 msgid "last Screen"
 msgstr "última tela"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alfabético"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "aleatório"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "melhor/lento"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "baixo/rápido (só Fotos)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "baixo/rápido (tudo)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + ajuste (alta qualidade, lento)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + ajuste (baixa qualidade, rápido)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "sem cache + sem ajuste"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Sintonizador integrado"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "Sintonizador USB"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Agora/Depois"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "reduzido"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript sem atualização"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Recarregar"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - lado a lado"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "modo Cópia alternativo/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "sim + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "sim, longo"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "sim, curto"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversearch"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "sempre"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "sempre"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Mídia+Repouso"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Repouso"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - color"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - cor/cinzento"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Tecla Info"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Tecla MUTE"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Tecla Info Prolongada"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x Tecla Avanço Rápido"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x Tecla Avanço Rápido Tipo 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Tecla Avanço Rápido Prolongada"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Tecla Avanço Rápido Prolongada Tipo 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Tecla Info"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Tecla MUTE"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Tecla Info Prolongada"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x Tecla Retrocesso Rápido"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x Tecla Retrocesso Rápido Tipo 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Tecla Retrocesso Rápido Prolongada"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Tecla Retrocesso Rápido Longo Tipo 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "sim, extendido"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Consola normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Arquivo de log extenso"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Arquivo de log normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "desligado"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Rádio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Rádio + Mídia"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Rádio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Rádio+Mídia"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (completo)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normal (completo)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "ajustado (preto)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "ajustado (transparente)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "MUTE ou teclas definidas"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "qualquer Chave"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Hora+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Hora+Duração+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Hora+Duração+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "metade esquerda"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "metade direita"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Quadro x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Linha"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "sem Barra"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "sem orla"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normal"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Gradiente"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Margens de Sombra"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Nome"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normal"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Posição abaixo"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Posição esquerda"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Posição direita"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Posição"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Nome"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Desconetado"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Conetado"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Conetado+Desconetado"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "usar só Temporizador"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "usar hora principal"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "sem Timer completo"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "mostrar Temporizador completo"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "uma linha"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "duas linhas"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Memória disponível"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Memória livre"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "ecrã completo"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "sim, excepto gravações"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "ENE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "ESE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "O"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "ONO"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "OSO"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Carregar Arquivo de Configuração Ativo"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Carregar Padrões / Config vazia"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Salvar Configuração no arquivo...(%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Carregar Arquivo : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Apagar Ficheiro?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "apagado"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "ajuste atual : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Selecionar"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "Definições do LCD4linux"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Menu"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Salvar"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Reiniciar Ecrãs"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Def On >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "não existe Arquivo de Imagem de LCD1"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "não existe Arquivo de Imagem de LCD2"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "não existe Arquivo de Imagem de LCD"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux ativado"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "Tipo LCD 1"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- Rodar LCD 1"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- Cor de Fundo LCD 1"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- Fundo-Imagem LCD 1 [OK]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- Brilho LCD 1"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- Redução Noturna LCD 1"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- Refrescar LCD 1"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "Tipo LCD 2"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- Rodar LCD 2"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- Cor de Fundo LCD 2"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- Fundo-Imagem LCD 2 [OK]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- Brilho LCD 2"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- Redução Noturna LCD 2"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- Refrescar LCD 2"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "Tipo LCD 3"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- Rodar LCD 3"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- Cor de Fundo LCD 3"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- Fundo-Imagem LCD 3 [OK]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- Brilho LCD 3"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- Redução Noturna LCD 3"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- Refrescar LCD 3"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD Tamanho"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Desvio"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD Cor"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD Ativar Modo On"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD Ativar Modo Mídia"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD Ativar Modo Apagado"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [hora no ecrã]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- qual LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Mostrar em Modo"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Tamanho OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Fundo/Transparência"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Gravador Rápido de qualidade baixa"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Texto Emergente"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Clear Key"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Tamanho da Fonte"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Posição"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Alinhamento"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Cor"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Cor de Fundo"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Fonte"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Ecrã Ativo"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Selecionar ecrã a Mudar - LCD"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Ecrã padrão após mudança de modo - Ecrã"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Selecionar ecrã a Mudar - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Ecrãs usados para mudar"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Tempo para mudar Ecrã 1"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 2"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 3"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 4"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 5"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 6"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 7"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 8"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Tempo de permuta de Ecrã 9"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Tempo para mudar de Imagem"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Imagens aleatórias"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Diretório Recursivo de Imagens"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Qualidade da Imagem para Redimensionar"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Tempo de Atualização Rápida de Imagen [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Tipo de Imagem [só Imagem]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Fundo - Tipo de Imagem"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "O Tempo API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Chave do Tempo API OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Cidade para o Tempo"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Cidade para o Tempo 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Percurso de Icons do Tempo [OK]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Zoom de Icons do Tempo"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Cor de Baixa Temperatura do Tempo"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Cor de Alta Temperatura do Tempo"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Transparências do Tempo"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Unidade de Velocidade do Viento no Tempo"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Linhas de informação do vento do tempo"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Possibilidade de Chuva no Tempo"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Zoom da Chuva"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Cor da Chuva"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- A Chuva usa cor 2 desde"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Cor de Chuva 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Tempo Humidade Cor"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Linhas do Tempo"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Tempo Setas de Tendência"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Informações Extras do Tempo"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Zoom Extra"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Mostrar temperaturas mais frias desde a diferença"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Cor Extra da Cidade"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Cor Extra do Frio"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Intervalo Mínimo"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Intervalo Máximo"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "URL Meteo"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Percurso Icons Lunares [OK]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Imagem de Gravação [OK]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Trocas Tecla dupla"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Tecla para mudar Ecrã"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Tecla para Apagar/Acender Ecrã"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall Percurso da Imagem [OK]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Número de Linhas por Entrada"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Número de Entradas Listadas"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Número de Imagems"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall Orientação da Imagem"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "Transparência Imagem FritzCall"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall Busca de Imagens"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall apagar chamadas fora de horas"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Hora Emergente"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall LCD Emergente"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Cor Emergente"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Quadro de Imagem [OK]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Percurso Calendário ics [OK]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "URL Calendário ics"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Calendário planerFS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Calendário Cor Sábado"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Calendário Cor Domingo"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Calendário Linhas Finas"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Calendário Previsualização Eventos Diários"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Calendário Correção Zona Horária"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Calendário Transparência"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Calendário Intervalo"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Cor Sintonizador"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Cor Sintonizador Activo"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Cor Sintonizador Ligado"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Primeiro Busca de Canais"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "Correção da qualidade de Sinal DVB-T"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Fonte Global [OK]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Fonte 1 [OK]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Fonte 2 [OK]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Fonte 3 [OK]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Fonte 4 [OK]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Fonte 5 [OK]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Conetar E-Mail 1"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Servidor E-Mail 1"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "E-Mail 1 [Nome:]Usuário"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Senha E-Mail 1"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Conetar E-Mail 2"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Servidor E-Mail 2"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "E-Mail 2 [Nome:]Usuário\""
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Senha E-Mail 2"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Conetar E-Mail 3"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Servidor E-Mail 3"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "E-Mail 3 [Nome:]Usuário"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Senha E-Mail 3"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Conetar E-Mail 4"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Servidor E-Mail 4"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "E-Mail 4 [Nome:]Usuário"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Senha E-Mail 4"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Conetar E-Mail 5"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Servidor E-Mail 5"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "E-Mail 5 [Nome:]Usuário"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Senha E-Mail 5"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Intervalo E-Mail"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "E-Mail IMAP limitado até aos últimos dias"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Mostrar Caixas Vazias de E-Mail"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Data de Exibir o E-Mail"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "O E-Mail Esconde o Endereço"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 1 [NomeEcrã:]IP/Nome"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 2 [NomeEcrã:]IP/Nome"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 3 [NomeEcrã:]IP/Nome"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 4 [NomeEcrã:]IP/Nome"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Dispositivo Remoto 5 [NomeEcrã:]IP/Nome"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Sondar Dispositivo Remoto todos os Minutos"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Timer da box remota [Nome a exibir:]IP/Nome"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Timer da box remota pesquisa todos os Minutos"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "Intervalo Conversor WWW"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "Uso do Conversor WWW"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "Chave Api WWW de cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "Chave Api WWW de convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "Refrescamento WebIF [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "Tipo de Refrescamento WebIF"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "Atraso de Inicio WebIF"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "IP Proibido WebIF"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "Desenho WebIF"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Guardar como Imagem para WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "Ativar Stream MJPEG LCD 1"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "Porta Stream MJPEG LCD 1"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Stream LCD 1 Brilho Virtual"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "Activar Stream MJPEG LCD 2"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "Porta Stream MJPEG LCD 2"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2 Brilho Virtual"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "Activar Stream MJPEG LCD 3"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "Porta Stream MJPEG LCD 3"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Stream LCD 3 Brilho Virtual"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "Ciclo MJPEG"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Reiniciar com erro"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "Modo de Cabeçalho MJPEG"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Mostrar Stream '4097; 5001...5003' no modo"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "IP Sonos"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Tempo limite de Ping Sonos [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Verificar reprodução Sonos"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Refrescar Sonos [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound tempo limite de Ping [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound verificar reprodução"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Refrescar [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast IP [opcional]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Tempo limite de Ping [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Verificar reprodução"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Refrescar [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Cobrir"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "Largura Personalizada do LCD"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "Altura Personalizada do LCD"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD Personalizado Largura 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD Personalizado Altura 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD Desligado ao desligar"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Hora ! calcular todas as vezes a hora/5*2 en Modo Rápido"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Atraso Ecrã [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Threads por LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Mostrar Crash"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Mostrar Mensagens 'não...'"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Forçar Leitura de Dispositivos de Armazenamento"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Dispositivos de armazenamento: Cor Fundo"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Dispositivos de armazenamento: Cor Barra"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Dispositivos de armazenamento: Cor Cheia"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Verificar rede ativa"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Por contador de planos (se for possível)"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Percurso para Guardar Configurações [OK]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Restaurar Configuração de todas as Definições"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Registo de Depuração > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Luz de Fundo Desligada [desligar ajuste Off=On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Luz de Fundo Ligada"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Luz de Fundo Fim de Semana desconetada [desligar ajuste Off=On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Luz de Fundo Fim de Semana ligada"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Auto-OFF"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Fundo"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Imagem [OK]"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Tamanho dos Picons"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Ecrã Dividido"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- Ecrã Completo"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Tamanho do Texto"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Transparência"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Percurso Picon [OK]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Percurso Picon 2 [OK]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache Percurso [OK]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Relógio"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
-msgstr "- Tipo"
+msgstr "-  Tipo"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Relógio Analógico"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Espaçado"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Tamanho"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Margens de Sombra"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Relógio 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Nome do Programa"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- máximo de Linhas"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Duração"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Número do Programa"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Informação do Programa"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Tipo"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Informação Programa 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Informação do Próximo Programa"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Descrição Extendida"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- usar informação quando vazia"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Barra de Progresso"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Cor do Texto"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Fundo de cor"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Margem"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Sombreado"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Unidade min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informações"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Informação do Tuner"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Sensores"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informações 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Barra de Qualidade do Sinal"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Gradiente"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Barra Gama Mínima"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Barra Gama Máxima"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satélite"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Operador"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Sintonizador Usado"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- só o Tuner ativo"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Próximo Evento Programado"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Volume"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "2 x Muda"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Online [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Mostrar Estado"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Descanso [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Nome Online:Endereço"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Endereço IP Externo"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- URL de IP externo"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Dispositivos de Armazenamento"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- Advertência"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- informação extra"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Nome do Dispositivo"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Zoom"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Tipo de Tempo"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "O Tempo 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Estação Metereológica do Tempo"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Estação"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Módulo"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Módulo definido pelo usuário"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Base"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Nome"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Cor 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Cor 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Cor 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Cor 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Cor 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Cor 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo Indicador de CO2"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Comprimento [Barra]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Indicador de Comodidade"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Fases da Lua"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Linhas de Informação"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Setas de Tendência"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Amanhecer"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Mostrar oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Arquivo [OK]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Mostrar ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Mostrar Arquivo de Texto"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Mostrar Arquivo de Texto 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Mostrar Arquivo de Texto 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Mostrar Texto HTTP"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "Conversor WWW-Internet"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- Largura HTTP"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- Altura HTTP"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Cortar desde X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Cortar desde Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Cortar Largura [desligar = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Cortar Altura [desligar = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Mostrar Imagem"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Arquivo ou Percurso [OK]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Tamanho Altura Máxima"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Atualização Rápida"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Mostrar Imagem 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Mostrar Imagem 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Mostrar Imagem 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Mostrar Imagem 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Mostrar Imagem 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Linhas"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- E-Mail Konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- Largura máxima"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Timer da box remota"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Tamanho Imagem"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- Posição Imagem"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Alinhamento Imagem"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Disposição"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Cor de Fundo Dia Atual"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Cor da Legenda"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Lista de Datas"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Barra de Icon do Evento"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Ecrã Aparição"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- LCD Aparição"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Mostrar Texto 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Texto"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Mostrar Texto 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Retângulo 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Posição x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Posição y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Tamanho x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Tamanho y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Retângulo 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "A gravar"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Stutter TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- Ecrãs usdados para permuta"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Título"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informações"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Mostrar Capa"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Buscar Percurso [OK]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Encontrar arquivo de capa [OK]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- Capa por Defeito [OK]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Picon Primeiro"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "Aparado"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Descarregar Capa"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Tipo de Descarga"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "Ecrã LCD"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Display-Mode On"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Def Mídia >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "Visor LCD4linux-Modo MediaPlayer"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Def Idle >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Display-Modo Idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Def Global >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Escolher pasta"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Escolher ficheiro"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Escolher Fonte"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Valor Atual: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5262,114 +4133,94 @@ msgstr ""
 "GUI necesita reiniciar para aplicar as alterações.\n"
 "Deseja reiniciar a GUI agora?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Reiniciar a GUI agora?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Dentro de Casa"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Fora de Casa"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Chuva"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Vento"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Lua Nova"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Quarto Crescente"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Quarto Crescente"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Lua crescente"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Lua Cheia"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Lua minguante"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Quarto Minguante"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Quarto Minguante"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Imagem não disponível"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "sem Timer"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM não está a funcionar"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "sem Chamadas"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d E-Mails %d Novos %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "plugin Netatmo não instalado"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "Mudar o Ecrã LCD4linux"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "sm (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "seta + texto"
-
-#~ msgid "only arrow"
-#~ msgstr "apenas seta"
-
-#~ msgid "only text"
-#~ msgstr "apenas texto"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Clima Direcção do vento"

--- a/LCD4linux/po/ru.po
+++ b/LCD4linux/po/ru.po
@@ -2,15 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 10:59+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:36+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -64,47 +65,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Экран"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Погода"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Почта"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Удаленный ящик"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Календарь"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP Разрешать"
 
@@ -113,8 +102,7 @@ msgid "No or wrong File selected, try a correct File first !"
 msgstr ""
 "Файл не выбран или выбран неверный файл, сначала попробуйте правильный файл!"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Режим"
 
@@ -130,7 +118,7 @@ msgstr "Креш лог"
 msgid "Show"
 msgstr "Показать"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Удалить"
 
@@ -162,35 +150,24 @@ msgstr "Сохранить конфигурацию"
 msgid "stop Screencycle"
 msgstr "остановить Screencycle"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Глобально"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Вкл"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Медиа"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Праздный"
 
@@ -238,253 +215,299 @@ msgstr "Список устройств хранения"
 msgid "Parent Directory"
 msgstr "Родительский каталог"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Пятн"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Пон"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "Субб"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Воскр"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Чет"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Вт"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "Ср"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "черный"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "белый"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "серый"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "серебро"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "сланец серый"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "aquamarine"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "золотой"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "greenyellow"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "желтый"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "темнооранжевый"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "dunkelrot"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indianrot"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "оранжевый"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "orangered"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "красный"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "tomato"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "темнозеленый"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "зеленый"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "lawngreen"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "светло-зеленый"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "лайм"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "синий"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "blauviolett"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "cadetblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "cornflowerblue"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "темносиний"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "светло-синий"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "голубой"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "dunkelorchidee"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "deeppink"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "пурпурный"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "фиолетовый"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "коричневый"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "moccasin"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "оливковый"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "rosigbraun"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "sandbraun"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Экран 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Экран 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Экран 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Экран 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Экран 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Экран 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Экран 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Экран 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Экран 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Экран 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Экран 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Экран 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Экран 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Экран 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Экран 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Экран 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Экран 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Экран 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Экран 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Экран 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Экран 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Экран 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Экран 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Экран 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Экран 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Экран 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Экран 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Экран 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Экран 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Экран 9"
 
@@ -506,1312 +529,1131 @@ msgstr "Экран 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "выкл"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Экран 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Экран 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Экран 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Экран 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Экран 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Экран 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Экран 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Экран 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Экран 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Экран 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Экран 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Экран 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Экран 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Экран 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Экран 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Экран 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Экран 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Экран 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "вкл"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2час"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3час"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3мин"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40с"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4мин"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50с"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5час"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5с"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10с"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15с"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1мин"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20с"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2мин"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30с"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10мин"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5мин"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20мин"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30мин"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60мин"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20мин"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10мин"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5мин"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2час"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3час"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3мин"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40с"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4мин"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50с"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5час"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5с"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (or compatible LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (или совместимый ЖК-дисплей) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (or compatible LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (or compatible LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H alt 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H alt 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Internal Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Internal TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "только фото 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "только фото 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "только фото 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "только фото 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "только фото своего размера"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "только фото своего размера 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Internes Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Текущий"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 дня 1 линия"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 дня 2 линии"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 дня 1 линия"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 дня 2 линии"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 дня вертикально"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 дней в 1 линию"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 дней в 2 линии"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 дней вертикально"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Текущяя температура (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Текущяя температура (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Текущий"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Текущяя температура"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Все"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Температура"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Температура+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Температура+Co2+Давление"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Температура+Влажность"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Модуль 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Модуль 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Модуль 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Модуль 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Модуль 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Модуль 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Модуль 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Модуль 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Модуль 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Модуль 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Модуль 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Модуль 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Модуль 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Модуль 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Модуль 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Модуль 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Модуль 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Модуль 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Модуль 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Модуль 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Модуль 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Модуль 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Модуль 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "определяемые пользователем"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Balken"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Balken+Wert"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Кнопка"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Кнопка + значение"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Аналоговый"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Аналоговые+дата"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Аналоговые+дата+будни"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Аналоговые+дата+будни 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Дата"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Дата+Время"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Дата + время + день недели"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Закрылки Дизайн Дата"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Закрылки Дизайн Будний день"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Время"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Время+День"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Будний день"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "центр"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "слева"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "справа"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "центр"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Расширенное"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Расширенное (Short)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Краткий"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Краткий (Расширенный)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Краткий+Расширенный"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Месяц"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Месяц + заголовок"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Неделя"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Неделя+Заголовок"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "нет календаря"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "нет даты"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Даты в 1 линию"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Даты в 3 линии"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Даты в 5 линий"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Даты в 9 линий"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Даты компактно в 2 линии"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Даты компактно в 3 линии"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Фрейм"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "нет даты"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Подчеркивание"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Подчеркивание 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Фрейм"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Даты"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Даты компактно"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Даты компактно без иконок"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Даты без иконок"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "нет значка"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "без значка, с целевым числом"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "mit Icon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "со значком и целевым числом"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + об/мин"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + об/мин/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "rpm"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "rpm/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "нет"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + об/мин"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + об/мин/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "rpm"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "rpm/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Загрузить@1мин"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Загрузить@5мин"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "показать запущенные"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "показать запущенные+sleep"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Всегда все"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Всегда новые"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Только новости"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Вся информация"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Только расстояние"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Расстояние+Освещение"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Расстояние+фаза луны"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Только подсветка"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Освещение+фаза луны"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Только фаза луны"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Пикон"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Канал"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Канал+Заголовок"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Пикон+Канал"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Пикон+Канал+Название"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Пикон"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "такого же цвета"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "прозрачный"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "да"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "да +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "горизонтально"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "да"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "вертикально"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "горизонтально"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "все"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Угол"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Угол+сдвиг во времени"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Пикон+сдвиг во времени"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "только прогресс-бар"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "с оставшимися минутами"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "с оставшимися минутами (Размер 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "с оставшимися минутами (Размер 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "вместе с процентами"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "вместе с процентами (Размер 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "вместе с процентами (Размер 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "с оставшимися минутами (выше"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "с оставшимися минутами (выше/Размер 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "с оставшимися минутами (выше/Размер 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "вместе с процентами (выше)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "вместе с процентами (выше/Размер 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "вместе с процентами (выше/Размер 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "с оставшимися минутами (ниже)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "с оставшимися минутами (ниже/Размер 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "с оставшимися минутами (ниже/Размер 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "вместе с процентами (ниже)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "вместе с процентами (ниже/Размер 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "вместе с процентами (ниже/Размер 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "от текущего"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "от текущего 00:00 (размер 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "от текущего 00:00 (размер 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "от текущего 00:00 (выше)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "with Current 00:00 (above/Size 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "with Current 00:00 (above/Size 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "with Current 00:00 (below)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "with Current 00:00 (below/Size 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "with Current 00:00 (below/Size 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "с процентами минут / Всего (выше)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "с процентами минут / Всего (выше/Размер 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "с процентами минут / Всего (выше/Размер 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "с абсолютным Концом"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "с абсолютным Концом (Размер 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "с абсолютным Концом (Размер 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "с итогом в минутах / Время окончания (выше)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "с итогом в минутах / Время окончания (выше/Размер 1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "с итогом в минутах / Время окончания (выше/Размер 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Быстрый режим (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Нормальный (5с)"
 
@@ -1819,3437 +1661,2467 @@ msgstr "Нормальный (5с)"
 msgid "last Screen"
 msgstr "Последний экран"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "алфавитный"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "случайно"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "лучше/медленная"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "низкий/быстрый (Только изображения)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "низкий/быстрый (Все)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "тайник + корректирование (высокое качество, медленный)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "тайник + корректирование (низкое качество, быстрый)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "без кеша + без настройки"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Затыкать Тюнер"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Тюнер"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "E"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Сейчас/дальше"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "нормальный"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "уменьшенный"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "авто"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "JavaScript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "JavaScript нет обновления"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 нормальный"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - бок о бок"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternative Copy-Mode/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "да + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "да, долго"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "да, коротко"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "км/ч"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "м/с"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Обложка поиск"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "всегда"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / мин"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "всегда"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "On+Media+Standby"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Ожидать"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit -Цвет"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - серый/цветной"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x EPG"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x Немой"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Долгое нажатие EPG"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x  >>"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x >> Тип 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Долгое нажатие >>"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Долгое нажатие >> Тип 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x EPG"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x Немой"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Долгое нажатие EPG"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x <<"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2x << Тип 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Долгое нажатие <<"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Долгое нажатие << Тип 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15мин"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "да, продлен"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Konsole normal"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Logfile extensive"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Logfile normal"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "выключен"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Радио"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Радио+Медиа"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Радио+Медиа"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (полный)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "нормальный (полный)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "обрезается (черный)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "обрезается (прозрачный)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "Немой или определенные ключи"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "любой ключ"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Инфо"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Время +Информация"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Время +Продолжительность+Информация"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Время+Длинна+Инфо"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "левая половина"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "правая половина"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Фрейм x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "- Линия"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "нет бара"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "без рамки"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Нормальный"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Градиент"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Края тени"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Имя"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Нормальный"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Пикон+позиция ниже"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Пикон+позиция слева"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Пикон+позиция справа"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Позиция"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Имя"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Оффлайн"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Онлайн"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Онлайн+Оффлайн"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "использовать только таймер"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "использовать время"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "нет общего таймера"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "показать общий таймер"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "одна линия"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "две строки"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Доступная память"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Свободная память"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "во весь экран"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "да, за исключением записей"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "E"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "NE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "NNE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "NNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "NW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "SE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "SSE"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "SSW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "SW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "W"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "WNW"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "WSW"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Загрузить активный конфиг"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Загрузить умолчанию / пустой конфиг"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Сохранить конфиг в файл... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Загрузить Файл : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Удалить файл?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "удаленный"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "настоящее время установлен : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Выберите"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux Выключатель"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Меню"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Сохранить"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Рестарт дисплея"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Задавать На >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "нет LCD1 картинки-Файл"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "нет LCD2 картинки-Файл"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "нет LCD3 картинки-Файл"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux включен"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Тип"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 чередовать"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 Цвет фона"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 Фон-картинка [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Яркость"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Ночное сокращение"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 Обновить"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Тип"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 Чередовать"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 Цвет фона"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 Фон-Картинка [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Яркость"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Ночное сокращение"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 Обновить"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Тип"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 Чередовать"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 Цвет фона"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 Фон-Картинка [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Яркость"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Ночное сокращение"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 Обновить"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD размер"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Компенсировать"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD цвет"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD Enable On-Mode"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD включить медиа режим"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD Aktiviere Idle-Mode"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [Отображение времени]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- какой LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- Показать в режиме"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- Размер OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Фон/Прозрачность"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- Быстрый Grab низкого качества"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Всплывающий текст"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Очистить ключ"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- Размер шрифта"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- Позиция"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Выравнивание"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Цвет"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Цвет фона"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- Шрифт"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Активный экран"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Экран Выключатель Выбирать - Экран"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Экран по умолчанию после изменения режима - Экран"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Экран Выключатель Выбирать - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Экраны используется для изменения"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Экран 1-Изменить время"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- Экран 2 Изменение времени"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- Экран 3 Изменение времени"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- Экран 4 Изменение времени"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- Экран 5 Изменение времени"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- Экран 6 Изменение времени"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- Экран 7 Изменение времени"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- Экран 8 Изменение времени"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- Экран 9 Изменение времени"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Картина Изменение времени"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Картина Сортировка"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Картина каталог Рекурсивный"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Картина Качество для изменения размера"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Картина Время обновления [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Картина Тип [Только Картина]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Задний план-Картина Тип"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Weather"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Weather API-Key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Weather API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Погода-Город"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Погода-Город 2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Погода-Икона-Дорожка [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Погода-Икона зум"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Низкая температура(погода)-Цвет"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Высокая температура(погода)-Цвет"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Погода Прозрачность"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Погода Ветер скорость единицы измерения"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Линии информации о погоде и ветре"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Возможен дождь"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- Увеличение дождя"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- Цвет дождя"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- Rain use Color 2 from"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- Цвет дождя 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Погода-Город 2"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Погода-Линии"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "трендов стрелки погодных"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Погода-Экстра инфо"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Экстра увеличение"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- Показать разницу температур"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Дополнительные цвета городов"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Дополнительные цвета"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 мин Диапазон"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Максимум Диапазон"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "Погода URL"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Месяц-путь к иконкам[ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Запись Картина [ok]"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Double-button switches"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Клавиша изменения экрана"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Key for Screen On/Off"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall Путь изображения [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall Количество строк на вход"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall Количество записей в списке"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall Количество изображений"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall Ориентация изображения"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall Прозрачность изображения"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall Поиск картинок"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall Удалить звонок в нерабочее время"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall Выскакивать-Время"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall Выскакивать LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall Выскакивать окна"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall Рамка Картина [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Календарь ics-путь [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Календарь ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Календарь"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Календарь Суббота Цвет"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Календарь Воскресенье Цвет"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Календарь-толщина линий"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Календарь Дневное событие превью"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Календарь Коррекция часового пояса"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Календарь Прозрачность"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Календарь Интервал опроса"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Цвет тюнера"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Цвет активного тюнера"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Цвет тюнера"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Поиск услуги в первую очередь"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T Сигнал Качество Исправление"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Zeichensatz Global [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Шрифт 1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Шрифт 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Шрифт 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Шрифт 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Шрифт 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Почта 1 подключить"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Почта 1 Сервер"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Почта 1 Имя пользователя"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Почта 1 - пароль"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Почта 2 подключить"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Почта 2 Сервер"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Почта 2 Имя пользователя"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Почта 2 - пароль"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Почта 3 подключить"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Почта 3 Сервер"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Почта 3 Имя пользователя"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Почта 3 - пароль"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Почта 4 подключить"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Почта 4 Сервер"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Почта 4 Имя пользователя"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Почта 4 - пароль"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Почта 5 подключить"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Почта 5 Сервер"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Почта 5 Имя пользователя"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Почта 5 - пароль"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Почта Интервал опроса"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Почта IMAP предел до последних дней"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Почта-Показывать пустые почтовые ящики"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Почта показать Дата"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Почта Спрятать Почтовый адрес"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Удаленный ящик 1 [Показать имя] IP/Имя"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Удаленный ящик 2 [Показать имя]IP/Имя"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Удаленный ящик 3 [Показать имя]IP/Имя"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Удаленный ящик 4 [Показать имя]IP/Имя"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Удаленный ящик 5 [Показать имя]IP/Имя"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Удаленный ящик Опрашивайте каждую минуту"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Удаленный ящик Таймер [Показать имя]IP/Имя"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Удаленный ящик Таймер Опрашивайте каждую минуту"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Converter Poll Interval"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW Конвертер использование"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey из cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey из convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF обновление [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF тип обновления"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Инициализировать Задерживать"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP Отрицать"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF Дизайн"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Сохранить как рисунок для WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG Ручей LCD 1 включить"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Ручей LCD 1 Порт"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG Ручей LCD 1 виртуальная яркость"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG Ручей LCD 2 включить"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Ручей LCD 2 Порт"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Ручей LCD 2 виртуальная яркость"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG Ручей LCD 3 включить"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Ручей LCD 3 Порт"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG Ручей LCD 3 виртуальная яркость"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG Цикл"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Перезагрузить при ошибке"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG Режим заголовка"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Показать потоки '4097; 5001...5003' в режиме"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Ping Тайм-аут [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos играть Проверять"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Обновить [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping Тайм-аут [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound играть Проверять"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Обновить [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Сервер IP [по желанию]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Ping Тайм-аут [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast играть Проверять"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Обновить [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Обложка"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD Своя Ширина"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD Своя высота"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD Своя Ширина 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD Своя высота 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD выключен при выключении"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Выбор времени! calc all Times to Time/5*2 in Fastmode"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Задержка [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Threads pro LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Показать Крушение Угол"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Показать 'нет...' Сообщения"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Хранение-Устройство: Принудит Чтение"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Хранение-Устройство: Цвет Задний план"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Хранение-Устройство: Цвет Бар"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Хранение-Устройство: Цвет Полный"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Проверка сети активна"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Выключатель Кадровый буфер [если возможно]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Конфиг Путь к резервному копированию[ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Конфиг Восстановить все настройки"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Debug-Logging > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Выключение подсветки [Off = On]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Включение подсветки"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Подсвечивать выходные [для отключения установить Off = On]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Hintergrundbeleuchtung Wochenende Ein"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Автоматическое отключение"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Задний план"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "Картина [ok]"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Размер пиконов"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- Разделение экрана"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- На весь экран"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- Размер текста"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- Прозрачность"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Путь к пиконам [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Путь к пиконам 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache путь [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Пикон 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Часы"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Тип"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Аналоговые часы"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- Растояние"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- Размер"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- Теневые грани"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Часы 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Название передачи"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- маскимум линий"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- Длина"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Номер канала"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Инфо о програме"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Тип"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Инфо о програме 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Инфо о следующей программе"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Расширенное описание"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- использовать информацию, когда она пуста"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Прогресс бар"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Цвет Текст"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Цветной фон"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Граница"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- Затенить"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- единица измерения мин"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Информация"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Инфо о тюнере"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- Сенсор"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Информация 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Уровень сигнала"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- Градиент"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- Бар диапазон мин"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- Бар диапазон макс"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Спутник"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Провайдер"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Используемый тюнер"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- только активный тюнер"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Следующее событие таймера"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Громкость"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Немой"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Аудио/Видео"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Онлайн [Пинг]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- Показать состояние"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- Тайм-аут [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- Ник:адрес"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Внешний IP-адрес"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- внешний IP URL"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Хранение-Устройство"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- бесплатно предупреждение"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- экстра инфо"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- Имя устройства"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- Увеличение"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- Тип погоды"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Погода 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Погода-Источник"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Станция"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Модуль"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Модуль определяемые пользователем"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "Основание"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Имя"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Цвет 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Цвет 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Цвет 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Цвет 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Цвет 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Цвет 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Индикатор"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- Длина [Бар]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Комфорт Индикатор"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Фазы Луны"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Информационные строки"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- стрелки тренда"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Восход солнца"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Показать oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- Файл [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Показать ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Показать текст файл"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Показать текст файл 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Показать текст файл 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Показать HTTP текст"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW-Internet Converter"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP Ширина"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP Высота"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- Вырезать из X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- Вырезать из Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- Обрезать по ширине [выкл. = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- Обрезать по высоте [выкл. = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Показать картинку"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- Файл или путь [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- Высота макс"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- Быстрое обновление"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Показать картинку 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Показать картинку 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Показать картинку 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Показать картинку 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Показать картинку 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- Линий"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- Учетная запись почты"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- ширина макс"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Удаленный ящик v"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- Размер картинки"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "-Позиция изображения"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- Выравнивание изображения"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- Макет"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Цвет фона текущего дня"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- Название цвета"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Список дат"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Event Icon Bar"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- Popup Screen"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- Popup LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Показать текст 1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Текст"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Показать текст 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Прямоугольник 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- Позиция по оси x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- Позиция по оси y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- Размер по оси x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- Размер по оси y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Прямоугольник 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Запись"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Заикание TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "Функция используется для изменения экранов"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Заголовок"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Узнайте больше"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Показать обложку"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- Поиск пути [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Найти Обложка Файл [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- По умолчанию обложка [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- Первый пикон"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Обрезанный"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Скачать обложку"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Скачать Тип"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "Google API-Key console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Дисплей"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux режим отображения На"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Задавать СМИ >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux режим отображения Медиа плеер"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Задавать Праздный  >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux режим отображения праздный"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Задавать Глобальный >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Выберите каталог"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Выберите файл"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Выберите шрифт"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - Текущее значение: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5257,99 +4129,94 @@ msgstr ""
 "GUI должен быть перезапущен для активации изменений.\n"
 "Сделать это сейчас?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Перегрузить GUI сейчас?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "В помещении"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Открытый"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Дождь"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Ветер"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Новолуние"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Первая четверть"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Растущий серп"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Растущая Луна"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Полнолуние"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Убывающая Луна"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Убывающая Луна"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Последняя четверть"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Картина недоступен"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "нет таймера"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAMне запущен"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "нет звонки"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Почта  %d Новая  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "netatmo-Plugin не установлен"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux Экран Выключатель"

--- a/LCD4linux/po/sk.po
+++ b/LCD4linux/po/sk.po
@@ -2,16 +2,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 11:00+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:36+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,-1,-1,-1,-1,747\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -65,47 +66,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "Obrazovka"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "MusicCast"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Počasie"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "Pošta"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "Vzdialený Box"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Kalendár"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP povoľ"
 
@@ -113,8 +102,7 @@ msgstr "WebIF IP povoľ"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "Žiadny alebo nesprávny zvolený súbor, skús najprv správny súbor !"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Režim"
 
@@ -130,7 +118,7 @@ msgstr "Chybový výpis"
 msgid "Show"
 msgstr "Zobraziť"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Zmazať"
 
@@ -162,35 +150,24 @@ msgstr "Ulož cfg"
 msgid "stop Screencycle"
 msgstr "zastav výmenu obrazoviek"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "Celkovo"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "Zapnuté"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "Média"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "Nečinný"
 
@@ -238,253 +215,299 @@ msgstr "Zoznam úložných zariadení"
 msgid "Parent Directory"
 msgstr "Nadradený adresár"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "Pi"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "Po"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "So"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "Ne"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "Št"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "Ut"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "St"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "čierna"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "biela"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "šedá"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "strieborná"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "bridlicovo sivá"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "akvamarín"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "zlatá"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "zelenožltá"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "žltá"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "tmavooranžová"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "tmavočervená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "indiánska červená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "oranžová"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "oranžovočervená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "červená"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "paradajková"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "tmavozelená"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "zelená"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "zelený trávnik"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "svetlosvetlozelená"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "limetka"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "modrofialová"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "kadet modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "nevädza modrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "tmavomodrá"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "indigo"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "svetlosvetlomodrá"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "svetlomodrá"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "tmavá orchidea"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "tmavoružová"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "purpurová"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "fialová"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "hnedá"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "mokasín"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "olivová"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "ružovohnedá"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "pieskovohnedá"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "Obrazovka 1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "Obrazovka 1+2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "Obrazovka 1+2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "Obrazovka 1+2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "Obrazovka 1+2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "Obrazovka 1+3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "Obrazovka 1+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "Obrazovka 1+3+5+7+9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "Obrazovka 1+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "Obrazovka 2+3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "Obrazovka 2+3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "Obrazovka 2+4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "Obrazovka 2+4+6+8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "Obrazovka 3+4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "Obrazovka 5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "Obrazovka 5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Obrazovka 1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Obrazovka 1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Obrazovka 1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Obrazovka 1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Obrazovka 1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "Obrazovka 1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Obrazovka 2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Obrazovka 3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Obrazovka 4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Obrazovka 5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Obrazovka 6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Obrazovka 7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Obrazovka 8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Obrazovka 9"
 
@@ -506,1312 +529,1131 @@ msgstr "Obrazovka 9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "vypnuté"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "Obrazovka 1+2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "Obrazovka 1+2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "Obrazovka 1+2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "Obrazovka 1+2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "Obrazovka 1+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "Obrazovka 1+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "Obrazovka 1+3+5+7+9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "Obrazovka 1+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "Obrazovka 2+3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "Obrazovka 2+3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "Obrazovka 2+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "Obrazovka 2+4+6+8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "Obrazovka 3+4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "Obrazovka 5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "Obrazovka 5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Obrazovka 1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Obrazovka 1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Obrazovka 1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "zapnuté"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2h"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3h"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3min"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4min"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5h"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5s"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2min"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30s"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10min"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5min"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20min"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30min"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60min"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10min"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4min"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5h"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5s"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "Pearl (alebo kompatibilné LCD) 480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "Pearl (eller kompatibel LCD) 800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (alebo kompatibilné LCD) 240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (alebo kompatibilné LCD) 320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H alt 800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H alt 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Zabudovaný Box-Skin-LCD"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Zabudovaný TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "len obrázok 1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "len obrázok 320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "len obrázok 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "len obrázok 800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "len obrázok vlastná veľkosť"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "len obrázok vlastná veľkosť 2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "Zabudovaný Vu+ Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "Aktuálny"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2 dni 1 riadok"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2 dni 2 riadky"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4 dni 1 riadok"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4 dni 2 riadky"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4 dni zvislý pohľad"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5 dní 1 riadok"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5 dní 2 riadky"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5 dní zvislý pohľad"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "Aaktuálna teplota (+C)"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Aktuálna teplota (-C)"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "Aktuálny"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Aktuálna teplota"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Všetko"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Teplota"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "Teplota+Co2"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "Teplota+Co2+Tlak"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Teplota+Vlhkosť"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modul 1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Modul 1+2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Modul 1+2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Modul 1+2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Modul 1+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Modul 1+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Modul 1+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Modul 1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Modul 1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Modul 1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modul 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Modul 2+3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Modul 2+3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Modul 2+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Modul 2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modul 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Modul 3+4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Modul 3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modul 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Modul 4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modul 5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Modul 5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Modul 6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "definované užívateľom"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "Stĺpec"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "Stĺpec+hodnota"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "Tlačidlo"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "Tlačidlo+hodnota"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "Analógové"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "Analógové+dátum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "Analógové+dátum+deň týždňa"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "Analógové+dátum+deň týždňa 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Dátum"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Dátum+čas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Dátum+čas+deň týždňa"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "Dátum návrhu klapiek"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "Návrh klapiek vo všedný deň"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Čas"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Čas+Deň týždňa"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Deň týždňa"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "vycentrovať"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "ľavý"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "vpravo"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "vycentrovať"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Rozšírený"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "Rozšírený (menej info)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Krátky"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "Krátky(rozširený)"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "Krátky+rozšírený"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Mesiac"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "Mesiac+hlavička"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Týždeň"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "Týždeň+Hlavička"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "žiaden kalendár"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "žiadne termíny"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "Dátum 1 riadok"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "Dátum 3 riadky"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "Dátum 5 riadkov"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "Dátum 9 riadkov"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "Kompaktné dátumy 2 riadky"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "Kompaktné dátumy 3 riadky"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "Rámček"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "žiadne termíny"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "Podčiarknutie"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "Podčiarknutie 2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "Rámček"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "Dátumy"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "Kompaktné dátumy"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "Kompaktné dátumy bez ikon"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "Dátumy bez ikon"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "žiadna ikona"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "žiadna ikona, s cieľovým počtom"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "s ikonou"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "s ikonou & cieľové číslo"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C + otáčky"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + otáčky/2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "otáčky"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "otáčky/2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "nie"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C + otáčky"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + otáčky/2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "otáčky"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "otáčky/2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "% + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "db"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "db + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "db + % + BER"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "db + BER"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + Load@5min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "Load@1min"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "Load@5min"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "zobraz aktívne"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "zobraz aktívne+čakajúce"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "Vždy všetko"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "Vždy nové"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "Len nové"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "Všetky Informácie"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "Len Vzdialenosť"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "Vzdialenosť+Osvetlenie"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "Vzdialenosť+Fáza mesiaca"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "Len Osvetlenie"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "Osvetlenie+Fáza mesačná"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "Len Fáza Mesiaca"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "Picon"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "Kanál"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "Kanál+titulok"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon+kanál"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon+kanál+titulok"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "Picon"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "rovnaká farba"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "prozorno"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "áno"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "áno +25%"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "vodorovne"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "áno"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "zvislo"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "vodorovne"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "všetko"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "Roh"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "Roh + časový posun"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon+Časový posun"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "len stĺpec priebehu"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "a zostávajúce minúty"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "a zostávajúce minúty (veľkosť 1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "a zostávajúce minúty (veľkosť 2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "a percenta"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "a percenta (veľkosť 1.5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "a percenta (veľkosť 2)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "a zostávajúce minúty (nad)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "a zostávajúce minúty (nad/veľkosť 1.5)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "a zostávajúce minúty (nad/veľkosť 2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "s percentami (nad)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "s percentami (nad/veľkosť 1.5)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "s percentami (nad/veľkosť 2)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "a zostávajúce minúty (pod)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "a zostávajúce minúty (pod/veľkosť 1.5)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "a zostávajúce minúty (pod/veľkosť 2)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "s percentami (pod)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "s percentami (pod/veľkosť 1.5)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "s percentami (nad/veľkosť 2)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "s aktuálnym 00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "s aktuálnym 00:00 (veľkosť 1.5)"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "s aktuálnym 00:00 (veľkosť 2)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "s aktuálnym 00:00 (nad)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "s aktuálnym 00:00 (nad/veľkosť 1.5)"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "s aktuálnym 00:00 (nad/veľkosť 2)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "s aktuálnym 00:00 (pod)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "s aktuálnym 00:00 (pod/veľkosť 1.5)"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "s aktuálnym 00:00 (pod/veľkosť 2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "s percentami minút / Celkovo (nad)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "s percentami minút / Celkovo (nad/veľkosť 1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "s percentami minút / Celkovo (nad/veľkosť 2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "s absolútnym časom konca"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "s absolútnym časom konca (veľkosť 1.5)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "s absolútnym časom konca (veľkosť 2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "s celkovým počtom minút / konečným časom (vyššie)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "s celkovým počtom minút / konečným časom (vyššie / veľkosť 1,5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "s celkovým počtom minút / konečným časom (vyššie / veľkosť 2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Rýchly mód (2s)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normalne (5s)"
 
@@ -1819,3437 +1661,2467 @@ msgstr "Normalne (5s)"
 msgid "last Screen"
 msgstr "posledná obrazovka"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "abecedne"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "náhodne"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "lepší/pomalší"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "pomaly/rýchlo (len obrázok)"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "pomaly/rýchlo (všetko)"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "cache + prispôsobenie(vysoká kvalita, pomalšie)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "cache + prispôsobenie(nízka kvalita, rýchlejšie)"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "bez cache + bez nastavovania"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "Zabudovaný tuner"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB Tuner"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Teraz/Ďalší"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normálne"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "redukované"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "Auto"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Javascript"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Javascript nie Obnoviť"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "Znovu nahratie"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normálne"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2 - bok po boku"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "alternatívny Mód kopírovania/DM800hd (24bit)"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "áno + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "áno, dlhé"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "áno, krátke"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "km/h"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "m/s"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "Coversearch"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "vždy"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / min"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "vždy"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "Zapnuté+Média+Pohotovostný režim"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "Pohotovostný režim"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - farba"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8bit - čb/farba"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 x Info tlačidlo"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x stlmiť zvuk"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "Dlhé tlačidlo info"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x rýchlo vred tlačidlo"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x rýchlo vred tlačidlo typ 2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "Dlhé tlačidlo rýchlovpred"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "Dlhé tlačidlo rýchlovpred typ 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 x Info tlačidlo"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x stlmiť zvuk"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "Dlhé tlačidlo info"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 x rýchlospäť tlačidlo"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x Rýchlo späť tlačítko Typ 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "Dlhé tlačidlo rýchlospäť"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "Dlhé Rýchlo späť tlačítko Typ 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15min"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "áno, rozšírené"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "Bežná konzola"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "Rozsiahly log súbor"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "Normálny log súbor"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "zakázané"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "TV"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Rádio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Rádio+Média"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Rádio"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Rádio+Média"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "TV"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "TV (plný)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "normálne (plné)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "zdobené (čierna)"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "zdobené (priehľadné)"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "ZTLM alebo definuj kľúče"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "ľubovoľnú klávesu"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "Čas+Info"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "Čas+Trvanie+Info"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "Mini-EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "Čas+Dĺžka+Info"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "polovica vľavo"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "polovica vpravo"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "Rámček x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "Riadok"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "žiadny bar"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "žiadny Rámček"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "Normalne"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "Spád"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "Hrany tieňa"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "Meno"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "Normalne"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+Pozícia pod"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "Picon+Pozícia vľavo"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "Picon+Pozícia vpravo"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "Umiestnenie"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "Meno"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "Vypnuté"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "Aktívný"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "Aktívný+Neaktívny"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "len použitý časovač"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "použiť čas dodania"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "žiaden celkový časovač"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "zobraz celkový časovač"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "jeden riadok"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "dva riadky"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "Dostupná pamäť"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "Voľná pamäť"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "na celú obrazovku"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "áno okrem nahrávok"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "V"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "VSV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "VJV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "S"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "SV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "SSV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "SSZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "SZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "J"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "JV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "JJV"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "JJZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "JZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "Z"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "ZSZ"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "ZJZ"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%d.%m.%Y - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%d-%b-%Y"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "Nahraj aktívny konfig. súbor"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "Načítať predvolené hodnoty / Prázdna konfigurácia"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "Uložiť konfig do súboru... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Nahraj súbor : %s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Zmazať súbor?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "zmazané"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "aktuálne nastavené : %s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "Vyberte"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux nastavenie"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "Ponuka"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Uložiť"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "Reštart zobrazovačov"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "Nastaviť On >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "žiadne LCD1 Obrazkové data"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "žiadne LCD2 Obrazkové data"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "žiadne LCD3 Obrazkové data"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "LCD4linux povolené"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1 Typ"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1 otočiť"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 farba pozadia"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 obrázok pozadia [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 Jas"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1 Nočná redukcia"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1 obnova"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2 Typ"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2 otočiť"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 farba pozadia"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 obrázok pozadia [ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 Jas"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2 Nočná redukcia"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2 obnova"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3 Typ"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3 otočiť"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 farba pozadia"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 obrázok pozadia [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 Jas"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3 Nočná redukcia"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3 obnova"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "Box-Skin-LCD rozmery"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Ofset"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "Box-Skin-LCD Farba"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD povoliť zap. mód"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD povoliť média mód"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD povoliť čakací mód"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [čas zobrazenia]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- ktoré LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- zobraz v móde"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- veľkosť OSD"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- Pozadie/Priehľadnosť"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- rýchly snímok nízkej kvality"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "Vyskakovací text"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- Vymazať kľúč"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- veľkosť písma"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- umiestnenie"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- Zarovnanie"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- Farba"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- Farba pozadia"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- písmo"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "Aktívna obrazovka"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "Výber prepínača obrazovky - Obrazovka"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "Predvolená obrazovka po zmene režimu - obrazovka"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "Výber prepínača obrazovky - LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "Obrazovky použité na výmenu"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "Obrazovka 1 čas zmeny"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- čas zmeny obrazovky 2"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- čas zmeny obrazovky 3"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- čas zmeny obrazovky 4"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- čas zmeny obrazovky 5"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- čas zmeny obrazovky 6"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- čas zmeny obrazovky 7"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- čas zmeny obrazovky 8"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- čas zmeny obrazovky 9"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "Obrázok čas zmeny"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "Zoradenie obrázkov"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "Obrázok rekurzívny priečinok"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "Kvalita obrázka na zmenu veľkosti"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "Obrázok čas rychlej aktualizácie [s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "Typ obrázka [len obrázok]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "Typ obrázka pozadia"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "Počasie - výber providera"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "Počasie API-key OpenWeatherMap"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "Počasie API-ID Key WeatherUnlocked"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "Počasie MSN (pre Mesto 1)"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "Počasie MSN (pre Mesto 2)"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "Počasie-Ikona-Cesta [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "Počasie-Ikona zväčšenie"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "Počasie farba nízkej  (mínusovej) teploty"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "Počasie farba vysokej (plusovej) teploty"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "Počasie priehľadnosť"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "Počasie jednotky rýchlosti vetra"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "Počasie smer a rýchlosť vetra"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "Počasie pravdepodobnosť dažďa"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- zväčšenie dažďa"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- farba dažďa"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- dážď používa farbu 2 z"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- farba dažďa 2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "Väder Luftfuktighet Färg"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "Počasie riadky"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "Počasie sípky trendov"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "Počasie rozšírené info"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- Extra zväčšenie"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- zobraz teplotu ochladenia ak je rozdiel"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- Extra farba mesta"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- Extra farba ochladenia"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2 Min rozsah"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2 Max rozsah"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "URL počasia"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "Cesta k ikone mesiaca [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "Obrázok záznamu [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "Zmena dvoj-stlačením tlačidla"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "Kľúč na zmenu obrazovky"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "Klávesa pre zapnutie / vypnutie obrazovky"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall cesta k obrázkom [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall počet riadkov na vstupny údaj"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall počet položiek zoznamu"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall počet obrázkov"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall orientácia obrázka"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall priehľadnosť obrázka"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall vyhľadávanie obrázkov"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall odobrať volania po hodinách"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall čas vyskakovaieho okna"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall vyskakovací LCD"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall farba vyskakovacieho okna"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall obrázok rámčeka [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "Kalendár ics-cesta [ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "Kalendár ics-URL"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "Kalendár plánovač"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "Kalendár farba soboty"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "Kalendár farba nedele"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "Kalendár hrúbka čiary"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "Kalendár denny prehľad"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "Kalendár korekcia časovej zóny"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "Kalendár priehľadnosť"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "Kalendár čas obnovy"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "Ladička Farba"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "Ladička Farba Aktívny"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "Ladička Farba Zapnúť"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "Najprv prehľadať kanál"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T korekcia kvality signálu"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "Písmo celkovo [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "Písmo1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "Písmo 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "Písmo 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "Font 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "Font 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "Pošta 1 pripojenie"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "Pošta 1 server"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "Pošta 1 [Zobrazované meno:]Meno používateľa"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "Pošta 1 heslo"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "Pošta 2 pripojenie"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "Pošta 2 server"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "Pošta 2 [Zobrazované meno:]Meno používateľa"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "Pošta 2 heslo"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "Pošta 3 pripojenie"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "Pošta 3 server"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "Pošta 3 [Zobrazované meno:]Meno používateľa"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "Pošta 3 heslo"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "Pošta 4 pripojenie"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "Pošta 4 server"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "Pošta 4 [Zobrazované meno:]Meno používateľa"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "Pošta 4 heslo"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "Pošta 5 pripojenie"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "Pošta 5 server"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "Pošta 5 [Zobrazované meno:]Meno používateľa"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "Pošta 5 heslo"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "Pošta obnovovací interval"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "Pošta IMAP limit na posledné dni"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "Pošta zobraz prázdne kontá"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "Pošta zobraz dátum"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "Pošta skryť adresy"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "Vzdialený Box 1 [zobrazované meno:]IP/Meno"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Vzdialený Box 2 [zobrazované meno:]IP/Meno"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "Vzdialený Box 3 [zobrazované meno:]IP/Meno"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Vzdialený Box 4 [zobrazované meno:]IP/Meno"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Vzdialený Box 5 [zobrazované meno:]IP/Meno"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "Vzdialený Box obnova v minútach"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "Vzdialený Box 1 [zobrazované meno:]IP/Meno"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "Vzdialený Box obnova v minútach"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW Konvertor čas obnovy"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "Použiť WWW konvertor"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "WWW ApiKey z cloudconvert.org"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "WWW ApiKey z convertapi.com"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF aktualizácia [s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF typ aktualizácie"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF Inicializácia oneskorenie"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP zakáž"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF vzhľad"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "Uložiť ako obrázok pre WebIF"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG stream pre LCD 1 povoliť"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG Stream LCD 1 porty"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG stream pre LCD 1 Virtuálny jas"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG stream pre LCD 2 povoliť"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG Stream LCD 2 porty"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG stream pre LCD 2 Virtuálny jas"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG stream pre LCD 3 povoliť"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG Stream LCD 3 porty"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG stream pre LCD 2 Virtuálny jas"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG cyklus"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "MJPEG Reštartujte pri chybe"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG režim hlavičky"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Zobraziť streamy '4097; 5001...5003' v režime"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "Sonos Časový limit ping [ms]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "Sonos Prehrať šek"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "Sonos Obnoviť [s]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Časový limit ping [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound Prehrať šek"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound Obnoviť [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "MusicCast IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast Server IP [optional]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "MusicCast Časový limit ping [ms]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast Prehrať šek"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast Obnoviť [s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "MusicCast Obal"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD voliteľná šírka"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD voliteľná výška"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD voliteľná šírka 2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD voliteľná výška 2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "LCD Vypnuté pri vypnutí"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "Časovanie ! vypočet všetkých časov na Čas/5*2 v rýchlom móde"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "Oneskorenie zobrazovača [ms]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "Témy pre LCD"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "Zobraz chybové hlásenia"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "Zobraz 'žiadne ....' hlásenia"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "Úložné zariadenia: Vynútiť čítanie"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "Úložné zariadenia: Farba späť"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "Úložné zariadenia: Farebná lišta"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "Úložné zariadenia: Farba plná"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "Kontrola siete aktívna"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "Prepnúť FrameBuffer [ak je to možné]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "Cesta zálohy konfig. [ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "Konfigurácia obnova všetkých nastavení"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "Logovanie > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- Podsvietenie vyp. [ Zap.=Vyp.]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- Podsvietenie zap"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- Podsvietenie cez víkend vyp. [ Zap.=Vyp.]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- Podsvietenie cez víkend zap"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD Automatické vypnutie"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "Pozadie"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- Obrázok [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon veľkosť"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- rozdelená obrazovka"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- celá obrazovka"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- veľkosť textu"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- priehľadnosť"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon cesta [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon cesta 2 [ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon Cache cesta [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Hodiny"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  Typ"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- Analogové Hodiny"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- rozstup"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- veľkosť"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- hrany tieňa"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Hodiny 2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "Názov kanálu"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- maximum riadkov"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- dĺžka"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "Číslo kanálu"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "Info o programe"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- Typ"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "Program Info 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "Info o ďalšom programe"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "Rozšírený popis"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- prázdne použite informáciu"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "Priebeh"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- Farebný text"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- Barva ozadja"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- Okraj"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- tieňované"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- Jednotka min"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "Informácie"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- Tuner nfo"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- snímače"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- CPU"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "Informácie 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "Stĺpec kvality signálu"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- spád"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- rozsah stĺpca kvality signálu na Min"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- rozsah stĺpca kvality signálu na Max"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Satelit"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Poskytovateľ"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "Použitý tuner"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- len aktívny tuner"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "Ďalší časovač udalostí"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "Hlasitosť"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "Stíšiť"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "Audio/Video"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "Stav siete [Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- zobraz stav"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- čas vypršania [ms]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- sieťové meno :Adresa"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "Externá adresa IP"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- externá adresa URL IP"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Pamäťové-zariadenia"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- bez varovania"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- extra Info"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- meno zariadenia"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- zväčšenie"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- typ počasia"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Počasie 2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "Meteo stanica"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- Stanica"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- Modul"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- Definovaný používateľom"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- Základ"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- Meno"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- Farba 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- Farba 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- Farba 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- Farba 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- Farba 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Farba 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2 Indikátor"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- dĺžka [Bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo Komfortný Indikátor"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "Fáza mesiaca"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- Informačné linky"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- Šípky trendov"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "Východ slnka"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "Zobraz oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- súbor [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "Zobraz ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "Zobraz textový súbor"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "Zobraz textový súbor 2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "Zobraz textový súbor 3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "Zobraz HTTP Text"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "Konvertor web stránok"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP šírka"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP výška"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- orezanie z X"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- orezanie z Y"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- šírka orezania [vyp. = 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- výška orezania [vyp. = 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "Zobraz obrázok"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- súbor alebo cesta [ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- max výška"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- rýchla aktualizácia"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "Zobraz obrázok 2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "Zobraz obrázok 3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "Zobraz obrázok 4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "Zobraz obrázok 5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "Zobraz obrázok 6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- riadky"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- e-mailové konto"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- max šírka"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "Vzdialený Box"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- veľkosť obrázka"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- umiestnenie obrázka"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- zarovnanie obrázka"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- rozmiestnenie"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- Farba pozadia aktuálneho dňa"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- farba titulku"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "Zoznam dátumov"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "Stĺpec ikon udalosti"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- vyskakovacia obrazovka"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- vyskakovacie LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "Zobraziť text  1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- Text"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "Zobraziť text 2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "Obdĺžnik 1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- pozícia x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- pozícia y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- veľkosť x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- veľkosť y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "Obdĺžnik 2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "Záznam"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "Zobraz - zrkadlenie TV"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- použité obrazovky na výmenu"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "Titulok"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "Informácie"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "Zobraz obálku"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- prehľadávaná cesta [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- Nájdite súbor obalu  [ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- predvolená obálka [ok]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- najprv Picon"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- Orezané"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- Stiahnite si obálku"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- Typ sťahovania"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "- Kľúč Google API console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "LCD Displej"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux Režim zobrazenia je Mode on"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "Nastaviť Media >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux Režim zobrazenia MediaPlayer"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "Nastaviť Idle >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux Režim zobrazenia Idle"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "Nastaviť Global >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "Zvoľ priečinok"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "Zvoľ súbor"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Zvoľ písmo"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s -Súčasná hodnota: %s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5257,114 +4129,94 @@ msgstr ""
 "Je potrebné reštartovať GUI aby sa aplikovali zmeny.\n"
 "Chceš restartovať GUI teraz?"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "Reštartovať GUI teraz?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "Vnútorné"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "Vonkajšie"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "Dážď"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "Vietor"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Nový mesiac"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Prvá štvrtina"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "Dorastajúci kosáčik"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "Dorastajúci mesiac"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "Spln mesiaca"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "Ubúdajúci mesiac"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "Ubúdajúci kosáčik"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Posledná štvrtina"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%d.%m.%Y"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "Obrázok nie je k dispozícii"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "žiaden časovač"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM nebeží"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "žiadne volania"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d Správ  %d Nové  %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "nenainštalovaný Netatmo-Plugin"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux povolený"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4Linux povolený"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "Prepínač obrazovky LCD4linux"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "áno (32bit)"
-
-#~ msgid "arrow + text"
-#~ msgstr "šípka + text"
-
-#~ msgid "only arrow"
-#~ msgstr "iba šípka"
-
-#~ msgid "only text"
-#~ msgstr "iba text"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "Počasie Smer vetra"

--- a/LCD4linux/po/tr.po
+++ b/LCD4linux/po/tr.po
@@ -2,216 +2,217 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-27 17:01+0100\n"
-"PO-Revision-Date: 2025-01-27 17:24+0100\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:36+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: \n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "BlueSound"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 #, fuzzy
 #| msgid "Box-Skin-LCD Offset"
 msgid "Box-Skin-LCD"
 msgstr "Box-Skin-LCD Telafi etmek"
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "Font"
 msgstr "Yazı tipi"
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "Key"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "MJPEG Stream"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 #, fuzzy
 #| msgid "TV+OSD"
 msgid "OSD"
 msgstr "TV+OSD"
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "Picture"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "Popup-Text"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "Sonos"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "Tuner"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "WWW Converter"
 msgstr ""
 
-#: ..\WebConfigSite.py:28
+#: ..\WebConfigSite.py:34
 msgid "WebIF"
 msgstr ""
 
-#: ..\WebConfigSite.py:28 ..\WebConfigSite.py:557
+#: ..\WebConfigSite.py:34 ..\WebConfigSite.py:534
 msgid "Screen"
 msgstr "Ekran"
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:488
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr ""
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:6275 ..\plugin.py:6970 ..\plugin.py:7478
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "Hava durumu"
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:6306 ..\plugin.py:7001 ..\plugin.py:7509
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr ""
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:6533 ..\plugin.py:7160 ..\plugin.py:7726
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr ""
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:6548 ..\plugin.py:7175 ..\plugin.py:7741
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr ""
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:6576 ..\plugin.py:7203 ..\plugin.py:7769
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr ""
 
-#: ..\WebConfigSite.py:28 ..\plugin.py:6590 ..\plugin.py:7217 ..\plugin.py:7783
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "Takvim"
 
-#: ..\WebConfigSite.py:192 ..\plugin.py:5883
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr ""
 
-#: ..\WebConfigSite.py:260
+#: ..\WebConfigSite.py:240
 msgid "No or wrong File selected, try a correct File first !"
 msgstr ""
 
-#: ..\WebConfigSite.py:525 ..\WebConfigSite.py:568 ..\plugin.py:5511
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "Mod"
 
-#: ..\WebConfigSite.py:527
+#: ..\WebConfigSite.py:504
 msgid "IP seurity not supported by Box"
 msgstr ""
 
-#: ..\WebConfigSite.py:542
+#: ..\WebConfigSite.py:519
 msgid "Crashlog"
 msgstr ""
 
-#: ..\WebConfigSite.py:544
+#: ..\WebConfigSite.py:521
 msgid "Show"
 msgstr "Göster"
 
-#: ..\WebConfigSite.py:545
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "Sil"
 
-#: ..\WebConfigSite.py:549
+#: ..\WebConfigSite.py:526
 msgid "Filename"
 msgstr "Dosya adı"
 
-#: ..\WebConfigSite.py:550
+#: ..\WebConfigSite.py:527
 msgid "Restore Config"
 msgstr ""
 
-#: ..\WebConfigSite.py:551
+#: ..\WebConfigSite.py:528
 msgid "Backup Config"
 msgstr ""
 
-#: ..\WebConfigSite.py:553
+#: ..\WebConfigSite.py:530
 #, fuzzy
 #| msgid "Delete File?"
 msgid "Delete Logfile"
 msgstr "Dosya silinsin mi ?"
 
-#: ..\WebConfigSite.py:554
+#: ..\WebConfigSite.py:531
 #, fuzzy
 #| msgid "- Download Cover"
 msgid "Download Logfile"
 msgstr "- İndirmek Örtmek"
 
-#: ..\WebConfigSite.py:555
+#: ..\WebConfigSite.py:532
 msgid "Save Config"
 msgstr ""
 
-#: ..\WebConfigSite.py:563
+#: ..\WebConfigSite.py:540
 msgid "stop Screencycle"
 msgstr ""
 
-#: ..\WebConfigSite.py:569 ..\plugin.py:353 ..\plugin.py:5549 ..\plugin.py:5692
-#: ..\plugin.py:7881 ..\plugin.py:7897
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr ""
 
-#: ..\WebConfigSite.py:570 ..\plugin.py:437 ..\plugin.py:507 ..\plugin.py:5540
-#: ..\plugin.py:5935 ..\plugin.py:7882 ..\plugin.py:7886
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr ""
 
-#: ..\WebConfigSite.py:571 ..\plugin.py:437 ..\plugin.py:507 ..\plugin.py:632
-#: ..\plugin.py:5543 ..\plugin.py:6684 ..\plugin.py:7887 ..\plugin.py:7891
-#: ..\plugin.py:8100
+#: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr ""
 
-#: ..\WebConfigSite.py:572 ..\plugin.py:5546 ..\plugin.py:5567
-#: ..\plugin.py:7307 ..\plugin.py:7892 ..\plugin.py:7896 ..\plugin.py:8098
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr ""
 
-#: ..\WebConfigSite.py:574
+#: ..\WebConfigSite.py:551
 msgid "GUI Restart is required"
 msgstr "Sistemin yeniden başlatılması gerekiyor"
 
-#: ..\WebConfigSite.py:596
+#: ..\WebConfigSite.py:573
 msgid "Element"
 msgstr "Eleman"
 
-#: ..\WebConfigSite.py:624 ..\WebConfigSite.py:625
+#: ..\WebConfigSite.py:601 ..\WebConfigSite.py:602
 #, fuzzy
 #| msgid "Weather"
 msgid "other"
 msgstr "Hava durumu"
 
-#: ..\WebConfigSite.py:711 ..\WebConfigSite.py:725
+#: ..\WebConfigSite.py:687 ..\WebConfigSite.py:701
 msgid "set Settings"
 msgstr ""
 
-#: ..\WebConfigSite.py:714
+#: ..\WebConfigSite.py:690
 msgid "copy to On"
 msgstr ""
 
-#: ..\WebConfigSite.py:716
+#: ..\WebConfigSite.py:692
 msgid "copy to Media"
 msgstr ""
 
-#: ..\WebConfigSite.py:718
+#: ..\WebConfigSite.py:694
 msgid "copy to Idle"
 msgstr ""
 
-#: ..\WebConfigSite.py:733
+#: ..\WebConfigSite.py:709
 msgid "Exec"
 msgstr ""
 
-#: ..\WebConfigSite.py:752
+#: ..\WebConfigSite.py:728
 msgid "Show Externals"
 msgstr ""
 
@@ -251,3882 +252,3904 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: ..\plugin.py:300
+#: ..\plugin.py:301
 msgid "black"
 msgstr "siyah"
 
-#: ..\plugin.py:300
+#: ..\plugin.py:301
 msgid "white"
 msgstr "beyaz"
 
-#: ..\plugin.py:301
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "gri"
 
-#: ..\plugin.py:301
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "gümüş"
 
-#: ..\plugin.py:301
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "füme"
 
-#: ..\plugin.py:302
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "deniz yeşili"
 
-#: ..\plugin.py:303
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "altın rengi"
 
-#: ..\plugin.py:303
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "yeşil sarı"
 
-#: ..\plugin.py:303
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "sarı"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "koyu turuncu"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "koyu kırmızı"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "hint kırmızısı"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "turuncu"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "turuncukırmızı"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "red"
 msgstr "kırmızı"
 
-#: ..\plugin.py:304
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr ""
 
-#: ..\plugin.py:305
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "koyu yeşil"
 
-#: ..\plugin.py:305
+#: ..\plugin.py:306
 msgid "green"
 msgstr "yeşil"
 
-#: ..\plugin.py:305
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "çim yeşili"
 
-#: ..\plugin.py:305
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "açık yeşil"
 
-#: ..\plugin.py:305
+#: ..\plugin.py:306
 msgid "lime"
 msgstr ""
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "mavi"
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr ""
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr ""
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr ""
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "koyu mavi"
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "lacivert"
 
-#: ..\plugin.py:306
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "açık mavi"
 
-#: ..\plugin.py:307
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "camgöbeği"
 
-#: ..\plugin.py:307
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "koyu orkide"
 
-#: ..\plugin.py:307
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "koyu pembe"
 
-#: ..\plugin.py:307
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "eflatun"
 
-#: ..\plugin.py:307
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "mor"
 
-#: ..\plugin.py:308
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "kahverengi"
 
-#: ..\plugin.py:308
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr ""
 
-#: ..\plugin.py:308
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "zeytinrengi"
 
-#: ..\plugin.py:308
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr ""
 
-#: ..\plugin.py:308
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr ""
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+2"
 msgstr "Ekran 1+2"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+2+3"
 msgstr "Ekran 1+2+3"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+2+3+4"
 msgstr "Ekran 1+2+3+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+2+4"
 msgstr "Ekran 1+2+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+3"
 msgstr "Ekran 1+3"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+3+4"
 msgstr "Ekran 1+3+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+3+5+7+9"
 msgstr "Ekran 1+3+5+7+9"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 1+4"
 msgstr "Ekran 1+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 2+3"
 msgstr "Ekran 2+3"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 2+3+4"
 msgstr "Ekran 2+3+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 2+4"
 msgstr "Ekran 2+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 2+4+6+8"
 msgstr "Ekran 2+4+6+"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 3+4"
 msgstr "Ekran 3+4"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 #, fuzzy
 msgid "Screen 5-8"
 msgstr "Ekran 5-9"
 
-#: ..\plugin.py:310
+#: ..\plugin.py:311
 msgid "Screen 5-9"
 msgstr "Ekran 5-9"
 
-#: ..\plugin.py:310 ..\plugin.py:311
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "Ekran 1-5"
 
-#: ..\plugin.py:310 ..\plugin.py:311
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "Ekran 1-6"
 
-#: ..\plugin.py:310 ..\plugin.py:311
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "Ekran 1-7"
 
-#: ..\plugin.py:310 ..\plugin.py:311
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "Ekran 1-8"
 
-#: ..\plugin.py:310 ..\plugin.py:311
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "Ekran 1-9"
 
-#: ..\plugin.py:310 ..\plugin.py:311 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
 msgid "Screen 1"
 msgstr "Ekran 1"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "Ekran 2"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "Ekran 3"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "Ekran 4"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "Ekran 5"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "Ekran 6"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "Ekran 7"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "Ekran 8"
 
-#: ..\plugin.py:310 ..\plugin.py:312
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "Ekran 9"
 
-#: ..\plugin.py:310 ..\plugin.py:313 ..\plugin.py:343 ..\plugin.py:345
-#: ..\plugin.py:383 ..\plugin.py:392 ..\plugin.py:393 ..\plugin.py:407
-#: ..\plugin.py:470 ..\plugin.py:493 ..\plugin.py:494 ..\plugin.py:519
-#: ..\plugin.py:520 ..\plugin.py:625 ..\plugin.py:642 ..\plugin.py:651
-#: ..\plugin.py:665 ..\plugin.py:674 ..\plugin.py:684 ..\plugin.py:756
-#: ..\plugin.py:926 ..\plugin.py:1062 ..\plugin.py:1137 ..\plugin.py:1145
-#: ..\plugin.py:1156 ..\plugin.py:1167 ..\plugin.py:1177 ..\plugin.py:1187
-#: ..\plugin.py:1197 ..\plugin.py:1205 ..\plugin.py:1288 ..\plugin.py:1296
-#: ..\plugin.py:1307 ..\plugin.py:1436 ..\plugin.py:1620 ..\plugin.py:1713
-#: ..\plugin.py:1724 ..\plugin.py:1734 ..\plugin.py:1744 ..\plugin.py:1768
-#: ..\plugin.py:1776 ..\plugin.py:1790 ..\plugin.py:1799 ..\plugin.py:1809
-#: ..\plugin.py:1849 ..\plugin.py:1857 ..\plugin.py:1869 ..\plugin.py:1877
-#: ..\plugin.py:1888 ..\plugin.py:1994 ..\plugin.py:2083 ..\plugin.py:2155
-#: ..\plugin.py:2166 ..\plugin.py:2177 ..\plugin.py:2187 ..\plugin.py:2197
-#: ..\plugin.py:2207 ..\plugin.py:2215 ..\plugin.py:2291 ..\plugin.py:2305
-#: ..\plugin.py:2314 ..\plugin.py:2324 ..\plugin.py:2364 ..\plugin.py:2372
+#: ..\plugin.py:311 ..\plugin.py:314 ..\plugin.py:346 ..\plugin.py:348
+#: ..\plugin.py:388 ..\plugin.py:389 ..\plugin.py:390 ..\plugin.py:391
+#: ..\plugin.py:392 ..\plugin.py:393 ..\plugin.py:394 ..\plugin.py:395
+#: ..\plugin.py:396 ..\plugin.py:397 ..\plugin.py:398 ..\plugin.py:412
+#: ..\plugin.py:475 ..\plugin.py:498 ..\plugin.py:499 ..\plugin.py:524
+#: ..\plugin.py:525 ..\plugin.py:630 ..\plugin.py:647 ..\plugin.py:656
+#: ..\plugin.py:670 ..\plugin.py:679 ..\plugin.py:689 ..\plugin.py:761
+#: ..\plugin.py:931 ..\plugin.py:1067 ..\plugin.py:1142 ..\plugin.py:1150
+#: ..\plugin.py:1161 ..\plugin.py:1172 ..\plugin.py:1182 ..\plugin.py:1192
+#: ..\plugin.py:1202 ..\plugin.py:1210 ..\plugin.py:1293 ..\plugin.py:1301
+#: ..\plugin.py:1312 ..\plugin.py:1441 ..\plugin.py:1625 ..\plugin.py:1718
+#: ..\plugin.py:1729 ..\plugin.py:1739 ..\plugin.py:1749 ..\plugin.py:1773
+#: ..\plugin.py:1781 ..\plugin.py:1795 ..\plugin.py:1804 ..\plugin.py:1814
+#: ..\plugin.py:1854 ..\plugin.py:1862 ..\plugin.py:1874 ..\plugin.py:1882
+#: ..\plugin.py:1893 ..\plugin.py:1999 ..\plugin.py:2088 ..\plugin.py:2160
+#: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
+#: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
+#: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
 msgid "off"
 msgstr "kapalı"
 
-#: ..\plugin.py:311
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "Ekran 1-2"
 
-#: ..\plugin.py:311
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "Ekran 1-3"
 
-#: ..\plugin.py:311
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "Ekran 1-4"
 
-#: ..\plugin.py:313 ..\plugin.py:1869
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr ""
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "2h"
 msgstr ""
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "3h"
 msgstr ""
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "3min"
 msgstr "3 dk"
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "40s"
 msgstr "40 sn"
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "4min"
 msgstr "4 dk"
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "50s"
 msgstr "50 sn"
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "5h"
 msgstr ""
 
-#: ..\plugin.py:314
+#: ..\plugin.py:315
 msgid "5s"
 msgstr "5 sn"
 
-#: ..\plugin.py:314 ..\plugin.py:477 ..\plugin.py:482 ..\plugin.py:487
+#: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
 msgid "10s"
 msgstr "10 sn"
 
-#: ..\plugin.py:314 ..\plugin.py:477 ..\plugin.py:482 ..\plugin.py:487
+#: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
 msgid "15s"
 msgstr "15 sn"
 
-#: ..\plugin.py:314 ..\plugin.py:477 ..\plugin.py:482 ..\plugin.py:487
+#: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
 msgid "1min"
 msgstr "1 dk"
 
-#: ..\plugin.py:314 ..\plugin.py:477 ..\plugin.py:482 ..\plugin.py:487
+#: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
 msgid "20s"
 msgstr "20 sn"
 
-#: ..\plugin.py:314 ..\plugin.py:477 ..\plugin.py:482 ..\plugin.py:487
+#: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
 msgid "2min"
 msgstr "2 dk"
 
-#: ..\plugin.py:314 ..\plugin.py:477 ..\plugin.py:482 ..\plugin.py:487
+#: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
 msgid "30s"
 msgstr "30 sn"
 
-#: ..\plugin.py:314 ..\plugin.py:541
+#: ..\plugin.py:315 ..\plugin.py:546
 msgid "10min"
 msgstr "10 dk"
 
-#: ..\plugin.py:314 ..\plugin.py:541
+#: ..\plugin.py:315 ..\plugin.py:546
 msgid "5min"
 msgstr "5 dk"
 
-#: ..\plugin.py:314 ..\plugin.py:541 ..\plugin.py:590
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
 msgid "20min"
 msgstr "20 dk"
 
-#: ..\plugin.py:314 ..\plugin.py:541 ..\plugin.py:590 ..\plugin.py:1208
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
 msgid "30min"
 msgstr "30 dk"
 
-#: ..\plugin.py:314 ..\plugin.py:541 ..\plugin.py:590 ..\plugin.py:1208
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
 msgid "60min"
 msgstr "60 dk"
 
-#: ..\plugin.py:315
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:315
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:315
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:315
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:315 ..\plugin.py:316
+#: ..\plugin.py:316 ..\plugin.py:317
 msgid "LCD 1"
 msgstr "LCD 1"
 
-#: ..\plugin.py:315 ..\plugin.py:316
+#: ..\plugin.py:316 ..\plugin.py:317
 msgid "LCD 2"
 msgstr "LCD 2"
 
-#: ..\plugin.py:315 ..\plugin.py:316
+#: ..\plugin.py:316 ..\plugin.py:317
 msgid "LCD 3"
 msgstr "LCD 3"
 
-#: ..\plugin.py:316
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr ""
 
-#: ..\plugin.py:317
+#: ..\plugin.py:319
+#, fuzzy
+#| msgid "Pearl (or compatible LCD) 480x320"
+msgid "AX206 (or compatible LCD) 480x320"
+msgstr "Pearl (or compatible LCD) 480x320"
+
+#: ..\plugin.py:319
+#, fuzzy
+#| msgid "Pearl (or compatible LCD) 320x480"
+msgid "AX206 (or compatible LCD) 800x480"
+msgstr "Pearl (or compatible LCD) 320x480"
+
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby@Pearl 128x128"
 
-#: ..\plugin.py:317
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "Pearl (or compatible LCD) 240x320"
 
-#: ..\plugin.py:317
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "Pearl (or compatible LCD) 320x240"
 
-#: ..\plugin.py:317
-msgid "Pearl (or compatible LCD) 480x320"
-msgstr "Pearl (or compatible LCD) 480x320"
-
-#: ..\plugin.py:317
-#, fuzzy
-#| msgid "Pearl (or compatible LCD) 320x480"
-msgid "Pearl (or compatible LCD) 800x480"
-msgstr "Pearl (or compatible LCD) 320x480"
-
-#: ..\plugin.py:318
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "Samsung SPF-72H 800x480"
 
-#: ..\plugin.py:318
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "Samsung SPF-75H/76H 800x480"
 
-#: ..\plugin.py:318
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "Samsung SPF-83H 800x600"
 
-#: ..\plugin.py:318
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:318
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "Samsung SPF-87H old 800x480"
 
-#: ..\plugin.py:319
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "Samsung SPF-105P 1024x600"
 
-#: ..\plugin.py:319
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "Samsung SPF-107H 1024x600"
 
-#: ..\plugin.py:319
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "Samsung SPF-107H old 1024x600"
 
-#: ..\plugin.py:319
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "Samsung SPF-85H/86H 800x600"
 
-#: ..\plugin.py:319
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "Samsung SPF-85P/86P 800x600"
 
-#: ..\plugin.py:320
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "Internal Box-Skin-LCD"
 
-#: ..\plugin.py:320
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "Internal TFT-LCD 400x240"
 
-#: ..\plugin.py:320
+#: ..\plugin.py:322
 #, fuzzy
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "Samsung SPF-105P 1024x600 "
 
-#: ..\plugin.py:320
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "Samsung SPF-700T 800x600"
 
-#: ..\plugin.py:320
+#: ..\plugin.py:322
 #, fuzzy
 msgid "Samsung SPF-800P 800x480"
 msgstr "Samsung SPF-87H 800x480"
 
-#: ..\plugin.py:321
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr ""
 
-#: ..\plugin.py:321
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr ""
 
-#: ..\plugin.py:321
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr ""
 
-#: ..\plugin.py:321
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr ""
 
-#: ..\plugin.py:321
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr ""
 
-#: ..\plugin.py:321
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr ""
 
-#: ..\plugin.py:323
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr ""
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr ""
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr ""
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr ""
 
-#: ..\plugin.py:324
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr ""
 
-#: ..\plugin.py:325
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "Mevcut Sıcaklık (-C)"
 
-#: ..\plugin.py:325 ..\plugin.py:326
+#: ..\plugin.py:328 ..\plugin.py:329
 msgid "Current"
 msgstr ""
 
-#: ..\plugin.py:326
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "Mevcut Sıcaklık"
 
-#: ..\plugin.py:327
+#: ..\plugin.py:330
 msgid "All"
 msgstr "Hepsi"
 
-#: ..\plugin.py:327
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "Sıcaklık"
 
-#: ..\plugin.py:327
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr ""
 
-#: ..\plugin.py:327
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr ""
 
-#: ..\plugin.py:327
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "Sıcaklık+Nem"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "Modül 1"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "Modül 1+2"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "Modül 1+2+3"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "Modül 1+2+4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "Modül 1+3"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "Modül 1+3+4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "Modül 1+4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "Modül 1-4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "Modül 1-5"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "Modül 1-6"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "Modül 2"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "Modül 2+3"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "Modül 2+3+4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "Modül 2+4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "Modül 2-6"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "Modül 3"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "Modül 3+4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "Modül 3-6"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "Modül 4"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "Modül4-6"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "Modül 5"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "Modül 5-6"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "Modül 6"
 
-#: ..\plugin.py:328
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr ""
 
-#: ..\plugin.py:329
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr ""
 
-#: ..\plugin.py:329
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr ""
 
-#: ..\plugin.py:329
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr ""
 
-#: ..\plugin.py:329
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "Tarih"
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "Tarih+Saat"
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "Tarih+Saat+Gün"
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr ""
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "Saat"
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "Saat+Gün"
 
-#: ..\plugin.py:330
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "Gün"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "%30"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "%35"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "%40"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "%45"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "%50"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "%55"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "%60"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "%65"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "%70"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "%75"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "%80"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "%85"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "%90"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "%95"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "%97"
 
-#: ..\plugin.py:331 ..\plugin.py:344
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "%98"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "%10"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "%15"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "%2"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "%20"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "%25"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "%3"
 
-#: ..\plugin.py:331 ..\plugin.py:345
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "%5"
 
-#: ..\plugin.py:331 ..\plugin.py:640
+#: ..\plugin.py:334 ..\plugin.py:645
 msgid "center"
 msgstr "orta"
 
-#: ..\plugin.py:331 ..\plugin.py:640 ..\plugin.py:1134 ..\plugin.py:1142
-#: ..\plugin.py:1765 ..\plugin.py:2152
+#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "sol"
 
-#: ..\plugin.py:331 ..\plugin.py:640 ..\plugin.py:1134 ..\plugin.py:1142
-#: ..\plugin.py:1765 ..\plugin.py:2152
+#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "sağ"
 
-#: ..\plugin.py:332
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "Genişletilmiş"
 
-#: ..\plugin.py:332
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr ""
 
-#: ..\plugin.py:332
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "Küçük"
 
-#: ..\plugin.py:332
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr ""
 
-#: ..\plugin.py:332
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr ""
 
-#: ..\plugin.py:333
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "Ay"
 
-#: ..\plugin.py:333
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr ""
 
-#: ..\plugin.py:333
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "Hafta"
 
-#: ..\plugin.py:333
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr ""
 
-#: ..\plugin.py:333
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr ""
 
-#: ..\plugin.py:334
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr ""
 
-#: ..\plugin.py:334
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr ""
 
-#: ..\plugin.py:334
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr ""
 
-#: ..\plugin.py:334
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr ""
 
-#: ..\plugin.py:334
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr ""
 
-#: ..\plugin.py:334
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr ""
 
-#: ..\plugin.py:334 ..\plugin.py:14322
+#: ..\plugin.py:337 ..\plugin.py:14390
 msgid "no Dates"
 msgstr ""
 
-#: ..\plugin.py:335
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr ""
 
-#: ..\plugin.py:335
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr ""
 
-#: ..\plugin.py:335 ..\plugin.py:818 ..\plugin.py:1396
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame"
 msgstr ""
 
-#: ..\plugin.py:336
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr ""
 
-#: ..\plugin.py:336
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr ""
 
-#: ..\plugin.py:336
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr ""
 
-#: ..\plugin.py:336
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr ""
 
-#: ..\plugin.py:337
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr ""
 
-#: ..\plugin.py:337
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr ""
 
-#: ..\plugin.py:337
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr ""
 
-#: ..\plugin.py:337
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr ""
 
-#: ..\plugin.py:338
+#: ..\plugin.py:341
 msgid "C"
 msgstr "C"
 
-#: ..\plugin.py:338
+#: ..\plugin.py:341
 msgid "C + rpm"
 msgstr ""
 
-#: ..\plugin.py:338
+#: ..\plugin.py:341
 msgid "C + rpm/2"
 msgstr ""
 
-#: ..\plugin.py:338
+#: ..\plugin.py:341
 msgid "rpm"
 msgstr ""
 
-#: ..\plugin.py:338
+#: ..\plugin.py:341
 msgid "rpm/2"
 msgstr ""
 
-#: ..\plugin.py:338 ..\plugin.py:339 ..\plugin.py:340 ..\plugin.py:351
-#: ..\plugin.py:419 ..\plugin.py:422 ..\plugin.py:454 ..\plugin.py:456
-#: ..\plugin.py:462 ..\plugin.py:569 ..\plugin.py:571 ..\plugin.py:574
-#: ..\plugin.py:591 ..\plugin.py:701 ..\plugin.py:993 ..\plugin.py:1551
-#: ..\plugin.py:1758 ..\plugin.py:2033
+#: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
+#: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
+#: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
+#: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr ""
 
-#: ..\plugin.py:339
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr ""
 
-#: ..\plugin.py:339
+#: ..\plugin.py:342
 msgid "db"
 msgstr ""
 
-#: ..\plugin.py:339
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr ""
 
-#: ..\plugin.py:339
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr ""
 
-#: ..\plugin.py:339
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr ""
 
-#: ..\plugin.py:339 ..\plugin.py:340
+#: ..\plugin.py:342 ..\plugin.py:343
 msgid "%"
 msgstr "%"
 
-#: ..\plugin.py:340
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr ""
 
-#: ..\plugin.py:340
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr ""
 
-#: ..\plugin.py:340
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr ""
 
-#: ..\plugin.py:340
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr ""
 
-#: ..\plugin.py:341
+#: ..\plugin.py:344
 msgid "show run"
 msgstr ""
 
-#: ..\plugin.py:341
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr ""
 
-#: ..\plugin.py:342
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr ""
 
-#: ..\plugin.py:342
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr ""
 
-#: ..\plugin.py:342
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr ""
 
-#: ..\plugin.py:343
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr ""
 
-#: ..\plugin.py:344
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "%100"
 
-#: ..\plugin.py:346
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:346
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:346
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:346
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:346 ..\plugin.py:353 ..\plugin.py:354 ..\plugin.py:396
-#: ..\plugin.py:470 ..\plugin.py:476 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "1"
 msgstr ""
 
-#: ..\plugin.py:347
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:347
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:347
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "POP3"
 
-#: ..\plugin.py:347
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "POP3-SSL"
 
-#: ..\plugin.py:348
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr ""
 
-#: ..\plugin.py:348
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr ""
 
-#: ..\plugin.py:348
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr ""
 
-#: ..\plugin.py:348
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr ""
 
-#: ..\plugin.py:348 ..\plugin.py:355 ..\plugin.py:829 ..\plugin.py:840
-#: ..\plugin.py:5947
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
 msgid "Picon"
 msgstr ""
 
-#: ..\plugin.py:349
+#: ..\plugin.py:352
 msgid "same color"
 msgstr ""
 
-#: ..\plugin.py:350
+#: ..\plugin.py:353
 #, fuzzy
 #| msgid "- Transparency"
 msgid "transparent"
 msgstr "- saydam"
 
-#: ..\plugin.py:351
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "evet +%25"
 
-#: ..\plugin.py:351 ..\plugin.py:454 ..\plugin.py:456 ..\plugin.py:569
-#: ..\plugin.py:571 ..\plugin.py:591 ..\plugin.py:701 ..\plugin.py:1758
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
 msgid "yes"
 msgstr "evet"
 
-#: ..\plugin.py:352
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "dikey"
 
-#: ..\plugin.py:352 ..\plugin.py:887 ..\plugin.py:1494 ..\plugin.py:1940
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
 msgid "horizontally"
 msgstr "yatay"
 
-#: ..\plugin.py:353
+#: ..\plugin.py:356
 msgid "4"
 msgstr ""
 
-#: ..\plugin.py:353 ..\plugin.py:354 ..\plugin.py:396 ..\plugin.py:470
-#: ..\plugin.py:476 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr ""
 
-#: ..\plugin.py:353 ..\plugin.py:354 ..\plugin.py:396 ..\plugin.py:476
-#: ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr ""
 
-#: ..\plugin.py:353 ..\plugin.py:396 ..\plugin.py:476 ..\plugin.py:481
-#: ..\plugin.py:486
+#: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
 msgid "5"
 msgstr ""
 
-#: ..\plugin.py:354
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:354
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:354
+#: ..\plugin.py:357
 msgid "all"
 msgstr "tümü"
 
-#: ..\plugin.py:354 ..\plugin.py:396 ..\plugin.py:476 ..\plugin.py:481
-#: ..\plugin.py:486
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
 msgid "30"
 msgstr ""
 
-#: ..\plugin.py:355
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr ""
 
-#: ..\plugin.py:355
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr ""
 
-#: ..\plugin.py:355
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr ""
 
-#: ..\plugin.py:356
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr ""
 
-#: ..\plugin.py:357
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr ""
 
-#: ..\plugin.py:357
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:357
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr ""
 
-#: ..\plugin.py:358
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr ""
 
-#: ..\plugin.py:358
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:358
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr ""
 
-#: ..\plugin.py:359
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr ""
 
-#: ..\plugin.py:359
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:359
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:360
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr ""
 
-#: ..\plugin.py:360
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:360
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:361
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr ""
 
-#: ..\plugin.py:361
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:361
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:362
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr ""
 
-#: ..\plugin.py:362
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:362
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:363
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr ""
 
-#: ..\plugin.py:363
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:363
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr ""
 
-#: ..\plugin.py:364
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr ""
 
-#: ..\plugin.py:364
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:364
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:365
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr ""
 
-#: ..\plugin.py:365
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:365
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:366
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr ""
 
-#: ..\plugin.py:366
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:366
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:367
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr ""
 
-#: ..\plugin.py:367
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:367
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr ""
 
-#: ..\plugin.py:368
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr ""
 
-#: ..\plugin.py:368
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr ""
 
-#: ..\plugin.py:368
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr ""
 
-#: ..\plugin.py:377
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "Hızlı (2sn)"
 
-#: ..\plugin.py:377
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "Normal (5sn)"
 
-#: ..\plugin.py:393
+#: ..\plugin.py:385
+#, fuzzy
+#| msgid "full Screen"
+msgid "last Screen"
+msgstr "tam Ekran"
+
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "alfabetik"
 
-#: ..\plugin.py:393
+#: ..\plugin.py:398
 msgid "random"
 msgstr "rasgele"
 
-#: ..\plugin.py:394
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr ""
 
-#: ..\plugin.py:394
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr ""
 
-#: ..\plugin.py:394
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr ""
 
-#: ..\plugin.py:396
+#: ..\plugin.py:401
 msgid "0.5"
 msgstr "0.5"
 
-#: ..\plugin.py:396 ..\plugin.py:476 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "10"
 msgstr ""
 
-#: ..\plugin.py:396 ..\plugin.py:476 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "20"
 msgstr ""
 
-#: ..\plugin.py:399
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:399
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:400
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr ""
 
-#: ..\plugin.py:400
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr ""
 
-#: ..\plugin.py:400
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr ""
 
-#: ..\plugin.py:419
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr ""
 
-#: ..\plugin.py:419
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr ""
 
-#: ..\plugin.py:420
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:420
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "Şimdi/Önümüzdeki"
 
-#: ..\plugin.py:434
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "normal"
 
-#: ..\plugin.py:434
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr ""
 
-#: ..\plugin.py:437
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr ""
 
-#: ..\plugin.py:439
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr ""
 
-#: ..\plugin.py:439
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr ""
 
-#: ..\plugin.py:439
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr ""
 
-#: ..\plugin.py:443
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - normal"
 
-#: ..\plugin.py:443
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2- yan yana"
 
-#: ..\plugin.py:444
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr ""
 
-#: ..\plugin.py:444
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr ""
 
-#: ..\plugin.py:444
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr ""
 
-#: ..\plugin.py:444
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "WeatherUnlocked"
 
-#: ..\plugin.py:454 ..\plugin.py:591
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr ""
 
-#: ..\plugin.py:456
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "evet + %"
 
-#: ..\plugin.py:462
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "evet, uzun"
 
-#: ..\plugin.py:462
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "evet, kısa"
 
-#: ..\plugin.py:469
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr ""
 
-#: ..\plugin.py:469
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr ""
 
-#: ..\plugin.py:476 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 #, fuzzy
 msgid "60"
 msgstr "%60"
 
-#: ..\plugin.py:488
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr ""
 
-#: ..\plugin.py:495 ..\plugin.py:496 ..\plugin.py:497
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:495 ..\plugin.py:496 ..\plugin.py:497
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:495 ..\plugin.py:496 ..\plugin.py:497
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:495 ..\plugin.py:496 ..\plugin.py:497
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr ""
 
-#: ..\plugin.py:504 ..\plugin.py:505 ..\plugin.py:506
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1 / dk"
 
-#: ..\plugin.py:504 ..\plugin.py:505 ..\plugin.py:506 ..\plugin.py:629
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
 msgid "always"
 msgstr ""
 
-#: ..\plugin.py:507
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr ""
 
-#: ..\plugin.py:507
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr ""
 
-#: ..\plugin.py:509
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32bit - renk"
 
-#: ..\plugin.py:509
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr ""
 
-#: ..\plugin.py:519
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr ""
 
-#: ..\plugin.py:519
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr ""
 
-#: ..\plugin.py:519
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr ""
 
-#: ..\plugin.py:519
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr ""
 
-#: ..\plugin.py:519 ..\plugin.py:520
+#: ..\plugin.py:524 ..\plugin.py:525
 msgid "2 x InfoKey"
 msgstr ""
 
-#: ..\plugin.py:519 ..\plugin.py:520
+#: ..\plugin.py:524 ..\plugin.py:525
 msgid "2 x Mute"
 msgstr ""
 
-#: ..\plugin.py:519 ..\plugin.py:520
+#: ..\plugin.py:524 ..\plugin.py:525
 msgid "Long InfoKey"
 msgstr ""
 
-#: ..\plugin.py:520
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr ""
 
-#: ..\plugin.py:520
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr ""
 
-#: ..\plugin.py:520
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr ""
 
-#: ..\plugin.py:520
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr ""
 
-#: ..\plugin.py:541 ..\plugin.py:590
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15 dk"
 
-#: ..\plugin.py:569
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr ""
 
-#: ..\plugin.py:625
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr ""
 
-#: ..\plugin.py:625
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr ""
 
-#: ..\plugin.py:625
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr ""
 
-#: ..\plugin.py:629
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr ""
 
-#: ..\plugin.py:632
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "Radyo"
 
-#: ..\plugin.py:632
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "Radyo+medya"
 
-#: ..\plugin.py:632
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "TV+Radyo"
 
-#: ..\plugin.py:632
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "TV+Radyo+Medya"
 
-#: ..\plugin.py:632 ..\plugin.py:1280
+#: ..\plugin.py:637 ..\plugin.py:1285
 msgid "TV"
 msgstr "TV"
 
-#: ..\plugin.py:633
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr ""
 
-#: ..\plugin.py:633
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr ""
 
-#: ..\plugin.py:633
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr ""
 
-#: ..\plugin.py:633
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr ""
 
-#: ..\plugin.py:636
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr ""
 
-#: ..\plugin.py:636
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr ""
 
-#: ..\plugin.py:773 ..\plugin.py:785 ..\plugin.py:797 ..\plugin.py:1363
-#: ..\plugin.py:1375
+#: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr ""
 
-#: ..\plugin.py:773 ..\plugin.py:785 ..\plugin.py:797 ..\plugin.py:1363
-#: ..\plugin.py:1375
+#: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr ""
 
-#: ..\plugin.py:773 ..\plugin.py:785 ..\plugin.py:1363
+#: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
 msgid "Time+Duration+Info"
 msgstr ""
 
-#: ..\plugin.py:797 ..\plugin.py:1375
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr ""
 
-#: ..\plugin.py:797 ..\plugin.py:1375
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr ""
 
-#: ..\plugin.py:812 ..\plugin.py:1391
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr ""
 
-#: ..\plugin.py:812 ..\plugin.py:1391
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr ""
 
-#: ..\plugin.py:818 ..\plugin.py:1396
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr ""
 
-#: ..\plugin.py:818 ..\plugin.py:1396
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr ""
 
-#: ..\plugin.py:818 ..\plugin.py:1396
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr ""
 
-#: ..\plugin.py:818 ..\plugin.py:1396
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr ""
 
-#: ..\plugin.py:820 ..\plugin.py:1398
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr ""
 
-#: ..\plugin.py:820 ..\plugin.py:1398
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr ""
 
-#: ..\plugin.py:820 ..\plugin.py:1398 ..\plugin.py:1759
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
 msgid "Normal"
 msgstr "Normal"
 
-#: ..\plugin.py:829
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr ""
 
-#: ..\plugin.py:829
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr ""
 
-#: ..\plugin.py:829
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr ""
 
-#: ..\plugin.py:829
+#: ..\plugin.py:834
 msgid "Position"
 msgstr ""
 
-#: ..\plugin.py:829 ..\plugin.py:840
+#: ..\plugin.py:834 ..\plugin.py:845
 msgid "Name"
 msgstr ""
 
-#: ..\plugin.py:908 ..\plugin.py:1418 ..\plugin.py:1976
+#: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
 msgid "Offline"
 msgstr "Çevrimdışı"
 
-#: ..\plugin.py:908 ..\plugin.py:1418 ..\plugin.py:1976
+#: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
 msgid "Online"
 msgstr "Çevrimiçi"
 
-#: ..\plugin.py:908 ..\plugin.py:1418 ..\plugin.py:1976
+#: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
 msgid "Online+Offline"
 msgstr "Çevrimiçi+Çevrimdışı"
 
-#: ..\plugin.py:952 ..\plugin.py:1016 ..\plugin.py:1455 ..\plugin.py:1574
-#: ..\plugin.py:1925 ..\plugin.py:2013
+#: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr ""
 
-#: ..\plugin.py:952 ..\plugin.py:1016 ..\plugin.py:1455 ..\plugin.py:1574
-#: ..\plugin.py:1925 ..\plugin.py:2013
+#: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr ""
 
-#: ..\plugin.py:953 ..\plugin.py:1017 ..\plugin.py:1456 ..\plugin.py:1575
-#: ..\plugin.py:1926 ..\plugin.py:2014
+#: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr ""
 
-#: ..\plugin.py:953 ..\plugin.py:1017 ..\plugin.py:1456 ..\plugin.py:1575
-#: ..\plugin.py:1926 ..\plugin.py:2014
+#: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr ""
 
-#: ..\plugin.py:971 ..\plugin.py:1529
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr ""
 
-#: ..\plugin.py:971 ..\plugin.py:1529
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr ""
 
-#: ..\plugin.py:993 ..\plugin.py:1551 ..\plugin.py:2033
+#: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
 msgid "Memory available"
 msgstr "Kullanılabilir hafıza"
 
-#: ..\plugin.py:993 ..\plugin.py:1551 ..\plugin.py:2033
+#: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
 msgid "Memory free"
 msgstr "Boş hafıza"
 
-#: ..\plugin.py:1209
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr ""
 
-#: ..\plugin.py:1209
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr ""
 
-#: ..\plugin.py:1230 ..\plugin.py:1239 ..\plugin.py:1248 ..\plugin.py:1257
-#: ..\plugin.py:1266 ..\plugin.py:1275 ..\plugin.py:1691 ..\plugin.py:1700
-#: ..\plugin.py:2236 ..\plugin.py:2245 ..\plugin.py:2254 ..\plugin.py:2263
-#: ..\plugin.py:2272 ..\plugin.py:2281
+#: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
+#: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
+#: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "tam Ekran"
 
-#: ..\plugin.py:1280
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "TV+OSD"
 
-#: ..\plugin.py:1758
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr ""
 
-#: ..\plugin.py:1759
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "E"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "N"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "S"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "W"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr ""
 
-#: ..\plugin.py:2670
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr ""
 
-#: ..\plugin.py:4595
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr ""
 
-#: ..\plugin.py:4596
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr ""
 
-#: ..\plugin.py:5161
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr ""
 
-#: ..\plugin.py:5287
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr ""
 
-#: ..\plugin.py:5288
+#: ..\plugin.py:5296
 #, fuzzy
 msgid "Load Defaults / Empty Config"
 msgstr "varsayılanları tükle"
 
-#: ..\plugin.py:5289
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr ""
 
-#: ..\plugin.py:5293 ..\plugin.py:5329
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "Dosya yükle : %s"
 
-#: ..\plugin.py:5302
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "Dosya silinsin mi ?"
 
-#: ..\plugin.py:5337
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "silindi"
 
-#: ..\plugin.py:5362
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr ""
 
-#: ..\plugin.py:5470 ..\plugin.py:7898
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr ""
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr ""
 
-#: ..\plugin.py:5520
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr ""
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "Iptal"
 
-#: ..\plugin.py:5521
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "Kaydet"
 
-#: ..\plugin.py:5522
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr ""
 
-#: ..\plugin.py:5523 ..\plugin.py:7899
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr ""
 
-#: ..\plugin.py:5606
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr ""
 
-#: ..\plugin.py:5631
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr ""
 
-#: ..\plugin.py:5657
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr ""
 
-#: ..\plugin.py:5694
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr ""
 
-#: ..\plugin.py:5695
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr ""
 
-#: ..\plugin.py:5696
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr ""
 
-#: ..\plugin.py:5697 ..\plugin.py:6686 ..\plugin.py:7315
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1 arkaplan rengi"
 
-#: ..\plugin.py:5698 ..\plugin.py:6687 ..\plugin.py:7316
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1 arkaplan resmi [ok]>"
 
-#: ..\plugin.py:5699 ..\plugin.py:6688 ..\plugin.py:7317
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1 parlaklık"
 
-#: ..\plugin.py:5700 ..\plugin.py:6689 ..\plugin.py:7318
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr ""
 
-#: ..\plugin.py:5701
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr ""
 
-#: ..\plugin.py:5702
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr ""
 
-#: ..\plugin.py:5704
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr ""
 
-#: ..\plugin.py:5705 ..\plugin.py:6690 ..\plugin.py:7319
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2 arkaplan rengi"
 
-#: ..\plugin.py:5706 ..\plugin.py:6691 ..\plugin.py:7320
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2 arkaplan resmi [ok]>"
 
-#: ..\plugin.py:5707 ..\plugin.py:6692 ..\plugin.py:7321
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2 parlaklık"
 
-#: ..\plugin.py:5708 ..\plugin.py:6693 ..\plugin.py:7322
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr ""
 
-#: ..\plugin.py:5709
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr ""
 
-#: ..\plugin.py:5710
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr ""
 
-#: ..\plugin.py:5712
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr ""
 
-#: ..\plugin.py:5713 ..\plugin.py:6694 ..\plugin.py:7323
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3 arkaplan rengi"
 
-#: ..\plugin.py:5714 ..\plugin.py:6695 ..\plugin.py:7324
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3 arkaplan resmi [ok]>"
 
-#: ..\plugin.py:5715 ..\plugin.py:6696 ..\plugin.py:7325
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3 parlaklık"
 
-#: ..\plugin.py:5716 ..\plugin.py:6697 ..\plugin.py:7326
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr ""
 
-#: ..\plugin.py:5717
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr ""
 
-#: ..\plugin.py:5719
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr ""
 
-#: ..\plugin.py:5720
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD Telafi etmek"
 
-#: ..\plugin.py:5721
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr ""
 
-#: ..\plugin.py:5722
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr ""
 
-#: ..\plugin.py:5723
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr ""
 
-#: ..\plugin.py:5724
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr ""
 
-#: ..\plugin.py:5725
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr ""
 
-#: ..\plugin.py:5728 ..\plugin.py:5735 ..\plugin.py:5944 ..\plugin.py:5949
-#: ..\plugin.py:5962 ..\plugin.py:5974 ..\plugin.py:5989 ..\plugin.py:6004
-#: ..\plugin.py:6016 ..\plugin.py:6026 ..\plugin.py:6039 ..\plugin.py:6052
-#: ..\plugin.py:6065 ..\plugin.py:6079 ..\plugin.py:6095 ..\plugin.py:6109
-#: ..\plugin.py:6123 ..\plugin.py:6135 ..\plugin.py:6147 ..\plugin.py:6159
-#: ..\plugin.py:6169 ..\plugin.py:6183 ..\plugin.py:6193 ..\plugin.py:6200
-#: ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6239 ..\plugin.py:6251
-#: ..\plugin.py:6269 ..\plugin.py:6277 ..\plugin.py:6288 ..\plugin.py:6299
-#: ..\plugin.py:6308 ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6364
-#: ..\plugin.py:6374 ..\plugin.py:6387 ..\plugin.py:6399 ..\plugin.py:6409
-#: ..\plugin.py:6418 ..\plugin.py:6429 ..\plugin.py:6440 ..\plugin.py:6451
-#: ..\plugin.py:6462 ..\plugin.py:6475 ..\plugin.py:6485 ..\plugin.py:6495
-#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
-#: ..\plugin.py:6550 ..\plugin.py:6565 ..\plugin.py:6578 ..\plugin.py:6592
-#: ..\plugin.py:6607 ..\plugin.py:6620 ..\plugin.py:6630 ..\plugin.py:6642
-#: ..\plugin.py:6654 ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:6681
-#: ..\plugin.py:6702 ..\plugin.py:6707 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6745 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6799 ..\plugin.py:6809 ..\plugin.py:6816 ..\plugin.py:6831
-#: ..\plugin.py:6846 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6882
-#: ..\plugin.py:6896 ..\plugin.py:6907 ..\plugin.py:6917 ..\plugin.py:6935
-#: ..\plugin.py:6946 ..\plugin.py:6964 ..\plugin.py:6972 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7003 ..\plugin.py:7026 ..\plugin.py:7049
-#: ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7082 ..\plugin.py:7094
-#: ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7153 ..\plugin.py:7162 ..\plugin.py:7177 ..\plugin.py:7192
-#: ..\plugin.py:7205 ..\plugin.py:7219 ..\plugin.py:7234 ..\plugin.py:7247
-#: ..\plugin.py:7257 ..\plugin.py:7269 ..\plugin.py:7281 ..\plugin.py:7290
-#: ..\plugin.py:7299 ..\plugin.py:7330 ..\plugin.py:7345 ..\plugin.py:7360
-#: ..\plugin.py:7375 ..\plugin.py:7389 ..\plugin.py:7402 ..\plugin.py:7415
-#: ..\plugin.py:7425 ..\plugin.py:7443 ..\plugin.py:7454 ..\plugin.py:7472
-#: ..\plugin.py:7480 ..\plugin.py:7491 ..\plugin.py:7502 ..\plugin.py:7511
-#: ..\plugin.py:7534 ..\plugin.py:7557 ..\plugin.py:7567 ..\plugin.py:7577
-#: ..\plugin.py:7590 ..\plugin.py:7602 ..\plugin.py:7611 ..\plugin.py:7622
-#: ..\plugin.py:7633 ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7668
-#: ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
-#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7743 ..\plugin.py:7758
-#: ..\plugin.py:7771 ..\plugin.py:7785 ..\plugin.py:7800 ..\plugin.py:7813
-#: ..\plugin.py:7823 ..\plugin.py:7835 ..\plugin.py:7847 ..\plugin.py:7856
-#: ..\plugin.py:7865
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr ""
 
-#: ..\plugin.py:5729
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr ""
 
-#: ..\plugin.py:5730
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr ""
 
-#: ..\plugin.py:5731
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- arkaplan/saydam"
 
-#: ..\plugin.py:5732
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr ""
 
-#: ..\plugin.py:5733
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr ""
 
-#: ..\plugin.py:5736
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr ""
 
-#: ..\plugin.py:5737 ..\plugin.py:6005 ..\plugin.py:6017 ..\plugin.py:6028
-#: ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6136
-#: ..\plugin.py:6148 ..\plugin.py:6160 ..\plugin.py:6170 ..\plugin.py:6194
-#: ..\plugin.py:6201 ..\plugin.py:6212 ..\plugin.py:6222 ..\plugin.py:6240
-#: ..\plugin.py:6252 ..\plugin.py:6270 ..\plugin.py:6310 ..\plugin.py:6333
-#: ..\plugin.py:6376 ..\plugin.py:6388 ..\plugin.py:6401 ..\plugin.py:6410
-#: ..\plugin.py:6420 ..\plugin.py:6431 ..\plugin.py:6442 ..\plugin.py:6453
-#: ..\plugin.py:6536 ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6579
-#: ..\plugin.py:6632 ..\plugin.py:6644 ..\plugin.py:6708 ..\plugin.py:6720
-#: ..\plugin.py:6733 ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772
-#: ..\plugin.py:6810 ..\plugin.py:6873 ..\plugin.py:6883 ..\plugin.py:6897
-#: ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6936 ..\plugin.py:6947
-#: ..\plugin.py:6965 ..\plugin.py:7005 ..\plugin.py:7028 ..\plugin.py:7071
-#: ..\plugin.py:7083 ..\plugin.py:7096 ..\plugin.py:7107 ..\plugin.py:7154
-#: ..\plugin.py:7163 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7206
-#: ..\plugin.py:7259 ..\plugin.py:7271 ..\plugin.py:7376 ..\plugin.py:7416
-#: ..\plugin.py:7426 ..\plugin.py:7444 ..\plugin.py:7455 ..\plugin.py:7473
-#: ..\plugin.py:7513 ..\plugin.py:7536 ..\plugin.py:7579 ..\plugin.py:7591
-#: ..\plugin.py:7603 ..\plugin.py:7613 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7729 ..\plugin.py:7744 ..\plugin.py:7759
-#: ..\plugin.py:7772 ..\plugin.py:7825 ..\plugin.py:7837
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- yazı tipi boyutu"
 
-#: ..\plugin.py:5738 ..\plugin.py:5951 ..\plugin.py:5964 ..\plugin.py:5981
-#: ..\plugin.py:5996 ..\plugin.py:6007 ..\plugin.py:6018 ..\plugin.py:6030
-#: ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6083
-#: ..\plugin.py:6100 ..\plugin.py:6114 ..\plugin.py:6125 ..\plugin.py:6137
-#: ..\plugin.py:6149 ..\plugin.py:6161 ..\plugin.py:6174 ..\plugin.py:6185
-#: ..\plugin.py:6195 ..\plugin.py:6202 ..\plugin.py:6213 ..\plugin.py:6223
-#: ..\plugin.py:6241 ..\plugin.py:6253 ..\plugin.py:6271 ..\plugin.py:6278
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6309 ..\plugin.py:6332
-#: ..\plugin.py:6355 ..\plugin.py:6365 ..\plugin.py:6377 ..\plugin.py:6389
-#: ..\plugin.py:6402 ..\plugin.py:6411 ..\plugin.py:6421 ..\plugin.py:6432
-#: ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6464 ..\plugin.py:6479
-#: ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509 ..\plugin.py:6519
-#: ..\plugin.py:6529 ..\plugin.py:6537 ..\plugin.py:6552 ..\plugin.py:6570
-#: ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6609 ..\plugin.py:6622
-#: ..\plugin.py:6633 ..\plugin.py:6645 ..\plugin.py:6676 ..\plugin.py:6710
-#: ..\plugin.py:6722 ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761
-#: ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6801 ..\plugin.py:6811
-#: ..\plugin.py:6823 ..\plugin.py:6838 ..\plugin.py:6850 ..\plugin.py:6863
-#: ..\plugin.py:6874 ..\plugin.py:6887 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6937 ..\plugin.py:6948 ..\plugin.py:6966
-#: ..\plugin.py:6973 ..\plugin.py:6984 ..\plugin.py:6995 ..\plugin.py:7004
-#: ..\plugin.py:7027 ..\plugin.py:7050 ..\plugin.py:7060 ..\plugin.py:7072
-#: ..\plugin.py:7084 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7120
-#: ..\plugin.py:7130 ..\plugin.py:7139 ..\plugin.py:7155 ..\plugin.py:7164
-#: ..\plugin.py:7179 ..\plugin.py:7197 ..\plugin.py:7207 ..\plugin.py:7220
-#: ..\plugin.py:7236 ..\plugin.py:7249 ..\plugin.py:7260 ..\plugin.py:7272
-#: ..\plugin.py:7303 ..\plugin.py:7352 ..\plugin.py:7367 ..\plugin.py:7380
-#: ..\plugin.py:7393 ..\plugin.py:7406 ..\plugin.py:7417 ..\plugin.py:7427
-#: ..\plugin.py:7445 ..\plugin.py:7456 ..\plugin.py:7474 ..\plugin.py:7481
-#: ..\plugin.py:7492 ..\plugin.py:7503 ..\plugin.py:7512 ..\plugin.py:7535
-#: ..\plugin.py:7558 ..\plugin.py:7568 ..\plugin.py:7580 ..\plugin.py:7592
-#: ..\plugin.py:7604 ..\plugin.py:7614 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7657 ..\plugin.py:7672 ..\plugin.py:7682
-#: ..\plugin.py:7692 ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722
-#: ..\plugin.py:7730 ..\plugin.py:7745 ..\plugin.py:7763 ..\plugin.py:7773
-#: ..\plugin.py:7786 ..\plugin.py:7802 ..\plugin.py:7815 ..\plugin.py:7826
-#: ..\plugin.py:7838 ..\plugin.py:7869
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr ""
 
-#: ..\plugin.py:5739 ..\plugin.py:5952 ..\plugin.py:5965 ..\plugin.py:5982
-#: ..\plugin.py:5997 ..\plugin.py:6008 ..\plugin.py:6019 ..\plugin.py:6031
-#: ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070 ..\plugin.py:6084
-#: ..\plugin.py:6101 ..\plugin.py:6115 ..\plugin.py:6126 ..\plugin.py:6138
-#: ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6175 ..\plugin.py:6186
-#: ..\plugin.py:6196 ..\plugin.py:6204 ..\plugin.py:6214 ..\plugin.py:6224
-#: ..\plugin.py:6242 ..\plugin.py:6254 ..\plugin.py:6272 ..\plugin.py:6280
-#: ..\plugin.py:6291 ..\plugin.py:6302 ..\plugin.py:6311 ..\plugin.py:6334
-#: ..\plugin.py:6357 ..\plugin.py:6367 ..\plugin.py:6378 ..\plugin.py:6390
-#: ..\plugin.py:6403 ..\plugin.py:6412 ..\plugin.py:6422 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6465 ..\plugin.py:6480
-#: ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510 ..\plugin.py:6520
-#: ..\plugin.py:6530 ..\plugin.py:6538 ..\plugin.py:6553 ..\plugin.py:6571
-#: ..\plugin.py:6581 ..\plugin.py:6595 ..\plugin.py:6610 ..\plugin.py:6623
-#: ..\plugin.py:6634 ..\plugin.py:6646 ..\plugin.py:6677 ..\plugin.py:6711
-#: ..\plugin.py:6723 ..\plugin.py:6736 ..\plugin.py:6749 ..\plugin.py:6762
-#: ..\plugin.py:6775 ..\plugin.py:6788 ..\plugin.py:6802 ..\plugin.py:6812
-#: ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6851 ..\plugin.py:6864
-#: ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6900 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6938 ..\plugin.py:6949 ..\plugin.py:6967
-#: ..\plugin.py:6975 ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7006
-#: ..\plugin.py:7029 ..\plugin.py:7052 ..\plugin.py:7062 ..\plugin.py:7073
-#: ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7109 ..\plugin.py:7121
-#: ..\plugin.py:7131 ..\plugin.py:7140 ..\plugin.py:7156 ..\plugin.py:7165
-#: ..\plugin.py:7180 ..\plugin.py:7198 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7261 ..\plugin.py:7273
-#: ..\plugin.py:7304 ..\plugin.py:7353 ..\plugin.py:7368 ..\plugin.py:7381
-#: ..\plugin.py:7394 ..\plugin.py:7407 ..\plugin.py:7418 ..\plugin.py:7428
-#: ..\plugin.py:7446 ..\plugin.py:7457 ..\plugin.py:7475 ..\plugin.py:7483
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7514 ..\plugin.py:7537
-#: ..\plugin.py:7560 ..\plugin.py:7570 ..\plugin.py:7581 ..\plugin.py:7593
-#: ..\plugin.py:7605 ..\plugin.py:7615 ..\plugin.py:7626 ..\plugin.py:7637
-#: ..\plugin.py:7648 ..\plugin.py:7658 ..\plugin.py:7673 ..\plugin.py:7683
-#: ..\plugin.py:7693 ..\plugin.py:7703 ..\plugin.py:7713 ..\plugin.py:7723
-#: ..\plugin.py:7731 ..\plugin.py:7746 ..\plugin.py:7764 ..\plugin.py:7774
-#: ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816 ..\plugin.py:7827
-#: ..\plugin.py:7839 ..\plugin.py:7870
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr ""
 
-#: ..\plugin.py:5740 ..\plugin.py:5816 ..\plugin.py:5818 ..\plugin.py:5820
-#: ..\plugin.py:5822 ..\plugin.py:5824 ..\plugin.py:5945 ..\plugin.py:5984
-#: ..\plugin.py:5999 ..\plugin.py:6011 ..\plugin.py:6020 ..\plugin.py:6034
-#: ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073 ..\plugin.py:6086
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6129 ..\plugin.py:6140
-#: ..\plugin.py:6152 ..\plugin.py:6178 ..\plugin.py:6189 ..\plugin.py:6206
-#: ..\plugin.py:6216 ..\plugin.py:6226 ..\plugin.py:6244 ..\plugin.py:6256
-#: ..\plugin.py:6283 ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6320
-#: ..\plugin.py:6343 ..\plugin.py:6382 ..\plugin.py:6392 ..\plugin.py:6405
-#: ..\plugin.py:6414 ..\plugin.py:6423 ..\plugin.py:6434 ..\plugin.py:6445
-#: ..\plugin.py:6456 ..\plugin.py:6540 ..\plugin.py:6582 ..\plugin.py:6600
-#: ..\plugin.py:6615 ..\plugin.py:6636 ..\plugin.py:6648 ..\plugin.py:6659
-#: ..\plugin.py:6668 ..\plugin.py:6703 ..\plugin.py:6714 ..\plugin.py:6726
-#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
-#: ..\plugin.py:6790 ..\plugin.py:6805 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:6854 ..\plugin.py:6867 ..\plugin.py:6891 ..\plugin.py:6902
-#: ..\plugin.py:6912 ..\plugin.py:6922 ..\plugin.py:6940 ..\plugin.py:6951
-#: ..\plugin.py:6978 ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7015
-#: ..\plugin.py:7038 ..\plugin.py:7077 ..\plugin.py:7087 ..\plugin.py:7099
-#: ..\plugin.py:7110 ..\plugin.py:7158 ..\plugin.py:7167 ..\plugin.py:7209
-#: ..\plugin.py:7227 ..\plugin.py:7242 ..\plugin.py:7263 ..\plugin.py:7275
-#: ..\plugin.py:7286 ..\plugin.py:7295 ..\plugin.py:7331 ..\plugin.py:7355
-#: ..\plugin.py:7370 ..\plugin.py:7384 ..\plugin.py:7397 ..\plugin.py:7410
-#: ..\plugin.py:7430 ..\plugin.py:7448 ..\plugin.py:7459 ..\plugin.py:7486
-#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7523 ..\plugin.py:7546
-#: ..\plugin.py:7585 ..\plugin.py:7595 ..\plugin.py:7607 ..\plugin.py:7616
-#: ..\plugin.py:7627 ..\plugin.py:7638 ..\plugin.py:7649 ..\plugin.py:7733
-#: ..\plugin.py:7775 ..\plugin.py:7793 ..\plugin.py:7808 ..\plugin.py:7829
-#: ..\plugin.py:7841 ..\plugin.py:7852 ..\plugin.py:7861
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- renk"
 
-#: ..\plugin.py:5741 ..\plugin.py:6021 ..\plugin.py:6245 ..\plugin.py:6393
-#: ..\plugin.py:6406 ..\plugin.py:6415 ..\plugin.py:6424 ..\plugin.py:6435
-#: ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6541 ..\plugin.py:6583
-#: ..\plugin.py:6637 ..\plugin.py:6649 ..\plugin.py:6660 ..\plugin.py:6669
-#: ..\plugin.py:6941 ..\plugin.py:7088 ..\plugin.py:7100 ..\plugin.py:7111
-#: ..\plugin.py:7159 ..\plugin.py:7168 ..\plugin.py:7210 ..\plugin.py:7264
-#: ..\plugin.py:7276 ..\plugin.py:7287 ..\plugin.py:7296 ..\plugin.py:7449
-#: ..\plugin.py:7596 ..\plugin.py:7608 ..\plugin.py:7617 ..\plugin.py:7628
-#: ..\plugin.py:7639 ..\plugin.py:7650 ..\plugin.py:7734 ..\plugin.py:7776
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7853 ..\plugin.py:7862
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- arkaplan rengi"
 
-#: ..\plugin.py:5742 ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6013
-#: ..\plugin.py:6023 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6092 ..\plugin.py:6106 ..\plugin.py:6120
-#: ..\plugin.py:6144 ..\plugin.py:6156 ..\plugin.py:6166 ..\plugin.py:6180
-#: ..\plugin.py:6208 ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6247
-#: ..\plugin.py:6258 ..\plugin.py:6285 ..\plugin.py:6296 ..\plugin.py:6328
-#: ..\plugin.py:6351 ..\plugin.py:6384 ..\plugin.py:6396 ..\plugin.py:6426
-#: ..\plugin.py:6437 ..\plugin.py:6448 ..\plugin.py:6459 ..\plugin.py:6547
-#: ..\plugin.py:6562 ..\plugin.py:6575 ..\plugin.py:6589 ..\plugin.py:6604
-#: ..\plugin.py:6617 ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6716
-#: ..\plugin.py:6728 ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767
-#: ..\plugin.py:6780 ..\plugin.py:6796 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:6879 ..\plugin.py:6893
-#: ..\plugin.py:6904 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6943
-#: ..\plugin.py:6953 ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7079 ..\plugin.py:7091 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7174 ..\plugin.py:7189 ..\plugin.py:7202
-#: ..\plugin.py:7216 ..\plugin.py:7231 ..\plugin.py:7244 ..\plugin.py:7266
-#: ..\plugin.py:7278 ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin.py:7386
-#: ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7422 ..\plugin.py:7432
-#: ..\plugin.py:7451 ..\plugin.py:7461 ..\plugin.py:7488 ..\plugin.py:7499
-#: ..\plugin.py:7531 ..\plugin.py:7554 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
-#: ..\plugin.py:7740 ..\plugin.py:7755 ..\plugin.py:7768 ..\plugin.py:7782
-#: ..\plugin.py:7797 ..\plugin.py:7810 ..\plugin.py:7832 ..\plugin.py:7844
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- yazı tipi"
 
-#: ..\plugin.py:5745
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr ""
 
-#: ..\plugin.py:5746
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr ""
 
-#: ..\plugin.py:5747
-msgid "Screen Switch Select - LCD"
-msgstr ""
-
-#: ..\plugin.py:5748
-msgid "Screens used for Changing"
-msgstr ""
-
-#: ..\plugin.py:5749 ..\plugin.py:7333
-msgid "Screen 1 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5751 ..\plugin.py:7335
-msgid "- Screen 2 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5752 ..\plugin.py:7336
-msgid "- Screen 3 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5753 ..\plugin.py:7337
-msgid "- Screen 4 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5754 ..\plugin.py:7338
-msgid "- Screen 5 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5755 ..\plugin.py:7339
-msgid "- Screen 6 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5756 ..\plugin.py:7340
-msgid "- Screen 7 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5757 ..\plugin.py:7341
-msgid "- Screen 8 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5758 ..\plugin.py:7342
-msgid "- Screen 9 Changing Time"
-msgstr ""
-
-#: ..\plugin.py:5759
-msgid "Picture Changing Time"
-msgstr ""
-
 #: ..\plugin.py:5760
-msgid "Picture Sort"
+msgid "Screen Default after mode change - Screen"
 msgstr ""
 
 #: ..\plugin.py:5761
-msgid "Picture Directory Recursive"
+msgid "Screen Switch Select - LCD"
 msgstr ""
 
 #: ..\plugin.py:5762
-msgid "Picture Quality for Resizing"
+msgid "Screens used for Changing"
 msgstr ""
 
-#: ..\plugin.py:5764
-msgid "Picture Quick Update Time [s]"
+#: ..\plugin.py:5763 ..\plugin.py:7350
+msgid "Screen 1 Changing Time"
 msgstr ""
 
-#: ..\plugin.py:5766
-msgid "Picture Type [only Picture]"
+#: ..\plugin.py:5765 ..\plugin.py:7352
+msgid "- Screen 2 Changing Time"
 msgstr ""
 
-#: ..\plugin.py:5767
-msgid "Background-Picture Type"
-msgstr "Arkaplan resim tipi"
-
-#: ..\plugin.py:5768
-msgid "Weather API"
+#: ..\plugin.py:5766 ..\plugin.py:7353
+msgid "- Screen 3 Changing Time"
 msgstr ""
 
-#: ..\plugin.py:5769
-msgid "Weather API-Key OpenWeatherMap"
+#: ..\plugin.py:5767 ..\plugin.py:7354
+msgid "- Screen 4 Changing Time"
 msgstr ""
 
-#: ..\plugin.py:5770
-msgid "Weather API-ID Key WeatherUnlocked"
+#: ..\plugin.py:5768 ..\plugin.py:7355
+msgid "- Screen 5 Changing Time"
 msgstr ""
 
-#: ..\plugin.py:5771
-msgid "Weather City"
+#: ..\plugin.py:5769 ..\plugin.py:7356
+msgid "- Screen 6 Changing Time"
 msgstr ""
 
-#: ..\plugin.py:5772
-msgid "Weather City 2"
+#: ..\plugin.py:5770 ..\plugin.py:7357
+msgid "- Screen 7 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5771 ..\plugin.py:7358
+msgid "- Screen 8 Changing Time"
+msgstr ""
+
+#: ..\plugin.py:5772 ..\plugin.py:7359
+msgid "- Screen 9 Changing Time"
 msgstr ""
 
 #: ..\plugin.py:5773
-msgid "Weather-Icon-Path [ok]>"
+msgid "Picture Changing Time"
 msgstr ""
 
 #: ..\plugin.py:5774
-msgid "Weather-Icon Zoom"
+msgid "Picture Sort"
 msgstr ""
 
 #: ..\plugin.py:5775
-msgid "Weather Low Temperature Color"
+msgid "Picture Directory Recursive"
 msgstr ""
 
 #: ..\plugin.py:5776
-msgid "Weather High Temperature Color"
-msgstr ""
-
-#: ..\plugin.py:5777
-msgid "Weather Transparency"
+msgid "Picture Quality for Resizing"
 msgstr ""
 
 #: ..\plugin.py:5778
-msgid "Weather Wind speed unit"
-msgstr ""
-
-#: ..\plugin.py:5779
-msgid "Weather Wind Info Lines"
+msgid "Picture Quick Update Time [s]"
 msgstr ""
 
 #: ..\plugin.py:5780
-msgid "Weather Rain Chance"
+msgid "Picture Type [only Picture]"
 msgstr ""
 
+#: ..\plugin.py:5781
+msgid "Background-Picture Type"
+msgstr "Arkaplan resim tipi"
+
 #: ..\plugin.py:5782
-msgid "- Rain Zoom"
+msgid "Weather API"
 msgstr ""
 
 #: ..\plugin.py:5783
-msgid "- Rain Color"
+msgid "Weather API-Key OpenWeatherMap"
 msgstr ""
 
 #: ..\plugin.py:5784
-msgid "- Rain use Color 2 from"
+msgid "Weather API-ID Key WeatherUnlocked"
 msgstr ""
 
 #: ..\plugin.py:5785
-msgid "- Rain Color 2"
+msgid "Weather City"
 msgstr ""
 
 #: ..\plugin.py:5786
-msgid "Weather Humidity Color"
+msgid "Weather City 2"
 msgstr ""
 
 #: ..\plugin.py:5787
-msgid "Weather Lines"
+msgid "Weather-Icon-Path [ok]>"
 msgstr ""
 
 #: ..\plugin.py:5788
-msgid "Weather Trendarrows"
+msgid "Weather-Icon Zoom"
 msgstr ""
 
 #: ..\plugin.py:5789
-msgid "Weather Extra Infos"
+msgid "Weather Low Temperature Color"
+msgstr ""
+
+#: ..\plugin.py:5790
+msgid "Weather High Temperature Color"
 msgstr ""
 
 #: ..\plugin.py:5791
-msgid "- Extra Zoom"
+msgid "Weather Transparency"
 msgstr ""
 
 #: ..\plugin.py:5792
-msgid "- Show chill temperature from difference"
+msgid "Weather Wind speed unit"
 msgstr ""
 
 #: ..\plugin.py:5793
-msgid "- Extra Color City"
+msgid "Weather Wind Info Lines"
 msgstr ""
 
 #: ..\plugin.py:5794
-msgid "- Extra Color Chill"
-msgstr ""
-
-#: ..\plugin.py:5795
-msgid "Netatmo CO2 Min Range"
+msgid "Weather Rain Chance"
 msgstr ""
 
 #: ..\plugin.py:5796
-msgid "Netatmo CO2 Max Range"
+msgid "- Rain Zoom"
 msgstr ""
 
 #: ..\plugin.py:5797
-msgid "Meteo URL"
+msgid "- Rain Color"
 msgstr ""
 
 #: ..\plugin.py:5798
-msgid "Moon-Icon-Path [ok]>"
+msgid "- Rain use Color 2 from"
 msgstr ""
 
 #: ..\plugin.py:5799
-msgid "Recording Picture [ok]>"
+msgid "- Rain Color 2"
 msgstr ""
 
 #: ..\plugin.py:5800
-msgid "Double-button switches"
+msgid "Weather Humidity Color"
 msgstr ""
 
 #: ..\plugin.py:5801
-msgid "Key for Screen Change"
+msgid "Weather Lines"
 msgstr ""
 
 #: ..\plugin.py:5802
-msgid "Key for Screen On/Off"
+msgid "Weather Trendarrows"
 msgstr ""
 
 #: ..\plugin.py:5803
-msgid "FritzCall Picture Path [ok]>"
-msgstr ""
-
-#: ..\plugin.py:5804
-msgid "FritzCall Number of Lines per Entry"
+msgid "Weather Extra Infos"
 msgstr ""
 
 #: ..\plugin.py:5805
-msgid "FritzCall Number of List Entries"
+msgid "- Extra Zoom"
 msgstr ""
 
 #: ..\plugin.py:5806
-msgid "FritzCall Number of Pictures"
+msgid "- Show chill temperature from difference"
 msgstr ""
 
 #: ..\plugin.py:5807
-msgid "FritzCall Picture Orientation"
+msgid "- Extra Color City"
 msgstr ""
 
 #: ..\plugin.py:5808
-msgid "FritzCall Picture Transparency"
+msgid "- Extra Color Chill"
 msgstr ""
 
 #: ..\plugin.py:5809
-msgid "FritzCall Pictures Search"
+msgid "Netatmo CO2 Min Range"
 msgstr ""
 
 #: ..\plugin.py:5810
-msgid "FritzCall remove Calls after hours"
+msgid "Netatmo CO2 Max Range"
 msgstr ""
 
 #: ..\plugin.py:5811
-msgid "FritzCall Popup-Time"
+msgid "Meteo URL"
 msgstr ""
 
 #: ..\plugin.py:5812
-msgid "FritzCall Popup LCD"
+msgid "Moon-Icon-Path [ok]>"
 msgstr ""
 
 #: ..\plugin.py:5813
-msgid "FritzCall Popup Color"
+msgid "Recording Picture [ok]>"
 msgstr ""
 
 #: ..\plugin.py:5814
-msgid "FritzCall Frame Picture [ok]>"
+msgid "Double-button switches"
 msgstr ""
 
 #: ..\plugin.py:5815
-msgid "Calendar ics-Path [ok]>"
+msgid "Key for Screen Change"
 msgstr ""
 
-#: ..\plugin.py:5817 ..\plugin.py:5819 ..\plugin.py:5821
-msgid "Calendar ics-URL"
+#: ..\plugin.py:5816
+msgid "Key for Screen On/Off"
+msgstr ""
+
+#: ..\plugin.py:5817
+msgid "FritzCall Picture Path [ok]>"
+msgstr ""
+
+#: ..\plugin.py:5818
+msgid "FritzCall Number of Lines per Entry"
+msgstr ""
+
+#: ..\plugin.py:5819
+msgid "FritzCall Number of List Entries"
+msgstr ""
+
+#: ..\plugin.py:5820
+msgid "FritzCall Number of Pictures"
+msgstr ""
+
+#: ..\plugin.py:5821
+msgid "FritzCall Picture Orientation"
+msgstr ""
+
+#: ..\plugin.py:5822
+msgid "FritzCall Picture Transparency"
 msgstr ""
 
 #: ..\plugin.py:5823
-msgid "Calendar planerFS"
+msgid "FritzCall Pictures Search"
+msgstr ""
+
+#: ..\plugin.py:5824
+msgid "FritzCall remove Calls after hours"
 msgstr ""
 
 #: ..\plugin.py:5825
-msgid "Calendar Saturday Color"
+msgid "FritzCall Popup-Time"
 msgstr ""
 
 #: ..\plugin.py:5826
-msgid "Calendar Sunday Color"
+msgid "FritzCall Popup LCD"
 msgstr ""
 
 #: ..\plugin.py:5827
-msgid "Calendar Line Thickness"
+msgid "FritzCall Popup Color"
 msgstr ""
 
 #: ..\plugin.py:5828
-msgid "Calendar Day Event Preview"
+msgid "FritzCall Frame Picture [ok]>"
 msgstr ""
 
 #: ..\plugin.py:5829
-msgid "Calendar Timezone Correction"
+msgid "Calendar ics-Path [ok]>"
 msgstr ""
 
-#: ..\plugin.py:5830
-msgid "Calendar Transparency"
-msgstr ""
-
-#: ..\plugin.py:5831
-msgid "Calendar Poll Interval"
-msgstr ""
-
-#: ..\plugin.py:5832
-msgid "Tuner Color"
-msgstr ""
-
-#: ..\plugin.py:5833
-msgid "Tuner Color Active"
-msgstr ""
-
-#: ..\plugin.py:5834
-msgid "Tuner Color On"
-msgstr ""
-
-#: ..\plugin.py:5835
-msgid "Service search first"
-msgstr ""
-
-#: ..\plugin.py:5836
-msgid "DVB-T Signal-Quality Correction"
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
+msgid "Calendar ics-URL"
 msgstr ""
 
 #: ..\plugin.py:5837
-msgid "Font global [ok]>"
-msgstr "Yazı tipi genel [ok]>"
-
-#: ..\plugin.py:5838
-msgid "Font 1 [ok]>"
-msgstr "Yazı tipi 1 [ok]>"
+msgid "Calendar planerFS"
+msgstr ""
 
 #: ..\plugin.py:5839
-msgid "Font 2 [ok]>"
-msgstr "Yazı tipi 2 [ok]>"
+msgid "Calendar Saturday Color"
+msgstr ""
 
 #: ..\plugin.py:5840
-msgid "Font 3 [ok]>"
-msgstr "Yazı tipi 3 [ok]>"
+msgid "Calendar Sunday Color"
+msgstr ""
 
 #: ..\plugin.py:5841
-msgid "Font 4 [ok]>"
-msgstr "Yazı tipi 4 [ok]>"
+msgid "Calendar Line Thickness"
+msgstr ""
 
 #: ..\plugin.py:5842
-msgid "Font 5 [ok]>"
-msgstr "Yazı tipi 5 [ok]>"
+msgid "Calendar Day Event Preview"
+msgstr ""
 
 #: ..\plugin.py:5843
-msgid "Mail 1 Connect"
+msgid "Calendar Timezone Correction"
 msgstr ""
 
 #: ..\plugin.py:5844
-msgid "Mail 1 Server"
+msgid "Calendar Transparency"
 msgstr ""
 
 #: ..\plugin.py:5845
-msgid "Mail 1 [Displayname:]Username"
+msgid "Calendar Poll Interval"
 msgstr ""
 
 #: ..\plugin.py:5846
-msgid "Mail 1 Password"
+msgid "Tuner Color"
 msgstr ""
 
 #: ..\plugin.py:5847
-msgid "Mail 2 Connect"
+msgid "Tuner Color Active"
 msgstr ""
 
 #: ..\plugin.py:5848
-msgid "Mail 2 Server"
+msgid "Tuner Color On"
 msgstr ""
 
 #: ..\plugin.py:5849
-msgid "Mail 2 [Displayname:]Username"
+msgid "Service search first"
 msgstr ""
 
 #: ..\plugin.py:5850
-msgid "Mail 2 Password"
+msgid "DVB-T Signal-Quality Correction"
 msgstr ""
 
 #: ..\plugin.py:5851
-msgid "Mail 3 Connect"
-msgstr ""
+msgid "Font global [ok]>"
+msgstr "Yazı tipi genel [ok]>"
 
 #: ..\plugin.py:5852
-msgid "Mail 3 Server"
-msgstr ""
+msgid "Font 1 [ok]>"
+msgstr "Yazı tipi 1 [ok]>"
 
 #: ..\plugin.py:5853
-msgid "Mail 3 [Displayname:]Username"
-msgstr ""
+msgid "Font 2 [ok]>"
+msgstr "Yazı tipi 2 [ok]>"
 
 #: ..\plugin.py:5854
-msgid "Mail 3 Password"
-msgstr ""
+msgid "Font 3 [ok]>"
+msgstr "Yazı tipi 3 [ok]>"
 
 #: ..\plugin.py:5855
-msgid "Mail 4 Connect"
-msgstr ""
+msgid "Font 4 [ok]>"
+msgstr "Yazı tipi 4 [ok]>"
 
 #: ..\plugin.py:5856
-msgid "Mail 4 Server"
-msgstr ""
+msgid "Font 5 [ok]>"
+msgstr "Yazı tipi 5 [ok]>"
 
 #: ..\plugin.py:5857
-msgid "Mail 4 [Displayname:]Username"
+msgid "Mail 1 Connect"
 msgstr ""
 
 #: ..\plugin.py:5858
-msgid "Mail 4 Password"
+msgid "Mail 1 Server"
 msgstr ""
 
 #: ..\plugin.py:5859
-msgid "Mail 5 Connect"
+msgid "Mail 1 [Displayname:]Username"
 msgstr ""
 
 #: ..\plugin.py:5860
-msgid "Mail 5 Server"
+msgid "Mail 1 Password"
 msgstr ""
 
 #: ..\plugin.py:5861
-msgid "Mail 5 [Displayname:]Username"
+msgid "Mail 2 Connect"
 msgstr ""
 
 #: ..\plugin.py:5862
-msgid "Mail 5 Password"
+msgid "Mail 2 Server"
 msgstr ""
 
 #: ..\plugin.py:5863
-msgid "Mail Poll Interval"
+msgid "Mail 2 [Displayname:]Username"
 msgstr ""
 
 #: ..\plugin.py:5864
-msgid "Mail IMAP limit to last days"
+msgid "Mail 2 Password"
 msgstr ""
 
 #: ..\plugin.py:5865
-msgid "Mail Show Empty Mailboxes"
+msgid "Mail 3 Connect"
 msgstr ""
 
 #: ..\plugin.py:5866
-msgid "Mail Show Date"
+msgid "Mail 3 Server"
 msgstr ""
 
 #: ..\plugin.py:5867
-msgid "Mail Hide Mailadress"
+msgid "Mail 3 [Displayname:]Username"
 msgstr ""
 
 #: ..\plugin.py:5868
-msgid "Remote Box 1 [Displayname:]IP/Name"
+msgid "Mail 3 Password"
 msgstr ""
 
 #: ..\plugin.py:5869
-msgid "Remote Box 2 [Displayname:]IP/Name"
+msgid "Mail 4 Connect"
 msgstr ""
 
 #: ..\plugin.py:5870
-msgid "Remote Box 3 [Displayname:]IP/Name"
+msgid "Mail 4 Server"
 msgstr ""
 
 #: ..\plugin.py:5871
-msgid "Remote Box 4 [Displayname:]IP/Name"
+msgid "Mail 4 [Displayname:]Username"
 msgstr ""
 
 #: ..\plugin.py:5872
-msgid "Remote Box 5 [Displayname:]IP/Name"
+msgid "Mail 4 Password"
 msgstr ""
 
 #: ..\plugin.py:5873
-msgid "Remote Box Poll every Minutes"
+msgid "Mail 5 Connect"
 msgstr ""
 
 #: ..\plugin.py:5874
-msgid "Remote Box Timer [Displayname:]IP/Name"
+msgid "Mail 5 Server"
 msgstr ""
 
 #: ..\plugin.py:5875
-msgid "Remote Box Timer Poll every Minutes"
+msgid "Mail 5 [Displayname:]Username"
 msgstr ""
 
 #: ..\plugin.py:5876
-msgid "WWW Converter Poll Interval"
+msgid "Mail 5 Password"
 msgstr ""
 
 #: ..\plugin.py:5877
-msgid "WWW Converter Usage"
+msgid "Mail Poll Interval"
 msgstr ""
 
 #: ..\plugin.py:5878
-msgid "WWW ApiKey from cloudconvert.org"
+msgid "Mail IMAP limit to last days"
 msgstr ""
 
 #: ..\plugin.py:5879
-msgid "WWW ApiKey from convertapi.com"
+msgid "Mail Show Empty Mailboxes"
 msgstr ""
 
 #: ..\plugin.py:5880
-msgid "WebIF Refresh [s]"
+msgid "Mail Show Date"
 msgstr ""
 
 #: ..\plugin.py:5881
-msgid "WebIF Refresh Type"
+msgid "Mail Hide Mailadress"
 msgstr ""
 
 #: ..\plugin.py:5882
-msgid "WebIF Init Delay"
+msgid "Remote Box 1 [Displayname:]IP/Name"
+msgstr ""
+
+#: ..\plugin.py:5883
+msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr ""
 
 #: ..\plugin.py:5884
-msgid "WebIF IP Deny"
+msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr ""
 
 #: ..\plugin.py:5885
-msgid "WebIF Design"
+msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr ""
 
 #: ..\plugin.py:5886
-msgid "Save as Picture for WebIF"
+msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr ""
 
 #: ..\plugin.py:5887
-msgid "MJPEG Stream LCD 1 enable"
+msgid "Remote Box Poll every Minutes"
 msgstr ""
 
 #: ..\plugin.py:5888
-msgid "MJPEG Stream LCD 1 Port"
+msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr ""
 
 #: ..\plugin.py:5889
-msgid "MJPEG Stream LCD 1 Virtual Brightness"
-msgstr "- LCD 1 Sanal Parlaklık"
+msgid "Remote Box Timer Poll every Minutes"
+msgstr ""
 
 #: ..\plugin.py:5890
-msgid "MJPEG Stream LCD 2 enable"
+msgid "WWW Converter Poll Interval"
 msgstr ""
 
 #: ..\plugin.py:5891
-msgid "MJPEG Stream LCD 2 Port"
+msgid "WWW Converter Usage"
 msgstr ""
 
 #: ..\plugin.py:5892
-msgid "MJPEG Stream LCD 2 Virtual Brightness"
-msgstr "- LCD 2 Sanal Parlaklık"
+msgid "WWW ApiKey from cloudconvert.org"
+msgstr ""
 
 #: ..\plugin.py:5893
-msgid "MJPEG Stream LCD 3 enable"
+msgid "WWW ApiKey from convertapi.com"
 msgstr ""
 
 #: ..\plugin.py:5894
-msgid "MJPEG Stream LCD 3 Port"
+msgid "WebIF Refresh [s]"
 msgstr ""
 
 #: ..\plugin.py:5895
-msgid "MJPEG Stream LCD 3 Virtual Brightness"
-msgstr "- LCD 3 Sanal Parlaklık"
+msgid "WebIF Refresh Type"
+msgstr ""
 
-#: ..\plugin.py:5897
-msgid "MJPEG Cycle"
+#: ..\plugin.py:5896
+msgid "WebIF Init Delay"
 msgstr ""
 
 #: ..\plugin.py:5898
-msgid "MJPEG Restart on Error"
+msgid "WebIF IP Deny"
 msgstr ""
 
 #: ..\plugin.py:5899
-msgid "MJPEG Header Mode"
+msgid "WebIF Design"
 msgstr ""
 
 #: ..\plugin.py:5900
-msgid "Show Streams '4097; 5001...5003' in Mode"
+msgid "Save as Picture for WebIF"
 msgstr ""
 
 #: ..\plugin.py:5901
-msgid "Sonos IP"
+msgid "MJPEG Stream LCD 1 enable"
 msgstr ""
 
 #: ..\plugin.py:5902
-msgid "Sonos Ping Timeout [ms]"
+msgid "MJPEG Stream LCD 1 Port"
 msgstr ""
 
 #: ..\plugin.py:5903
-msgid "Sonos Play Check"
-msgstr ""
+msgid "MJPEG Stream LCD 1 Virtual Brightness"
+msgstr "- LCD 1 Sanal Parlaklık"
 
 #: ..\plugin.py:5904
-msgid "Sonos Refresh [s]"
+msgid "MJPEG Stream LCD 2 enable"
 msgstr ""
 
 #: ..\plugin.py:5905
-msgid "BlueSound IP"
+msgid "MJPEG Stream LCD 2 Port"
 msgstr ""
 
 #: ..\plugin.py:5906
-msgid "BlueSound Ping Timeout [ms]"
-msgstr ""
+msgid "MJPEG Stream LCD 2 Virtual Brightness"
+msgstr "- LCD 2 Sanal Parlaklık"
 
 #: ..\plugin.py:5907
-msgid "BlueSound Play Check"
+msgid "MJPEG Stream LCD 3 enable"
 msgstr ""
 
 #: ..\plugin.py:5908
-msgid "BlueSound Refresh [s]"
+msgid "MJPEG Stream LCD 3 Port"
 msgstr ""
 
 #: ..\plugin.py:5909
-msgid "MusicCast IP"
-msgstr ""
-
-#: ..\plugin.py:5910
-msgid "MusicCast Server IP [optional]"
-msgstr ""
+msgid "MJPEG Stream LCD 3 Virtual Brightness"
+msgstr "- LCD 3 Sanal Parlaklık"
 
 #: ..\plugin.py:5911
-msgid "MusicCast Ping Timeout [ms]"
+msgid "MJPEG Cycle"
 msgstr ""
 
 #: ..\plugin.py:5912
-msgid "MusicCast Play Check"
+msgid "MJPEG Restart on Error"
 msgstr ""
 
 #: ..\plugin.py:5913
-msgid "MusicCast Refresh [s]"
+msgid "MJPEG Header Mode"
 msgstr ""
 
 #: ..\plugin.py:5914
-msgid "MusicCast Cover"
+msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr ""
 
 #: ..\plugin.py:5915
-msgid "LCD Custom Width"
+msgid "Sonos IP"
 msgstr ""
 
 #: ..\plugin.py:5916
-msgid "LCD Custom Height"
+msgid "Sonos Ping Timeout [ms]"
 msgstr ""
 
 #: ..\plugin.py:5917
-msgid "LCD Custom Width 2"
+msgid "Sonos Play Check"
 msgstr ""
 
 #: ..\plugin.py:5918
-msgid "LCD Custom Height 2"
+msgid "Sonos Refresh [s]"
 msgstr ""
 
 #: ..\plugin.py:5919
-msgid "LCD Off when shutdown"
+msgid "BlueSound IP"
 msgstr ""
 
 #: ..\plugin.py:5920
-msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgid "BlueSound Ping Timeout [ms]"
 msgstr ""
 
 #: ..\plugin.py:5921
-msgid "Display Delay [ms]"
+msgid "BlueSound Play Check"
 msgstr ""
 
 #: ..\plugin.py:5922
-msgid "Threads per LCD"
+msgid "BlueSound Refresh [s]"
 msgstr ""
 
 #: ..\plugin.py:5923
-msgid "Show Crash Corner"
+msgid "MusicCast IP"
 msgstr ""
 
 #: ..\plugin.py:5924
-msgid "Show 'no ....' Messages"
+msgid "MusicCast Server IP [optional]"
 msgstr ""
 
 #: ..\plugin.py:5925
-msgid "Storage-Devices: Force Read"
+msgid "MusicCast Ping Timeout [ms]"
 msgstr ""
 
 #: ..\plugin.py:5926
+msgid "MusicCast Play Check"
+msgstr ""
+
+#: ..\plugin.py:5927
+msgid "MusicCast Refresh [s]"
+msgstr ""
+
+#: ..\plugin.py:5928
+msgid "MusicCast Cover"
+msgstr ""
+
+#: ..\plugin.py:5929
+msgid "LCD Custom Width"
+msgstr ""
+
+#: ..\plugin.py:5930
+msgid "LCD Custom Height"
+msgstr ""
+
+#: ..\plugin.py:5931
+msgid "LCD Custom Width 2"
+msgstr ""
+
+#: ..\plugin.py:5932
+msgid "LCD Custom Height 2"
+msgstr ""
+
+#: ..\plugin.py:5933
+msgid "LCD Off when shutdown"
+msgstr ""
+
+#: ..\plugin.py:5934
+msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
+msgstr ""
+
+#: ..\plugin.py:5935
+msgid "Display Delay [ms]"
+msgstr ""
+
+#: ..\plugin.py:5936
+msgid "Threads per LCD"
+msgstr ""
+
+#: ..\plugin.py:5937
+msgid "Show Crash Corner"
+msgstr ""
+
+#: ..\plugin.py:5938
+msgid "Show 'no ....' Messages"
+msgstr ""
+
+#: ..\plugin.py:5939
+msgid "Storage-Devices: Force Read"
+msgstr ""
+
+#: ..\plugin.py:5940
 #, fuzzy
 msgid "Storage-Devices: Color Back"
 msgstr "depolama aygıtları"
 
-#: ..\plugin.py:5927
+#: ..\plugin.py:5941
 #, fuzzy
 msgid "Storage-Devices: Color Bar"
 msgstr "depolama aygıtları"
 
-#: ..\plugin.py:5928
+#: ..\plugin.py:5942
 #, fuzzy
 msgid "Storage-Devices: Color Full"
 msgstr "depolama aygıtları"
 
-#: ..\plugin.py:5929
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr ""
 
-#: ..\plugin.py:5930
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr ""
 
-#: ..\plugin.py:5931
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr ""
 
-#: ..\plugin.py:5932
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr ""
 
-#: ..\plugin.py:5933
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr ""
 
-#: ..\plugin.py:5937 ..\plugin.py:7310
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr ""
 
-#: ..\plugin.py:5938 ..\plugin.py:7311
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr ""
 
-#: ..\plugin.py:5939 ..\plugin.py:7312
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr ""
 
-#: ..\plugin.py:5940 ..\plugin.py:7313
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr ""
 
-#: ..\plugin.py:5941 ..\plugin.py:6698 ..\plugin.py:7314
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr ""
 
-#: ..\plugin.py:5942 ..\plugin.py:6700 ..\plugin.py:7328
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr ""
 
-#: ..\plugin.py:5946 ..\plugin.py:6704 ..\plugin.py:7332
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr ""
 
-#: ..\plugin.py:5950 ..\plugin.py:5963
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr ""
 
-#: ..\plugin.py:5953 ..\plugin.py:5966 ..\plugin.py:5983 ..\plugin.py:5998
-#: ..\plugin.py:6010 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6102 ..\plugin.py:6116 ..\plugin.py:6128
-#: ..\plugin.py:6139 ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6177
-#: ..\plugin.py:6188 ..\plugin.py:6197 ..\plugin.py:6205 ..\plugin.py:6215
-#: ..\plugin.py:6225 ..\plugin.py:6243 ..\plugin.py:6255 ..\plugin.py:6273
-#: ..\plugin.py:6281 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6312
-#: ..\plugin.py:6335 ..\plugin.py:6359 ..\plugin.py:6369 ..\plugin.py:6381
-#: ..\plugin.py:6391 ..\plugin.py:6404 ..\plugin.py:6413 ..\plugin.py:6539
-#: ..\plugin.py:6573 ..\plugin.py:6596 ..\plugin.py:6611 ..\plugin.py:6624
-#: ..\plugin.py:6635 ..\plugin.py:6647 ..\plugin.py:6678 ..\plugin.py:6713
-#: ..\plugin.py:6725 ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764
-#: ..\plugin.py:6777 ..\plugin.py:6804 ..\plugin.py:6813 ..\plugin.py:6825
-#: ..\plugin.py:6840 ..\plugin.py:6852 ..\plugin.py:6865 ..\plugin.py:6876
-#: ..\plugin.py:6890 ..\plugin.py:6901 ..\plugin.py:6911 ..\plugin.py:6921
-#: ..\plugin.py:6939 ..\plugin.py:6950 ..\plugin.py:6968 ..\plugin.py:6976
-#: ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7007 ..\plugin.py:7030
-#: ..\plugin.py:7054 ..\plugin.py:7064 ..\plugin.py:7076 ..\plugin.py:7086
-#: ..\plugin.py:7157 ..\plugin.py:7166 ..\plugin.py:7200 ..\plugin.py:7223
-#: ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7262 ..\plugin.py:7274
-#: ..\plugin.py:7305 ..\plugin.py:7354 ..\plugin.py:7369 ..\plugin.py:7383
-#: ..\plugin.py:7395 ..\plugin.py:7408 ..\plugin.py:7419 ..\plugin.py:7429
-#: ..\plugin.py:7447 ..\plugin.py:7458 ..\plugin.py:7476 ..\plugin.py:7484
-#: ..\plugin.py:7495 ..\plugin.py:7506 ..\plugin.py:7515 ..\plugin.py:7538
-#: ..\plugin.py:7562 ..\plugin.py:7572 ..\plugin.py:7584 ..\plugin.py:7594
-#: ..\plugin.py:7606 ..\plugin.py:7732 ..\plugin.py:7766 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7828 ..\plugin.py:7840
-#: ..\plugin.py:7871
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr ""
 
-#: ..\plugin.py:5954 ..\plugin.py:5967
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- tam Ekran"
 
-#: ..\plugin.py:5955 ..\plugin.py:5968
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr ""
 
-#: ..\plugin.py:5956 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:7123
-#: ..\plugin.py:7133 ..\plugin.py:7146 ..\plugin.py:7675 ..\plugin.py:7685
-#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- saydam"
 
-#: ..\plugin.py:5957 ..\plugin.py:5969 ..\plugin.py:6142 ..\plugin.py:6154
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr ""
 
-#: ..\plugin.py:5958 ..\plugin.py:5970
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr ""
 
-#: ..\plugin.py:5959 ..\plugin.py:5971
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr ""
 
-#: ..\plugin.py:5960
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr ""
 
-#: ..\plugin.py:5972 ..\plugin.py:6814 ..\plugin.py:7343
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "Saat"
 
-#: ..\plugin.py:5975 ..\plugin.py:5990 ..\plugin.py:6673 ..\plugin.py:7300
-#: ..\plugin.py:7866
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
-msgstr "- tipi"
+msgstr "-  tipi"
 
-#: ..\plugin.py:5977 ..\plugin.py:5992 ..\plugin.py:6819 ..\plugin.py:6834
-#: ..\plugin.py:7348 ..\plugin.py:7363
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- analog saat"
 
-#: ..\plugin.py:5979 ..\plugin.py:5994 ..\plugin.py:6821 ..\plugin.py:6836
-#: ..\plugin.py:7350 ..\plugin.py:7365
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr ""
 
-#: ..\plugin.py:5980 ..\plugin.py:5995 ..\plugin.py:6082 ..\plugin.py:6099
-#: ..\plugin.py:6113 ..\plugin.py:6124 ..\plugin.py:6184 ..\plugin.py:6356
-#: ..\plugin.py:6366 ..\plugin.py:6375 ..\plugin.py:6463 ..\plugin.py:6477
-#: ..\plugin.py:6487 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
-#: ..\plugin.py:6527 ..\plugin.py:6608 ..\plugin.py:6621 ..\plugin.py:6674
-#: ..\plugin.py:6786 ..\plugin.py:6800 ..\plugin.py:6822 ..\plugin.py:6837
-#: ..\plugin.py:6849 ..\plugin.py:6862 ..\plugin.py:7051 ..\plugin.py:7061
-#: ..\plugin.py:7070 ..\plugin.py:7118 ..\plugin.py:7128 ..\plugin.py:7137
-#: ..\plugin.py:7235 ..\plugin.py:7248 ..\plugin.py:7301 ..\plugin.py:7351
-#: ..\plugin.py:7366 ..\plugin.py:7392 ..\plugin.py:7405 ..\plugin.py:7559
-#: ..\plugin.py:7569 ..\plugin.py:7578 ..\plugin.py:7656 ..\plugin.py:7670
-#: ..\plugin.py:7680 ..\plugin.py:7690 ..\plugin.py:7700 ..\plugin.py:7710
-#: ..\plugin.py:7720 ..\plugin.py:7801 ..\plugin.py:7814 ..\plugin.py:7867
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr ""
 
-#: ..\plugin.py:5985 ..\plugin.py:6000 ..\plugin.py:6012 ..\plugin.py:6022
-#: ..\plugin.py:6035 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6143 ..\plugin.py:6155
-#: ..\plugin.py:6179 ..\plugin.py:6207 ..\plugin.py:6217 ..\plugin.py:6227
-#: ..\plugin.py:6246 ..\plugin.py:6257 ..\plugin.py:6284 ..\plugin.py:6295
-#: ..\plugin.py:6327 ..\plugin.py:6350 ..\plugin.py:6383 ..\plugin.py:6395
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6546 ..\plugin.py:6561 ..\plugin.py:6574 ..\plugin.py:6588
-#: ..\plugin.py:6603 ..\plugin.py:6616 ..\plugin.py:6638 ..\plugin.py:6650
-#: ..\plugin.py:6715 ..\plugin.py:6727 ..\plugin.py:6740 ..\plugin.py:6753
-#: ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6827 ..\plugin.py:6842
-#: ..\plugin.py:6855 ..\plugin.py:6868 ..\plugin.py:6892 ..\plugin.py:6903
-#: ..\plugin.py:6913 ..\plugin.py:6923 ..\plugin.py:6942 ..\plugin.py:6952
-#: ..\plugin.py:6979 ..\plugin.py:6990 ..\plugin.py:7022 ..\plugin.py:7045
-#: ..\plugin.py:7078 ..\plugin.py:7090 ..\plugin.py:7101 ..\plugin.py:7112
-#: ..\plugin.py:7173 ..\plugin.py:7188 ..\plugin.py:7201 ..\plugin.py:7215
-#: ..\plugin.py:7230 ..\plugin.py:7243 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7356 ..\plugin.py:7371 ..\plugin.py:7385 ..\plugin.py:7398
-#: ..\plugin.py:7411 ..\plugin.py:7431 ..\plugin.py:7450 ..\plugin.py:7460
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7586 ..\plugin.py:7598 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7739 ..\plugin.py:7754
-#: ..\plugin.py:7767 ..\plugin.py:7781 ..\plugin.py:7796 ..\plugin.py:7809
-#: ..\plugin.py:7831 ..\plugin.py:7843
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr ""
 
-#: ..\plugin.py:5987 ..\plugin.py:6829 ..\plugin.py:7358
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "Saat 2"
 
-#: ..\plugin.py:6002 ..\plugin.py:6743
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr ""
 
-#: ..\plugin.py:6006 ..\plugin.py:6029 ..\plugin.py:6042 ..\plugin.py:6055
-#: ..\plugin.py:6068 ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin.py:6171
-#: ..\plugin.py:6567 ..\plugin.py:6612 ..\plugin.py:6709 ..\plugin.py:6721
-#: ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760 ..\plugin.py:6773
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6884 ..\plugin.py:7194
-#: ..\plugin.py:7239 ..\plugin.py:7377 ..\plugin.py:7396 ..\plugin.py:7409
-#: ..\plugin.py:7760 ..\plugin.py:7805
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr ""
 
-#: ..\plugin.py:6009 ..\plugin.py:6032 ..\plugin.py:6045 ..\plugin.py:6058
-#: ..\plugin.py:6071 ..\plugin.py:6085 ..\plugin.py:6127 ..\plugin.py:6176
-#: ..\plugin.py:6187 ..\plugin.py:6572 ..\plugin.py:6712 ..\plugin.py:6724
-#: ..\plugin.py:6737 ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776
-#: ..\plugin.py:6789 ..\plugin.py:6803 ..\plugin.py:6889 ..\plugin.py:7199
-#: ..\plugin.py:7382 ..\plugin.py:7765
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr ""
 
-#: ..\plugin.py:6014
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr ""
 
-#: ..\plugin.py:6024 ..\plugin.py:6755
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr ""
 
-#: ..\plugin.py:6027 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6080 ..\plugin.py:6081 ..\plugin.py:6141 ..\plugin.py:6153
-#: ..\plugin.py:6164 ..\plugin.py:6172 ..\plugin.py:6173 ..\plugin.py:6203
-#: ..\plugin.py:6229 ..\plugin.py:6259 ..\plugin.py:6274 ..\plugin.py:6318
-#: ..\plugin.py:6319 ..\plugin.py:6341 ..\plugin.py:6342 ..\plugin.py:6361
-#: ..\plugin.py:6371 ..\plugin.py:6394 ..\plugin.py:6544 ..\plugin.py:6560
-#: ..\plugin.py:6568 ..\plugin.py:6569 ..\plugin.py:6584 ..\plugin.py:6597
-#: ..\plugin.py:6598 ..\plugin.py:6614 ..\plugin.py:6625 ..\plugin.py:6682
-#: ..\plugin.py:6732 ..\plugin.py:6758 ..\plugin.py:6771 ..\plugin.py:6784
-#: ..\plugin.py:6785 ..\plugin.py:6817 ..\plugin.py:6832 ..\plugin.py:6877
-#: ..\plugin.py:6885 ..\plugin.py:6886 ..\plugin.py:6899 ..\plugin.py:6925
-#: ..\plugin.py:6954 ..\plugin.py:6969 ..\plugin.py:7013 ..\plugin.py:7014
-#: ..\plugin.py:7036 ..\plugin.py:7037 ..\plugin.py:7056 ..\plugin.py:7066
-#: ..\plugin.py:7089 ..\plugin.py:7171 ..\plugin.py:7187 ..\plugin.py:7195
-#: ..\plugin.py:7196 ..\plugin.py:7211 ..\plugin.py:7224 ..\plugin.py:7225
-#: ..\plugin.py:7241 ..\plugin.py:7252 ..\plugin.py:7346 ..\plugin.py:7361
-#: ..\plugin.py:7378 ..\plugin.py:7379 ..\plugin.py:7420 ..\plugin.py:7433
-#: ..\plugin.py:7462 ..\plugin.py:7477 ..\plugin.py:7521 ..\plugin.py:7522
-#: ..\plugin.py:7544 ..\plugin.py:7545 ..\plugin.py:7564 ..\plugin.py:7574
-#: ..\plugin.py:7597 ..\plugin.py:7737 ..\plugin.py:7753 ..\plugin.py:7761
-#: ..\plugin.py:7762 ..\plugin.py:7777 ..\plugin.py:7790 ..\plugin.py:7791
-#: ..\plugin.py:7807 ..\plugin.py:7818
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- tipi"
 
-#: ..\plugin.py:6037
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr ""
 
-#: ..\plugin.py:6050 ..\plugin.py:6768
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr ""
 
-#: ..\plugin.py:6063 ..\plugin.py:6729
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr ""
 
-#: ..\plugin.py:6076 ..\plugin.py:6742
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr ""
 
-#: ..\plugin.py:6077 ..\plugin.py:6781
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr ""
 
-#: ..\plugin.py:6087 ..\plugin.py:6791
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- renk Metin"
 
-#: ..\plugin.py:6088 ..\plugin.py:6792
+#: ..\plugin.py:6103 ..\plugin.py:6808
 #, fuzzy
 #| msgid "- LCD 1 Background Color"
 msgid "- Color Background"
 msgstr "- LCD 1 arkaplan rengi"
 
-#: ..\plugin.py:6089 ..\plugin.py:6793
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr ""
 
-#: ..\plugin.py:6090 ..\plugin.py:6190 ..\plugin.py:6794 ..\plugin.py:6806
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr ""
 
-#: ..\plugin.py:6091 ..\plugin.py:6795
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr ""
 
-#: ..\plugin.py:6093 ..\plugin.py:6844 ..\plugin.py:7387
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr ""
 
-#: ..\plugin.py:6096 ..\plugin.py:6110
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr ""
 
-#: ..\plugin.py:6097 ..\plugin.py:6111 ..\plugin.py:6847 ..\plugin.py:6860
-#: ..\plugin.py:7390 ..\plugin.py:7403
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr ""
 
-#: ..\plugin.py:6098 ..\plugin.py:6112 ..\plugin.py:6848 ..\plugin.py:6861
-#: ..\plugin.py:7391 ..\plugin.py:7404
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr ""
 
-#: ..\plugin.py:6107 ..\plugin.py:6857 ..\plugin.py:7400
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr ""
 
-#: ..\plugin.py:6121
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr ""
 
-#: ..\plugin.py:6130
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr ""
 
-#: ..\plugin.py:6131
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr ""
 
-#: ..\plugin.py:6132
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr ""
 
-#: ..\plugin.py:6133
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "Uydu"
 
-#: ..\plugin.py:6145
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "Yayıncı"
 
-#: ..\plugin.py:6157 ..\plugin.py:6870 ..\plugin.py:7413
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr ""
 
-#: ..\plugin.py:6165 ..\plugin.py:6878 ..\plugin.py:7421
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr ""
 
-#: ..\plugin.py:6167 ..\plugin.py:6880 ..\plugin.py:7373
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr ""
 
-#: ..\plugin.py:6181 ..\plugin.py:6797
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr ""
 
-#: ..\plugin.py:6191 ..\plugin.py:6807
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr ""
 
-#: ..\plugin.py:6198 ..\plugin.py:6894
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr ""
 
-#: ..\plugin.py:6209 ..\plugin.py:6905
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr ""
 
-#: ..\plugin.py:6219 ..\plugin.py:6915 ..\plugin.py:7423
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr ""
 
-#: ..\plugin.py:6230 ..\plugin.py:6926 ..\plugin.py:7434
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr ""
 
-#: ..\plugin.py:6231 ..\plugin.py:6927 ..\plugin.py:7435
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr ""
 
-#: ..\plugin.py:6232 ..\plugin.py:6233 ..\plugin.py:6234 ..\plugin.py:6235
-#: ..\plugin.py:6236 ..\plugin.py:6928 ..\plugin.py:6929 ..\plugin.py:6930
-#: ..\plugin.py:6931 ..\plugin.py:6932 ..\plugin.py:7436 ..\plugin.py:7437
-#: ..\plugin.py:7438 ..\plugin.py:7439 ..\plugin.py:7440
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr ""
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr ""
 
-#: ..\plugin.py:6248
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr ""
 
-#: ..\plugin.py:6249 ..\plugin.py:6944 ..\plugin.py:7452
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "Depolama aygıtları"
 
-#: ..\plugin.py:6260 ..\plugin.py:6955 ..\plugin.py:7463
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr ""
 
-#: ..\plugin.py:6261 ..\plugin.py:6956 ..\plugin.py:7464
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr ""
 
-#: ..\plugin.py:6262 ..\plugin.py:6263 ..\plugin.py:6264 ..\plugin.py:6265
-#: ..\plugin.py:6266 ..\plugin.py:6957 ..\plugin.py:6958 ..\plugin.py:6959
-#: ..\plugin.py:6960 ..\plugin.py:6961 ..\plugin.py:7465 ..\plugin.py:7466
-#: ..\plugin.py:7467 ..\plugin.py:7468 ..\plugin.py:7469
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- aygıt adı"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr ""
 
-#: ..\plugin.py:6279 ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6594
-#: ..\plugin.py:6974 ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7221
-#: ..\plugin.py:7482 ..\plugin.py:7493 ..\plugin.py:7504 ..\plugin.py:7787
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr ""
 
-#: ..\plugin.py:6282 ..\plugin.py:6293 ..\plugin.py:6304 ..\plugin.py:6977
-#: ..\plugin.py:6988 ..\plugin.py:6999 ..\plugin.py:7485 ..\plugin.py:7496
-#: ..\plugin.py:7507
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr ""
 
-#: ..\plugin.py:6286 ..\plugin.py:6981 ..\plugin.py:7489
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "Hava durumu 2"
 
-#: ..\plugin.py:6297 ..\plugin.py:6992 ..\plugin.py:7500
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr ""
 
-#: ..\plugin.py:6313 ..\plugin.py:6336 ..\plugin.py:6360 ..\plugin.py:6370
-#: ..\plugin.py:7008 ..\plugin.py:7031 ..\plugin.py:7055 ..\plugin.py:7065
-#: ..\plugin.py:7516 ..\plugin.py:7539 ..\plugin.py:7563 ..\plugin.py:7573
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr ""
 
-#: ..\plugin.py:6314 ..\plugin.py:6337 ..\plugin.py:7009 ..\plugin.py:7032
-#: ..\plugin.py:7517 ..\plugin.py:7540
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr ""
 
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:7010 ..\plugin.py:7033
-#: ..\plugin.py:7518 ..\plugin.py:7541
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr ""
 
-#: ..\plugin.py:6316 ..\plugin.py:6339 ..\plugin.py:7011 ..\plugin.py:7034
-#: ..\plugin.py:7519 ..\plugin.py:7542
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr ""
 
-#: ..\plugin.py:6317 ..\plugin.py:6340 ..\plugin.py:7012 ..\plugin.py:7035
-#: ..\plugin.py:7520 ..\plugin.py:7543
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr ""
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:6555 ..\plugin.py:7016
-#: ..\plugin.py:7039 ..\plugin.py:7182 ..\plugin.py:7524 ..\plugin.py:7547
-#: ..\plugin.py:7748
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- renk 1"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:6556 ..\plugin.py:7017
-#: ..\plugin.py:7040 ..\plugin.py:7183 ..\plugin.py:7525 ..\plugin.py:7548
-#: ..\plugin.py:7749
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- renk 2"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6557 ..\plugin.py:7018
-#: ..\plugin.py:7041 ..\plugin.py:7184 ..\plugin.py:7526 ..\plugin.py:7549
-#: ..\plugin.py:7750
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- renk 3"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:6558 ..\plugin.py:7019
-#: ..\plugin.py:7042 ..\plugin.py:7185 ..\plugin.py:7527 ..\plugin.py:7550
-#: ..\plugin.py:7751
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- renk 4"
 
-#: ..\plugin.py:6325 ..\plugin.py:6348 ..\plugin.py:6559 ..\plugin.py:7020
-#: ..\plugin.py:7043 ..\plugin.py:7186 ..\plugin.py:7528 ..\plugin.py:7551
-#: ..\plugin.py:7752
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- renk 5"
 
-#: ..\plugin.py:6326 ..\plugin.py:6349 ..\plugin.py:7021 ..\plugin.py:7044
-#: ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- renk 6"
 
-#: ..\plugin.py:6329 ..\plugin.py:7024 ..\plugin.py:7532
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr ""
 
-#: ..\plugin.py:6352 ..\plugin.py:7047 ..\plugin.py:7555
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr ""
 
-#: ..\plugin.py:6358 ..\plugin.py:6368 ..\plugin.py:7053 ..\plugin.py:7063
-#: ..\plugin.py:7561 ..\plugin.py:7571
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr ""
 
-#: ..\plugin.py:6362 ..\plugin.py:7057 ..\plugin.py:7565
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr ""
 
-#: ..\plugin.py:6372 ..\plugin.py:7067 ..\plugin.py:7575
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr ""
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7075 ..\plugin.py:7582
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr ""
 
-#: ..\plugin.py:6380 ..\plugin.py:7583
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr ""
 
-#: ..\plugin.py:6385 ..\plugin.py:7080 ..\plugin.py:7588
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr ""
 
-#: ..\plugin.py:6397 ..\plugin.py:7151 ..\plugin.py:7600
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "oscam.lcd'yi göster"
 
-#: ..\plugin.py:6400 ..\plugin.py:6419 ..\plugin.py:6430 ..\plugin.py:6441
-#: ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526 ..\plugin.py:7095
-#: ..\plugin.py:7106 ..\plugin.py:7612 ..\plugin.py:7623 ..\plugin.py:7634
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr ""
 
-#: ..\plugin.py:6407
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "ecm.info adresini göster"
 
-#: ..\plugin.py:6416 ..\plugin.py:7092 ..\plugin.py:7609
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr ""
 
-#: ..\plugin.py:6427 ..\plugin.py:7103 ..\plugin.py:7620
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr ""
 
-#: ..\plugin.py:6438 ..\plugin.py:7631
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr ""
 
-#: ..\plugin.py:6449 ..\plugin.py:7642
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr ""
 
-#: ..\plugin.py:6452 ..\plugin.py:6466 ..\plugin.py:7645 ..\plugin.py:7659
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr ""
 
-#: ..\plugin.py:6460 ..\plugin.py:7653
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr ""
 
-#: ..\plugin.py:6467 ..\plugin.py:7660
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr ""
 
-#: ..\plugin.py:6468 ..\plugin.py:7661
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr ""
 
-#: ..\plugin.py:6469 ..\plugin.py:7662
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr ""
 
-#: ..\plugin.py:6470 ..\plugin.py:7663
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr ""
 
-#: ..\plugin.py:6471 ..\plugin.py:7664
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr ""
 
-#: ..\plugin.py:6472 ..\plugin.py:7665
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr ""
 
-#: ..\plugin.py:6473 ..\plugin.py:7114 ..\plugin.py:7666
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr ""
 
-#: ..\plugin.py:6476 ..\plugin.py:6486 ..\plugin.py:6496 ..\plugin.py:7117
-#: ..\plugin.py:7127 ..\plugin.py:7669 ..\plugin.py:7679 ..\plugin.py:7689
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr ""
 
-#: ..\plugin.py:6478 ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508
-#: ..\plugin.py:6518 ..\plugin.py:6528 ..\plugin.py:7119 ..\plugin.py:7129
-#: ..\plugin.py:7138 ..\plugin.py:7671 ..\plugin.py:7681 ..\plugin.py:7691
-#: ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr ""
 
-#: ..\plugin.py:6481 ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511
-#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:7122 ..\plugin.py:7132
-#: ..\plugin.py:7674 ..\plugin.py:7684 ..\plugin.py:7694 ..\plugin.py:7704
-#: ..\plugin.py:7714 ..\plugin.py:7724
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr ""
 
-#: ..\plugin.py:6483 ..\plugin.py:7124 ..\plugin.py:7676
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr ""
 
-#: ..\plugin.py:6493 ..\plugin.py:7686
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr ""
 
-#: ..\plugin.py:6503 ..\plugin.py:7696
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr ""
 
-#: ..\plugin.py:6513 ..\plugin.py:7706
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr ""
 
-#: ..\plugin.py:6523 ..\plugin.py:7716
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr ""
 
-#: ..\plugin.py:6542 ..\plugin.py:7169 ..\plugin.py:7735
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr ""
 
-#: ..\plugin.py:6543 ..\plugin.py:7170 ..\plugin.py:7736
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr ""
 
-#: ..\plugin.py:6545 ..\plugin.py:6554 ..\plugin.py:6613 ..\plugin.py:7172
-#: ..\plugin.py:7181 ..\plugin.py:7240 ..\plugin.py:7738 ..\plugin.py:7747
-#: ..\plugin.py:7806
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr ""
 
-#: ..\plugin.py:6563 ..\plugin.py:7190 ..\plugin.py:7756
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr ""
 
-#: ..\plugin.py:6585 ..\plugin.py:7212 ..\plugin.py:7778
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr ""
 
-#: ..\plugin.py:6586 ..\plugin.py:7213 ..\plugin.py:7779
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr ""
 
-#: ..\plugin.py:6587 ..\plugin.py:7214 ..\plugin.py:7780
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr ""
 
-#: ..\plugin.py:6599 ..\plugin.py:7226 ..\plugin.py:7792
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr ""
 
-#: ..\plugin.py:6601 ..\plugin.py:7228 ..\plugin.py:7794
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr ""
 
-#: ..\plugin.py:6602 ..\plugin.py:7229 ..\plugin.py:7795
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr ""
 
-#: ..\plugin.py:6605 ..\plugin.py:7232 ..\plugin.py:7798
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr ""
 
-#: ..\plugin.py:6618 ..\plugin.py:7245 ..\plugin.py:7811
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr ""
 
-#: ..\plugin.py:6626 ..\plugin.py:7253 ..\plugin.py:7819
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr ""
 
-#: ..\plugin.py:6627 ..\plugin.py:7254 ..\plugin.py:7820
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr ""
 
-#: ..\plugin.py:6628 ..\plugin.py:7255 ..\plugin.py:7821
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr ""
 
-#: ..\plugin.py:6631 ..\plugin.py:6643 ..\plugin.py:7258 ..\plugin.py:7270
-#: ..\plugin.py:7824 ..\plugin.py:7836
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr ""
 
-#: ..\plugin.py:6640 ..\plugin.py:7267 ..\plugin.py:7833
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr ""
 
-#: ..\plugin.py:6652 ..\plugin.py:7279 ..\plugin.py:7845
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr ""
 
-#: ..\plugin.py:6655 ..\plugin.py:6664 ..\plugin.py:7282 ..\plugin.py:7291
-#: ..\plugin.py:7848 ..\plugin.py:7857
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr ""
 
-#: ..\plugin.py:6656 ..\plugin.py:6665 ..\plugin.py:7283 ..\plugin.py:7292
-#: ..\plugin.py:7849 ..\plugin.py:7858
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr ""
 
-#: ..\plugin.py:6657 ..\plugin.py:6666 ..\plugin.py:7284 ..\plugin.py:7293
-#: ..\plugin.py:7850 ..\plugin.py:7859
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr ""
 
-#: ..\plugin.py:6658 ..\plugin.py:6667 ..\plugin.py:7285 ..\plugin.py:7294
-#: ..\plugin.py:7851 ..\plugin.py:7860
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr ""
 
-#: ..\plugin.py:6661 ..\plugin.py:7288 ..\plugin.py:7854
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr ""
 
-#: ..\plugin.py:6670 ..\plugin.py:7297 ..\plugin.py:7863
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr ""
 
-#: ..\plugin.py:6679
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr ""
 
-#: ..\plugin.py:6699 ..\plugin.py:7327
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr ""
 
-#: ..\plugin.py:6705
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr ""
 
-#: ..\plugin.py:6717
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr ""
 
-#: ..\plugin.py:7134
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr ""
 
-#: ..\plugin.py:7141 ..\plugin.py:7142
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr ""
 
-#: ..\plugin.py:7143
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr ""
 
-#: ..\plugin.py:7144
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr ""
 
-#: ..\plugin.py:7145
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr ""
 
-#: ..\plugin.py:7147
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr ""
 
-#: ..\plugin.py:7148
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- İndirmek Örtmek"
 
-#: ..\plugin.py:7149
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- İndirmek tipi"
 
-#: ..\plugin.py:7150
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr ""
 
-#: ..\plugin.py:7309
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr ""
 
-#: ..\plugin.py:7883
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr ""
 
-#: ..\plugin.py:7884
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr ""
 
-#: ..\plugin.py:7888
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr ""
 
-#: ..\plugin.py:7889
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr ""
 
-#: ..\plugin.py:7893
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr ""
 
-#: ..\plugin.py:7894
+#: ..\plugin.py:7909
 #, fuzzy
 msgid "Set Global >>"
 msgstr "yazı tipi genel [ok]>"
 
-#: ..\plugin.py:7912
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr ""
 
-#: ..\plugin.py:7915 ..\plugin.py:7918 ..\plugin.py:7924 ..\plugin.py:7927
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr ""
 
-#: ..\plugin.py:7921
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "Yazo tipi seç"
 
-#: ..\plugin.py:8092
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr ""
 
-#: ..\plugin.py:8234
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -4134,98 +4157,95 @@ msgstr ""
 "Değişikliklerin etkili olması için sistemi yeniden başlatmalısınız.\n"
 "sistemi şimdi teniden başlatmak istiyor musunuz ?"
 
-#: ..\plugin.py:8235
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "GUI'yi şimdi yeniden başlatalım mı?"
 
-#: ..\plugin.py:8789
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr ""
 
-#: ..\plugin.py:8789
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr ""
 
-#: ..\plugin.py:8789
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr ""
 
-#: ..\plugin.py:8789
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr ""
 
-#: ..\plugin.py:10621
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "Yeni ay"
 
-#: ..\plugin.py:10622
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "Ilk çeyrek"
 
-#: ..\plugin.py:10623
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr ""
 
-#: ..\plugin.py:10624
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr ""
 
-#: ..\plugin.py:10625
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr ""
 
-#: ..\plugin.py:10626
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr ""
 
-#: ..\plugin.py:10627
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr ""
 
-#: ..\plugin.py:10628
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "Son çeyrek"
 
-#: ..\plugin.py:11662 ..\plugin.py:11731 ..\plugin.py:11748 ..\plugin.py:11757
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr ""
 
-#: ..\plugin.py:11930
+#: ..\plugin.py:11991
 #, fuzzy
 msgid "Picture not available"
 msgstr "kullanılabilir hafıza"
 
-#: ..\plugin.py:12080 ..\plugin.py:12081
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr ""
 
-#: ..\plugin.py:13325 ..\plugin.py:13328
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM çalışmıyor"
 
-#: ..\plugin.py:13675
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr ""
 
-#: ..\plugin.py:13711
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr ""
 
-#: ..\plugin.py:13911
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr ""
 
-#: ..\plugin.py:15588 ..\plugin.py:15589
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr ""
 
-#: ..\plugin.py:15590
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr ""
 
-#: ..\plugin.py:15591
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr ""
-
-#~ msgid "yes (32bit)"
-#~ msgstr "evet (32bit)"

--- a/LCD4linux/po/zh_CN.po
+++ b/LCD4linux/po/zh_CN.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LCD4linux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 10:31+0200\n"
-"PO-Revision-Date: 2025-07-24 11:01+0200\n"
+"POT-Creation-Date: 2025-09-22 09:30+0200\n"
+"PO-Revision-Date: 2025-09-24 18:36+0200\n"
 "Last-Translator: Mr.Servo <mrservo via GitHub.com>\n"
 "Language-Team: 孤独之剑 <haotzyy1970@163.com>\n"
 "Language: zh_CN\n"
@@ -12,8 +12,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generated: TM2TURK by thawtes\n"
-"X-Generator: Poedit 3.5\n"
+"X-Generator: Poedit 3.7\n"
 "X-SourceCharset: UTF-8\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #: ..\WebConfigSite.py:34
 msgid "BlueSound"
@@ -67,47 +68,35 @@ msgstr "WebIF"
 msgid "Screen"
 msgstr "屏幕"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\WebConfigSite.py:34 ..\plugin.py:493
 msgid "MusicCast"
 msgstr "音乐广播"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6282 ..\plugin.py:6977 ..\plugin.py:7485
-#: ..\plugin_original.py:6280 ..\plugin_original.py:6975
-#: ..\plugin_original.py:7483
+#: ..\WebConfigSite.py:34 ..\plugin.py:6290 ..\plugin.py:6986 ..\plugin.py:7495
 msgid "Weather"
 msgstr "天气"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6313 ..\plugin.py:7008 ..\plugin.py:7516
-#: ..\plugin_original.py:6311 ..\plugin_original.py:7006
-#: ..\plugin_original.py:7514
+#: ..\WebConfigSite.py:34 ..\plugin.py:6321 ..\plugin.py:7017 ..\plugin.py:7526
 msgid "Netatmo"
 msgstr "Netatmo"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6540 ..\plugin.py:7167 ..\plugin.py:7733
-#: ..\plugin_original.py:6538 ..\plugin_original.py:7165
-#: ..\plugin_original.py:7731
+#: ..\WebConfigSite.py:34 ..\plugin.py:6548 ..\plugin.py:7176 ..\plugin.py:7743
 msgid "Mail"
 msgstr "邮件"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6555 ..\plugin.py:7182 ..\plugin.py:7748
-#: ..\plugin_original.py:6553 ..\plugin_original.py:7180
-#: ..\plugin_original.py:7746
+#: ..\WebConfigSite.py:34 ..\plugin.py:6563 ..\plugin.py:7191 ..\plugin.py:7758
 msgid "Remote Box"
 msgstr "遥控器"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6583 ..\plugin.py:7210 ..\plugin.py:7776
-#: ..\plugin_original.py:6581 ..\plugin_original.py:7208
-#: ..\plugin_original.py:7774
+#: ..\WebConfigSite.py:34 ..\plugin.py:6591 ..\plugin.py:7219 ..\plugin.py:7786
 msgid "FritzCall"
 msgstr "FritzCall"
 
-#: ..\WebConfigSite.py:34 ..\plugin.py:6597 ..\plugin.py:7224 ..\plugin.py:7790
-#: ..\plugin_original.py:6595 ..\plugin_original.py:7222
-#: ..\plugin_original.py:7788
+#: ..\WebConfigSite.py:34 ..\plugin.py:6605 ..\plugin.py:7233 ..\plugin.py:7800
 msgid "Calendar"
 msgstr "日历"
 
-#: ..\WebConfigSite.py:174 ..\plugin.py:5890 ..\plugin_original.py:5888
+#: ..\WebConfigSite.py:174 ..\plugin.py:5897
 msgid "WebIF IP Allow"
 msgstr "WebIF IP允许"
 
@@ -115,8 +104,7 @@ msgstr "WebIF IP允许"
 msgid "No or wrong File selected, try a correct File first !"
 msgstr "没有或选择了错误的文件，请先尝试正确的文件！"
 
-#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5517
-#: ..\plugin_original.py:5516
+#: ..\WebConfigSite.py:502 ..\WebConfigSite.py:545 ..\plugin.py:5528
 msgid "Mode"
 msgstr "模式"
 
@@ -132,7 +120,7 @@ msgstr "崩溃日志"
 msgid "Show"
 msgstr "显示"
 
-#: ..\WebConfigSite.py:522
+#: ..\WebConfigSite.py:522 ..\plugin.py:5285
 msgid "Delete"
 msgstr "删除"
 
@@ -164,35 +152,24 @@ msgstr "保存配置"
 msgid "stop Screencycle"
 msgstr "停止屏幕循环"
 
-#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5555 ..\plugin.py:5698
-#: ..\plugin.py:7888 ..\plugin.py:7904 ..\plugin_original.py:356
-#: ..\plugin_original.py:5554 ..\plugin_original.py:5697
-#: ..\plugin_original.py:7886 ..\plugin_original.py:7902
+#: ..\WebConfigSite.py:546 ..\plugin.py:356 ..\plugin.py:5565 ..\plugin.py:5706
+#: ..\plugin.py:7898 ..\plugin.py:7911
 msgid "Global"
 msgstr "全局"
 
-#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5546
-#: ..\plugin.py:5942 ..\plugin.py:7889 ..\plugin.py:7893
-#: ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:5545 ..\plugin_original.py:5940
-#: ..\plugin_original.py:7887 ..\plugin_original.py:7891
+#: ..\WebConfigSite.py:547 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:5556
+#: ..\plugin.py:5950 ..\plugin.py:7899 ..\plugin.py:7902
 msgid "On"
 msgstr "打开"
 
 #: ..\WebConfigSite.py:548 ..\plugin.py:442 ..\plugin.py:512 ..\plugin.py:637
-#: ..\plugin.py:5549 ..\plugin.py:6691 ..\plugin.py:7894 ..\plugin.py:7898
-#: ..\plugin.py:8107 ..\plugin_original.py:441 ..\plugin_original.py:511
-#: ..\plugin_original.py:636 ..\plugin_original.py:5548
-#: ..\plugin_original.py:6689 ..\plugin_original.py:7892
-#: ..\plugin_original.py:7896 ..\plugin_original.py:8105
+#: ..\plugin.py:5559 ..\plugin.py:6700 ..\plugin.py:7903 ..\plugin.py:7906
+#: ..\plugin.py:8114
 msgid "Media"
 msgstr "媒体"
 
-#: ..\WebConfigSite.py:549 ..\plugin.py:5552 ..\plugin.py:5573
-#: ..\plugin.py:7314 ..\plugin.py:7899 ..\plugin.py:7903 ..\plugin.py:8105
-#: ..\plugin_original.py:5551 ..\plugin_original.py:5572
-#: ..\plugin_original.py:7312 ..\plugin_original.py:7897
-#: ..\plugin_original.py:7901 ..\plugin_original.py:8103
+#: ..\WebConfigSite.py:549 ..\plugin.py:5562 ..\plugin.py:5581
+#: ..\plugin.py:7324 ..\plugin.py:7907 ..\plugin.py:7910 ..\plugin.py:8112
 msgid "Idle"
 msgstr "空闲"
 
@@ -240,253 +217,299 @@ msgstr "存储设备列表"
 msgid "Parent Directory"
 msgstr "父目录"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Fri"
 msgstr "周五"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Mon"
 msgstr "周一"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sat"
 msgstr "周六"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Sun"
 msgstr "周日"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Thur"
 msgstr "周四"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Tue"
 msgstr "周二"
 
-#: ..\plugin.py:299 ..\plugin_original.py:299
+#: ..\plugin.py:299
 msgid "Wed"
 msgstr "周三"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "black"
 msgstr "黑色"
 
-#: ..\plugin.py:301 ..\plugin_original.py:301
+#: ..\plugin.py:301
 msgid "white"
 msgstr "白色"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "gray"
 msgstr "灰色"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "silver"
 msgstr "银色"
 
-#: ..\plugin.py:302 ..\plugin_original.py:302
+#: ..\plugin.py:302
 msgid "slategray"
 msgstr "青灰色"
 
-#: ..\plugin.py:303 ..\plugin_original.py:303
+#: ..\plugin.py:303
 msgid "aquamarine"
 msgstr "藍綠色"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "gold"
 msgstr "金色"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "greenyellow"
 msgstr "黄绿色"
 
-#: ..\plugin.py:304 ..\plugin_original.py:304
+#: ..\plugin.py:304
 msgid "yellow"
 msgstr "黄色"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkorange"
 msgstr "深橙色"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "darkred"
 msgstr "深红"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "indianred"
 msgstr "印度红"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orange"
 msgstr "橙色"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "orangered"
 msgstr "橘红色"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "red"
 msgstr "红色"
 
-#: ..\plugin.py:305 ..\plugin_original.py:305
+#: ..\plugin.py:305
 msgid "tomato"
 msgstr "番茄"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "darkgreen"
 msgstr "深绿色"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "green"
 msgstr "绿色"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lawngreen"
 msgstr "草坪绿"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lightgreen"
 msgstr "浅绿色"
 
-#: ..\plugin.py:306 ..\plugin_original.py:306
+#: ..\plugin.py:306
 msgid "lime"
 msgstr "幸福绿"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blue"
 msgstr "蓝色"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "blueviolet"
 msgstr "紫罗兰色"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cadetblue"
 msgstr "灰蓝色"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "cornflowerblue"
 msgstr "浅蓝色"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "darkblue"
 msgstr "深蓝色"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "indigo"
 msgstr "靛藍"
 
-#: ..\plugin.py:307 ..\plugin_original.py:307
+#: ..\plugin.py:307
 msgid "lightblue"
 msgstr "浅蓝"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "cyan"
 msgstr "青色"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "darkorchid"
 msgstr "深紫色"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "deeppink"
 msgstr "深粉红色"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "magenta"
 msgstr "紫紅色"
 
-#: ..\plugin.py:308 ..\plugin_original.py:308
+#: ..\plugin.py:308
 msgid "violet"
 msgstr "紫罗兰色"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "brown"
 msgstr "棕色"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "moccasin"
 msgstr "鹿皮黄色"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "olive"
 msgstr "橄榄"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "rosybrown"
 msgstr "玫瑰棕色"
 
-#: ..\plugin.py:309 ..\plugin_original.py:309
+#: ..\plugin.py:309
 msgid "sandybrown"
 msgstr "沙棕色"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:312 ..\plugin_original.py:313
-msgid "Screen 1"
-msgstr "屏幕1"
+#: ..\plugin.py:311
+msgid "Screen 1+2"
+msgstr "屏幕1 + 2"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311
+msgid "Screen 1+2+3"
+msgstr "屏幕1 + 2 + 3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+3+4"
+msgstr "屏幕1 + 2 + 3 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+2+4"
+msgstr "屏幕1 + 2 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3"
+msgstr "屏幕1 + 3"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+4"
+msgstr "屏幕1 + 3 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 1+3+5+7+9"
+msgstr "屏幕1 + 3 + 5 + 7 + 9"
+
+#: ..\plugin.py:311
+msgid "Screen 1+4"
+msgstr "屏幕1 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3"
+msgstr "屏幕2 + 3"
+
+#: ..\plugin.py:311
+msgid "Screen 2+3+4"
+msgstr "屏幕2 + 3 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4"
+msgstr "屏幕2 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 2+4+6+8"
+msgstr "屏幕2 + 4 + 6 + 8"
+
+#: ..\plugin.py:311
+msgid "Screen 3+4"
+msgstr "屏幕3 + 4"
+
+#: ..\plugin.py:311
+msgid "Screen 5-8"
+msgstr "屏幕5-8"
+
+#: ..\plugin.py:311
+msgid "Screen 5-9"
+msgstr "屏幕5-9"
+
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-5"
 msgstr "屏幕1-5"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-6"
 msgstr "屏幕1-6"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-7"
 msgstr "屏幕1-7"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-8"
 msgstr "屏幕1-8"
 
-#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin_original.py:311
-#: ..\plugin_original.py:312
+#: ..\plugin.py:311 ..\plugin.py:312
 msgid "Screen 1-9"
 msgstr "屏幕1-9"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:312 ..\plugin.py:313
+msgid "Screen 1"
+msgstr "屏幕1"
+
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 2"
 msgstr "屏幕2"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 3"
 msgstr "屏幕3"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 4"
 msgstr "屏幕4"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 5"
 msgstr "屏幕5"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 6"
 msgstr "屏幕6"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 7"
 msgstr "屏幕7"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 8"
 msgstr "屏幕8"
 
-#: ..\plugin.py:311 ..\plugin.py:313 ..\plugin_original.py:311
-#: ..\plugin_original.py:313
+#: ..\plugin.py:311 ..\plugin.py:313
 msgid "Screen 9"
 msgstr "屏幕9"
 
@@ -508,1312 +531,1131 @@ msgstr "屏幕9"
 #: ..\plugin.py:2171 ..\plugin.py:2182 ..\plugin.py:2192 ..\plugin.py:2202
 #: ..\plugin.py:2212 ..\plugin.py:2220 ..\plugin.py:2296 ..\plugin.py:2310
 #: ..\plugin.py:2319 ..\plugin.py:2329 ..\plugin.py:2369 ..\plugin.py:2377
-#: ..\plugin_original.py:311 ..\plugin_original.py:314
-#: ..\plugin_original.py:346 ..\plugin_original.py:348
-#: ..\plugin_original.py:387 ..\plugin_original.py:396
-#: ..\plugin_original.py:397 ..\plugin_original.py:411
-#: ..\plugin_original.py:474 ..\plugin_original.py:497
-#: ..\plugin_original.py:498 ..\plugin_original.py:523
-#: ..\plugin_original.py:524 ..\plugin_original.py:629
-#: ..\plugin_original.py:646 ..\plugin_original.py:655
-#: ..\plugin_original.py:669 ..\plugin_original.py:678
-#: ..\plugin_original.py:688 ..\plugin_original.py:760
-#: ..\plugin_original.py:930 ..\plugin_original.py:1066
-#: ..\plugin_original.py:1141 ..\plugin_original.py:1149
-#: ..\plugin_original.py:1160 ..\plugin_original.py:1171
-#: ..\plugin_original.py:1181 ..\plugin_original.py:1191
-#: ..\plugin_original.py:1201 ..\plugin_original.py:1209
-#: ..\plugin_original.py:1292 ..\plugin_original.py:1300
-#: ..\plugin_original.py:1311 ..\plugin_original.py:1440
-#: ..\plugin_original.py:1624 ..\plugin_original.py:1717
-#: ..\plugin_original.py:1728 ..\plugin_original.py:1738
-#: ..\plugin_original.py:1748 ..\plugin_original.py:1772
-#: ..\plugin_original.py:1780 ..\plugin_original.py:1794
-#: ..\plugin_original.py:1803 ..\plugin_original.py:1813
-#: ..\plugin_original.py:1853 ..\plugin_original.py:1861
-#: ..\plugin_original.py:1873 ..\plugin_original.py:1881
-#: ..\plugin_original.py:1892 ..\plugin_original.py:1998
-#: ..\plugin_original.py:2087 ..\plugin_original.py:2159
-#: ..\plugin_original.py:2170 ..\plugin_original.py:2181
-#: ..\plugin_original.py:2191 ..\plugin_original.py:2201
-#: ..\plugin_original.py:2211 ..\plugin_original.py:2219
-#: ..\plugin_original.py:2295 ..\plugin_original.py:2309
-#: ..\plugin_original.py:2318 ..\plugin_original.py:2328
-#: ..\plugin_original.py:2368 ..\plugin_original.py:2376
 msgid "off"
 msgstr "关闭"
 
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2"
-msgstr "屏幕1 + 2"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3"
-msgstr "屏幕1 + 2 + 3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+3+4"
-msgstr "屏幕1 + 2 + 3 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+2+4"
-msgstr "屏幕1 + 2 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3"
-msgstr "屏幕1 + 3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+4"
-msgstr "屏幕1 + 3 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+3+5+7+9"
-msgstr "屏幕1 + 3 + 5 + 7 + 9"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 1+4"
-msgstr "屏幕1 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3"
-msgstr "屏幕2 + 3"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+3+4"
-msgstr "屏幕2 + 3 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4"
-msgstr "屏幕2 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 2+4+6+8"
-msgstr "屏幕2 + 4 + 6 + 8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 3+4"
-msgstr "屏幕3 + 4"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-8"
-msgstr "屏幕5-8"
-
-#: ..\plugin.py:311 ..\plugin_original.py:311
-msgid "Screen 5-9"
-msgstr "屏幕5-9"
-
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-2"
 msgstr "屏幕1-2"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-3"
 msgstr "屏幕1-3"
 
-#: ..\plugin.py:312 ..\plugin_original.py:312
+#: ..\plugin.py:312
 msgid "Screen 1-4"
 msgstr "屏幕1-4"
 
-#: ..\plugin.py:314 ..\plugin.py:1874 ..\plugin_original.py:314
-#: ..\plugin_original.py:1873
+#: ..\plugin.py:314 ..\plugin.py:1874
 msgid "on"
 msgstr "启用"
 
+#: ..\plugin.py:315
+msgid "2h"
+msgstr "2小时"
+
+#: ..\plugin.py:315
+msgid "3h"
+msgstr "3小时"
+
+#: ..\plugin.py:315
+msgid "3min"
+msgstr "3分钟"
+
+#: ..\plugin.py:315
+msgid "40s"
+msgstr "40s"
+
+#: ..\plugin.py:315
+msgid "4min"
+msgstr "4分钟"
+
+#: ..\plugin.py:315
+msgid "50s"
+msgstr "50s"
+
+#: ..\plugin.py:315
+msgid "5h"
+msgstr "5小时"
+
+#: ..\plugin.py:315
+msgid "5s"
+msgstr "5秒"
+
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "10s"
 msgstr "10秒"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "15s"
 msgstr "15秒"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "1min"
 msgstr "1分钟"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "20s"
 msgstr "20s"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "2min"
 msgstr "2分钟"
 
 #: ..\plugin.py:315 ..\plugin.py:482 ..\plugin.py:487 ..\plugin.py:492
-#: ..\plugin_original.py:315 ..\plugin_original.py:481
-#: ..\plugin_original.py:486 ..\plugin_original.py:491
 msgid "30s"
 msgstr "30秒"
 
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "10min"
+msgstr "10分钟"
+
+#: ..\plugin.py:315 ..\plugin.py:546
+msgid "5min"
+msgstr "5分钟"
+
+#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595
+msgid "20min"
+msgstr "20分钟"
+
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "30min"
 msgstr "30分钟"
 
 #: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin.py:1213
-#: ..\plugin_original.py:315 ..\plugin_original.py:545
-#: ..\plugin_original.py:594 ..\plugin_original.py:1212
 msgid "60min"
 msgstr "60分钟"
 
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:315
-#: ..\plugin_original.py:545 ..\plugin_original.py:594
-msgid "20min"
-msgstr "20分钟"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "10min"
-msgstr "10分钟"
-
-#: ..\plugin.py:315 ..\plugin.py:546 ..\plugin_original.py:315
-#: ..\plugin_original.py:545
-msgid "5min"
-msgstr "5分钟"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "2h"
-msgstr "2小时"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3h"
-msgstr "3小时"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "3min"
-msgstr "3分钟"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "40s"
-msgstr "40s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "4min"
-msgstr "4分钟"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "50s"
-msgstr "50s"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5h"
-msgstr "5小时"
-
-#: ..\plugin.py:315 ..\plugin_original.py:315
-msgid "5s"
-msgstr "5秒"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 1"
-msgstr "LCD 1"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 2"
-msgstr "LCD 2"
-
-#: ..\plugin.py:316 ..\plugin.py:317 ..\plugin_original.py:316
-#: ..\plugin_original.py:317
-msgid "LCD 3"
-msgstr "LCD 3"
-
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2"
 msgstr "LCD 1+2"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+2+3"
 msgstr "LCD 1+2+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 1+3"
 msgstr "LCD 1+3"
 
-#: ..\plugin.py:316 ..\plugin_original.py:316
+#: ..\plugin.py:316
 msgid "LCD 2+3"
 msgstr "LCD 2+3"
 
-#: ..\plugin.py:317 ..\plugin_original.py:317
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 1"
+msgstr "LCD 1"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 2"
+msgstr "LCD 2"
+
+#: ..\plugin.py:316 ..\plugin.py:317
+msgid "LCD 3"
+msgstr "LCD 3"
+
+#: ..\plugin.py:317
 msgid "LCD 1-3"
 msgstr "LCD 1-3"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 480x320"
 msgstr "珍珠（或相容的LCD）480x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "AX206 (or compatible LCD) 800x480"
 msgstr "珍珠屏（或兼容液晶屏）800x480"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Corby@Pearl 128x128"
 msgstr "Corby @珍珠128x128"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 240x320"
 msgstr "珍珠（或相容的LCD）240x320"
 
-#: ..\plugin.py:319 ..\plugin_original.py:319
+#: ..\plugin.py:319
 msgid "Pearl (or compatible LCD) 320x240"
 msgstr "珍珠（或相容的LCD）320x240"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-72H 800x480"
 msgstr "三星SPF-72H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-75H/76H 800x480"
 msgstr "三星SPF-75H / 76H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-83H 800x600"
 msgstr "三星SPF-83H 800x600"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H 800x480"
 msgstr "三星SPF-87H 800x480"
 
-#: ..\plugin.py:320 ..\plugin_original.py:320
+#: ..\plugin.py:320
 msgid "Samsung SPF-87H old 800x480"
 msgstr "三星SPF-87H旧800x480"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-105P 1024x600"
 msgstr "三星SPF-105P 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H 1024x600"
 msgstr "三星SPF-107H 1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-107H old 1024x600"
 msgstr "三星SPF-107H旧的1024x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85H/86H 800x600"
 msgstr "三星SPF-85H / 86H 800x600"
 
-#: ..\plugin.py:321 ..\plugin_original.py:321
+#: ..\plugin.py:321
 msgid "Samsung SPF-85P/86P 800x600"
 msgstr "三星SPF-85P / 86P 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal Box-Skin-LCD"
 msgstr "内盒式皮肤液晶显示器"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Internal TFT-LCD 400x240"
 msgstr "内置TFT-LCD 400x240"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-1000P 1024x600"
 msgstr "三星SPF-1000P 1024x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-700T 800x600"
 msgstr "三星SPF-700T 800x600"
 
-#: ..\plugin.py:322 ..\plugin_original.py:322
+#: ..\plugin.py:322
 msgid "Samsung SPF-800P 800x480"
 msgstr "三星SPF-800P 800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 1024x600"
 msgstr "仅图片1024x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 320x240"
 msgstr "仅图片320x240"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x480"
 msgstr "仅图片800x480"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture 800x600"
 msgstr "仅图片800x600"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size"
 msgstr "仅图片自定义尺寸"
 
-#: ..\plugin.py:323 ..\plugin_original.py:323
+#: ..\plugin.py:323
 msgid "only Picture Custom Size 2"
 msgstr "仅图片自定义尺寸2"
 
-#: ..\plugin.py:326 ..\plugin_original.py:326
+#: ..\plugin.py:326
 msgid "Internal Vu+ Duo2 LCD 400x240"
 msgstr "内置Vu + Duo2 LCD 400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x32"
 msgstr "128x32"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "128x64"
 msgstr "128x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "132x64"
 msgstr "132x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "220x176"
 msgstr "220x176"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "255x64"
 msgstr "255x64"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "400x240"
 msgstr "400x240"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "480x320"
 msgstr "480x320"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "720x405"
 msgstr "720x405"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "800x480"
 msgstr "800x480"
 
-#: ..\plugin.py:327 ..\plugin_original.py:327
+#: ..\plugin.py:327
 msgid "96x64"
 msgstr "96x64"
 
-#: ..\plugin.py:328 ..\plugin.py:329 ..\plugin_original.py:328
-#: ..\plugin_original.py:329
-msgid "Current"
-msgstr "当前"
-
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 1 Line"
 msgstr "2天1行"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "2 Days 2 Line"
 msgstr "2天2行"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 1 Line"
 msgstr "4天1行"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days 2 Lines"
 msgstr "4天2行"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "4 Days Vertical View"
 msgstr "4天垂直视图"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 1 Line"
 msgstr "5天1行"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days 2 Lines"
 msgstr "5天2行"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "5 Days Vertical View"
 msgstr "5天垂直视图"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (+C)"
 msgstr "当前温度（+C）"
 
-#: ..\plugin.py:328 ..\plugin_original.py:328
+#: ..\plugin.py:328
 msgid "Current Temperature (-C)"
 msgstr "当前温度（-C）"
 
-#: ..\plugin.py:329 ..\plugin_original.py:329
+#: ..\plugin.py:328 ..\plugin.py:329
+msgid "Current"
+msgstr "当前"
+
+#: ..\plugin.py:329
 msgid "Current Temperature"
 msgstr "当前温度"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "All"
 msgstr "全部"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature"
 msgstr "温度"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2"
 msgstr "温度+二氧化碳"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Co2+Pressure"
 msgstr "温度+ CO2 +压力"
 
-#: ..\plugin.py:330 ..\plugin_original.py:330
+#: ..\plugin.py:330
 msgid "Temperature+Humidity"
 msgstr "温度+湿度"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1"
 msgstr "模块1"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2"
 msgstr "模块1 + 2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+3"
 msgstr "模块1 + 2 + 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+2+4"
 msgstr "模块1 + 2 + 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3"
 msgstr "模块1 + 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+3+4"
 msgstr "模块1 + 3 + 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1+4"
 msgstr "模块1 + 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-4"
 msgstr "模块1-4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-5"
 msgstr "模块1-5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 1-6"
 msgstr "模块1-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2"
 msgstr "模块2"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3"
 msgstr "模块2 + 3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+3+4"
 msgstr "模块2 + 3 + 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2+4"
 msgstr "模块2 + 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 2-6"
 msgstr "模块2-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3"
 msgstr "模块3"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3+4"
 msgstr "模块3 + 4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 3-6"
 msgstr "模块3-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4"
 msgstr "模块4"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 4-6"
 msgstr "模块4-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5"
 msgstr "模块5"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 5-6"
 msgstr "模块5-6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "Module 6"
 msgstr "模块6"
 
-#: ..\plugin.py:331 ..\plugin_original.py:331
+#: ..\plugin.py:331
 msgid "userdefined"
 msgstr "用户自定义"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar"
 msgstr "条形图"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Bar+Value"
 msgstr "条形+数值"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob"
 msgstr "旋钮"
 
-#: ..\plugin.py:332 ..\plugin_original.py:332
+#: ..\plugin.py:332
 msgid "Knob+Value"
 msgstr "旋钮+值"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog"
 msgstr "模拟"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date"
 msgstr "模拟量+日期"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday"
 msgstr "模拟+日期+周"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Analog+Date+Weekday 2"
 msgstr "模拟+日期+周 2"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date"
 msgstr "日期"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time"
 msgstr "日期+时间"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Date+Time+Weekday"
 msgstr "日期+时间+工作日"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Date"
 msgstr "襟翼设计日期"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Flaps Design Weekday"
 msgstr "襟翼设计工作日"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time"
 msgstr "时间"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Time+Weekday"
 msgstr "时间+工作日"
 
-#: ..\plugin.py:333 ..\plugin_original.py:333
+#: ..\plugin.py:333
 msgid "Weekday"
 msgstr "周日"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "30%"
 msgstr "30%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "35%"
 msgstr "35%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "40%"
 msgstr "40%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "45%"
 msgstr "45%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "50%"
 msgstr "50%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "55%"
 msgstr "55%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "60%"
 msgstr "60%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "65%"
 msgstr "65%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "70%"
 msgstr "70%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "75%"
 msgstr "75%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "80%"
 msgstr "80%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "85%"
 msgstr "85%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "90%"
 msgstr "90%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "95%"
 msgstr "95%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "97%"
 msgstr "97%"
 
-#: ..\plugin.py:334 ..\plugin.py:347 ..\plugin_original.py:334
-#: ..\plugin_original.py:347
+#: ..\plugin.py:334 ..\plugin.py:347
 msgid "98%"
 msgstr "98%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "10%"
 msgstr "10%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "15%"
 msgstr "15%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "2%"
 msgstr "2%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "20%"
 msgstr "20%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "25%"
 msgstr "25%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "3%"
 msgstr "3%"
 
-#: ..\plugin.py:334 ..\plugin.py:348 ..\plugin_original.py:334
-#: ..\plugin_original.py:348
+#: ..\plugin.py:334 ..\plugin.py:348
 msgid "5%"
 msgstr "5%"
 
+#: ..\plugin.py:334 ..\plugin.py:645
+msgid "center"
+msgstr "居中"
+
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "left"
 msgstr "左边"
 
 #: ..\plugin.py:334 ..\plugin.py:645 ..\plugin.py:1139 ..\plugin.py:1147
-#: ..\plugin.py:1770 ..\plugin.py:2157 ..\plugin_original.py:334
-#: ..\plugin_original.py:644 ..\plugin_original.py:1138
-#: ..\plugin_original.py:1146 ..\plugin_original.py:1769
-#: ..\plugin_original.py:2156
+#: ..\plugin.py:1770 ..\plugin.py:2157
 msgid "right"
 msgstr "右边"
 
-#: ..\plugin.py:334 ..\plugin.py:645 ..\plugin_original.py:334
-#: ..\plugin_original.py:644
-msgid "center"
-msgstr "居中"
-
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended"
 msgstr "扩展"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Extended (Short)"
 msgstr "扩展（短）"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short"
 msgstr "短"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short (Extended)"
 msgstr "短（扩展）"
 
-#: ..\plugin.py:335 ..\plugin_original.py:335
+#: ..\plugin.py:335
 msgid "Short+Extended"
 msgstr "短+扩展"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month"
 msgstr "月"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Month+Header"
 msgstr "月+标题"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week"
 msgstr "周"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "Week+Header"
 msgstr "周+标题"
 
-#: ..\plugin.py:336 ..\plugin_original.py:336
+#: ..\plugin.py:336
 msgid "no Calendar"
 msgstr "没有日历"
 
-#: ..\plugin.py:337 ..\plugin.py:14410 ..\plugin_original.py:337
-#: ..\plugin_original.py:14408
-msgid "no Dates"
-msgstr "没有日期"
-
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 1 Line"
 msgstr "日期1行"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 3 Lines"
 msgstr "日期3行"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 5 Lines"
 msgstr "日期5行"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates 9 Lines"
 msgstr "日期9行"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 2 Lines"
 msgstr "日期紧凑2行"
 
-#: ..\plugin.py:337 ..\plugin_original.py:337
+#: ..\plugin.py:337
 msgid "Dates compact 3 Lines"
 msgstr "日期紧凑3行"
 
-#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
-#: ..\plugin_original.py:338 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
-msgid "Frame"
-msgstr "框架"
+#: ..\plugin.py:337 ..\plugin.py:14390
+msgid "no Dates"
+msgstr "没有日期"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline"
 msgstr "下划线"
 
-#: ..\plugin.py:338 ..\plugin_original.py:338
+#: ..\plugin.py:338
 msgid "Underline 2"
 msgstr "下划线2"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:338 ..\plugin.py:823 ..\plugin.py:1401
+msgid "Frame"
+msgstr "框架"
+
+#: ..\plugin.py:339
 msgid "Dates"
 msgstr "日期"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact"
 msgstr "日期紧凑"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates compact no Icon"
 msgstr "日期紧凑无图标"
 
-#: ..\plugin.py:339 ..\plugin_original.py:339
+#: ..\plugin.py:339
 msgid "Dates no Icon"
 msgstr "日期无图标"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon"
 msgstr "无图标"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "no Icon, with Targetnumber"
 msgstr "没有图标,有目标编号"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon"
 msgstr "带图标"
 
-#: ..\plugin.py:340 ..\plugin_original.py:340
+#: ..\plugin.py:340
 msgid "with Icon & Targetnumber"
 msgstr "带有图标和目标编号"
+
+#: ..\plugin.py:341
+msgid "C"
+msgstr "°C"
+
+#: ..\plugin.py:341
+msgid "C + rpm"
+msgstr "C +转速"
+
+#: ..\plugin.py:341
+msgid "C + rpm/2"
+msgstr "C + 转速 / 2"
+
+#: ..\plugin.py:341
+msgid "rpm"
+msgstr "每分钟转数"
+
+#: ..\plugin.py:341
+msgid "rpm/2"
+msgstr "转速/ 2"
 
 #: ..\plugin.py:341 ..\plugin.py:342 ..\plugin.py:343 ..\plugin.py:354
 #: ..\plugin.py:424 ..\plugin.py:427 ..\plugin.py:459 ..\plugin.py:461
 #: ..\plugin.py:467 ..\plugin.py:574 ..\plugin.py:576 ..\plugin.py:579
 #: ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:998 ..\plugin.py:1556
-#: ..\plugin.py:1763 ..\plugin.py:2038 ..\plugin_original.py:341
-#: ..\plugin_original.py:342 ..\plugin_original.py:343
-#: ..\plugin_original.py:354 ..\plugin_original.py:423
-#: ..\plugin_original.py:426 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:466
-#: ..\plugin_original.py:573 ..\plugin_original.py:575
-#: ..\plugin_original.py:578 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:997
-#: ..\plugin_original.py:1555 ..\plugin_original.py:1762
-#: ..\plugin_original.py:2037
+#: ..\plugin.py:1763 ..\plugin.py:2038
 msgid "no"
 msgstr "否"
 
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C"
-msgstr "°C"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm"
-msgstr "C +转速"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "C + rpm/2"
-msgstr "C + 转速 / 2"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm"
-msgstr "每分钟转数"
-
-#: ..\plugin.py:341 ..\plugin_original.py:341
-msgid "rpm/2"
-msgstr "转速/ 2"
-
-#: ..\plugin.py:342 ..\plugin.py:343 ..\plugin_original.py:342
-#: ..\plugin_original.py:343
-msgid "%"
-msgstr "%"
-
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "% + BER"
 msgstr "％+误码率"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db"
 msgstr "分贝"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + %"
 msgstr "分贝 + %"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + % + BER"
 msgstr "分贝+％+误码率"
 
-#: ..\plugin.py:342 ..\plugin_original.py:342
+#: ..\plugin.py:342
 msgid "db + BER"
 msgstr "分贝+误码率"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:342 ..\plugin.py:343
+msgid "%"
+msgstr "%"
+
+#: ..\plugin.py:343
 msgid "% + Load@1min"
 msgstr "% + 负载@1分钟"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "% + Load@5min"
 msgstr "% + 负载@ 5分钟"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@1min"
 msgstr "负荷@ 1分钟"
 
-#: ..\plugin.py:343 ..\plugin_original.py:343
+#: ..\plugin.py:343
 msgid "Load@5min"
 msgstr "负荷@ 5分钟"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run"
 msgstr "显示运行"
 
-#: ..\plugin.py:344 ..\plugin_original.py:344
+#: ..\plugin.py:344
 msgid "show run+sleep"
 msgstr "显示运行+睡眠"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always All"
 msgstr "总是"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Always New"
 msgstr "总是新的"
 
-#: ..\plugin.py:345 ..\plugin_original.py:345
+#: ..\plugin.py:345
 msgid "Only New"
 msgstr "只有新"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "All Informations"
 msgstr "所有信息"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance only"
 msgstr "仅距离"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Illumination"
 msgstr "距离+照度"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Distance+Moonphase"
 msgstr "距离+月相"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination only"
 msgstr "仅照明"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Illumination+Moonphase"
 msgstr "照明+月相"
 
-#: ..\plugin.py:346 ..\plugin_original.py:346
+#: ..\plugin.py:346
 msgid "Moonphase only"
 msgstr "仅月相"
 
-#: ..\plugin.py:347 ..\plugin_original.py:347
+#: ..\plugin.py:347
 msgid "100%"
 msgstr "100%"
 
-#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
-#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:349 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
-msgid "1"
-msgstr "1"
-
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-2"
 msgstr "1-2"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-3"
 msgstr "1-3"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-4"
 msgstr "1-4"
 
-#: ..\plugin.py:349 ..\plugin_original.py:349
+#: ..\plugin.py:349
 msgid "1-5"
 msgstr "1-5"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:349 ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401
+#: ..\plugin.py:475 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
+msgid "1"
+msgstr "1"
+
+#: ..\plugin.py:350
 msgid "IMAP"
 msgstr "IMAP"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "IMAP-SSL"
 msgstr "IMAP-SSL"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3"
 msgstr "Pop3"
 
-#: ..\plugin.py:350 ..\plugin_original.py:350
+#: ..\plugin.py:350
 msgid "Pop3-SSL"
 msgstr "Pop3-SSL"
 
-#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
-#: ..\plugin.py:5954 ..\plugin_original.py:351 ..\plugin_original.py:358
-#: ..\plugin_original.py:833 ..\plugin_original.py:844
-#: ..\plugin_original.py:5952
-msgid "Picon"
-msgstr "皮康"
-
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel"
 msgstr "频道"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Channel+Title"
 msgstr "频道+标题"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel"
 msgstr "Picon +频道"
 
-#: ..\plugin.py:351 ..\plugin_original.py:351
+#: ..\plugin.py:351
 msgid "Picon+Channel+Title"
 msgstr "Picon +频道+标题"
 
-#: ..\plugin.py:352 ..\plugin_original.py:352
+#: ..\plugin.py:351 ..\plugin.py:358 ..\plugin.py:834 ..\plugin.py:845
+#: ..\plugin.py:5962
+msgid "Picon"
+msgstr "皮康"
+
+#: ..\plugin.py:352
 msgid "same color"
 msgstr "相同颜色"
 
-#: ..\plugin.py:353 ..\plugin_original.py:353
+#: ..\plugin.py:353
 msgid "transparent"
 msgstr "透明"
 
-#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
-#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
-#: ..\plugin_original.py:354 ..\plugin_original.py:458
-#: ..\plugin_original.py:460 ..\plugin_original.py:573
-#: ..\plugin_original.py:575 ..\plugin_original.py:595
-#: ..\plugin_original.py:705 ..\plugin_original.py:1762
-msgid "yes"
-msgstr "是"
-
-#: ..\plugin.py:354 ..\plugin_original.py:354
+#: ..\plugin.py:354
 msgid "yes +25%"
 msgstr "是+ 25％"
 
-#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
-#: ..\plugin_original.py:355 ..\plugin_original.py:891
-#: ..\plugin_original.py:1498 ..\plugin_original.py:1944
-msgid "horizontally"
-msgstr "水平"
+#: ..\plugin.py:354 ..\plugin.py:459 ..\plugin.py:461 ..\plugin.py:574
+#: ..\plugin.py:576 ..\plugin.py:596 ..\plugin.py:706 ..\plugin.py:1763
+msgid "yes"
+msgstr "是"
 
-#: ..\plugin.py:355 ..\plugin_original.py:355
+#: ..\plugin.py:355
 msgid "vertically"
 msgstr "垂直"
 
+#: ..\plugin.py:355 ..\plugin.py:892 ..\plugin.py:1499 ..\plugin.py:1945
+msgid "horizontally"
+msgstr "水平"
+
+#: ..\plugin.py:356
+msgid "4"
+msgstr "4"
+
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:475
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:474 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "2"
 msgstr "2"
 
 #: ..\plugin.py:356 ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481
-#: ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:356
-#: ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:486 ..\plugin.py:491
 msgid "3"
 msgstr "3"
 
 #: ..\plugin.py:356 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:356 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
+#: ..\plugin.py:491
 msgid "5"
 msgstr "5"
 
-#: ..\plugin.py:356 ..\plugin_original.py:356
-msgid "4"
-msgstr "4"
-
-#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
-#: ..\plugin.py:491 ..\plugin_original.py:357 ..\plugin_original.py:400
-#: ..\plugin_original.py:480 ..\plugin_original.py:485
-#: ..\plugin_original.py:490
-msgid "30"
-msgstr "30"
-
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "14"
 msgstr "14"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "7"
 msgstr "7"
 
-#: ..\plugin.py:357 ..\plugin_original.py:357
+#: ..\plugin.py:357
 msgid "all"
 msgstr "全部"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:357 ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486
+#: ..\plugin.py:491
+msgid "30"
+msgstr "30"
+
+#: ..\plugin.py:358
 msgid "Corner"
 msgstr "转角"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Corner+Timeshift"
 msgstr "转角+时移"
 
-#: ..\plugin.py:358 ..\plugin_original.py:358
+#: ..\plugin.py:358
 msgid "Picon+Timeshift"
 msgstr "Picon +时移"
 
-#: ..\plugin.py:360 ..\plugin_original.py:360
+#: ..\plugin.py:360
 msgid "only Progress Bar"
 msgstr "仅进度栏"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes"
 msgstr "剩余分钟"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 1.5)"
 msgstr "剩余分钟 (尺寸1.5)"
 
-#: ..\plugin.py:361 ..\plugin_original.py:361
+#: ..\plugin.py:361
 msgid "with Remaining Minutes (Size 2)"
 msgstr "剩余分钟 (大于2)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent"
 msgstr "带百分比"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 1.5)"
 msgstr "带百分比 (尺寸1,5)"
 
-#: ..\plugin.py:362 ..\plugin_original.py:362
+#: ..\plugin.py:362
 msgid "with Percent (Size 2)"
 msgstr "与百分比（尺寸2）"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above)"
 msgstr "剩余分钟 (大于)"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 1.5)"
 msgstr "剩余分钟数（大于/尺寸1.5）"
 
-#: ..\plugin.py:363 ..\plugin_original.py:363
+#: ..\plugin.py:363
 msgid "with Remaining Minutes (above/Size 2)"
 msgstr "剩余分钟 (大于/尺寸2)"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above)"
 msgstr "与百分比（大于）"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 1.5)"
 msgstr "百分比（大于/尺寸1.5）"
 
-#: ..\plugin.py:364 ..\plugin_original.py:364
+#: ..\plugin.py:364
 msgid "with Percent (above/Size 2)"
 msgstr "百分比（大于/尺寸2）"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below)"
 msgstr "剩下的几分钟 (低于)"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 1.5)"
 msgstr "剩余分钟数（低于/尺寸1.5）"
 
-#: ..\plugin.py:365 ..\plugin_original.py:365
+#: ..\plugin.py:365
 msgid "with Remaining Minutes (below/Size 2)"
 msgstr "剩余分钟数（低于/尺寸2）"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below)"
 msgstr "百分比 (低于)"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 1.5)"
 msgstr "百分比（低于/尺寸1.5）"
 
-#: ..\plugin.py:366 ..\plugin_original.py:366
+#: ..\plugin.py:366
 msgid "with Percent (below/Size 2)"
 msgstr "百分比（低于/尺寸2）"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00"
 msgstr "当前00:00"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 1.5)"
 msgstr "当前00:00（尺寸1.5）"
 
-#: ..\plugin.py:367 ..\plugin_original.py:367
+#: ..\plugin.py:367
 msgid "with Current 00:00 (Size 2)"
 msgstr "当前00:00（尺寸2）"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above)"
 msgstr "当前00:00（以上）"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 1.5)"
 msgstr "当前00:00（高于/尺寸1.5）"
 
-#: ..\plugin.py:368 ..\plugin_original.py:368
+#: ..\plugin.py:368
 msgid "with Current 00:00 (above/Size 2)"
 msgstr "当前00:00（尺寸2以上）"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below)"
 msgstr "当前00:00（低于）"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 1.5)"
 msgstr "当前00:00（低于/尺寸1.5）"
 
-#: ..\plugin.py:369 ..\plugin_original.py:369
+#: ..\plugin.py:369
 msgid "with Current 00:00 (below/Size 2)"
 msgstr "当前00:00（下方/尺寸2）"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above)"
 msgstr "分钟/总计百分比 (大于/尺寸2)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 1.5)"
 msgstr "分钟/总计百分比 (大于/尺寸1.5)"
 
-#: ..\plugin.py:370 ..\plugin_original.py:370
+#: ..\plugin.py:370
 msgid "with Percent Minutes / Total (above/Size 2)"
 msgstr "分钟/总计百分比 (大于/尺寸2)"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime"
 msgstr "绝对结束时间"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 1.5)"
 msgstr "绝对结束时间（尺寸1.5）"
 
-#: ..\plugin.py:371 ..\plugin_original.py:371
+#: ..\plugin.py:371
 msgid "with absolute Endtime (Size 2)"
 msgstr "带绝对结束时间 (尺寸2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above)"
 msgstr "分钟/总计百分比 (大于/尺寸2)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 1.5)"
 msgstr "分钟/总计百分比 (大于/尺寸1.5)"
 
-#: ..\plugin.py:372 ..\plugin_original.py:372
+#: ..\plugin.py:372
 msgid "with Minutes Total / Endtime (above/Size 2)"
 msgstr "分钟/总计百分比 (大于/尺寸2)"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Fastmode (2s)"
 msgstr "快速模式（2秒）"
 
-#: ..\plugin.py:381 ..\plugin_original.py:381
+#: ..\plugin.py:381
 msgid "Normal (5s)"
 msgstr "正常 (5秒)"
 
@@ -1821,3437 +1663,2467 @@ msgstr "正常 (5秒)"
 msgid "last Screen"
 msgstr "最后一个屏幕"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "alphabetic"
 msgstr "按字母顺序排列"
 
-#: ..\plugin.py:398 ..\plugin_original.py:397
+#: ..\plugin.py:398
 msgid "random"
 msgstr "随机"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "better/slow"
 msgstr "较好/缓慢"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (Picture only)"
 msgstr "低/快（仅图片）"
 
-#: ..\plugin.py:399 ..\plugin_original.py:398
+#: ..\plugin.py:399
 msgid "low/fast (all)"
 msgstr "低/快（全部）"
 
+#: ..\plugin.py:401
+msgid "0.5"
+msgstr "0.5"
+
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "10"
 msgstr "10"
 
 #: ..\plugin.py:401 ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
-#: ..\plugin_original.py:400 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
 msgid "20"
 msgstr "20"
 
-#: ..\plugin.py:401 ..\plugin_original.py:400
-msgid "0.5"
-msgstr "0.5"
-
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "JPG"
 msgstr "JPG"
 
-#: ..\plugin.py:404 ..\plugin_original.py:403
+#: ..\plugin.py:404
 msgid "PNG"
 msgstr "PNG"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (high quality, slow)"
 msgstr "缓存+调整（高质量，慢）"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "cache + adjustment (low quality, fast)"
 msgstr "缓存+调整（低质量，快）"
 
-#: ..\plugin.py:405 ..\plugin_original.py:404
+#: ..\plugin.py:405
 msgid "no cache + no adjustment"
 msgstr "没有缓存+没有调整"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "Plug Tuner"
 msgstr "插头调谐器"
 
-#: ..\plugin.py:424 ..\plugin_original.py:423
+#: ..\plugin.py:424
 msgid "USB Tuner"
 msgstr "USB调谐器"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "EPG"
 msgstr "EPG"
 
-#: ..\plugin.py:425 ..\plugin_original.py:424
+#: ..\plugin.py:425
 msgid "Now/Next"
 msgstr "现在/下一个"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "normal"
 msgstr "正常"
 
-#: ..\plugin.py:439 ..\plugin_original.py:438
+#: ..\plugin.py:439
 msgid "reduced"
 msgstr "减少"
 
-#: ..\plugin.py:442 ..\plugin_original.py:441
+#: ..\plugin.py:442
 msgid "Auto"
 msgstr "汽车"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript"
 msgstr "Java脚本"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Javascript no Refresh"
 msgstr "Java脚本无刷新"
 
-#: ..\plugin.py:444 ..\plugin_original.py:443
+#: ..\plugin.py:444
 msgid "Reload"
 msgstr "加载"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "1 - normal"
 msgstr "1 - 正常"
 
-#: ..\plugin.py:448 ..\plugin_original.py:447
+#: ..\plugin.py:448
 msgid "2 - side by side"
 msgstr "2-并排"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "MSN"
 msgstr "MSN"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "Open-Meteo"
 msgstr "Open-Meteo"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "OpenWeatherMap"
 msgstr "打开天气图"
 
-#: ..\plugin.py:449 ..\plugin_original.py:448
+#: ..\plugin.py:449
 msgid "WeatherUnlocked"
 msgstr "天气解锁"
 
-#: ..\plugin.py:459 ..\plugin.py:596 ..\plugin_original.py:458
-#: ..\plugin_original.py:595
+#: ..\plugin.py:459 ..\plugin.py:596
 msgid "alternative Copy-Mode/DM800hd (24bit)"
 msgstr "备用复制模式/ DM800hd（24位）"
 
-#: ..\plugin.py:461 ..\plugin_original.py:460
+#: ..\plugin.py:461
 msgid "yes + %"
 msgstr "是 + %"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, long"
 msgstr "是,很长"
 
-#: ..\plugin.py:467 ..\plugin_original.py:466
+#: ..\plugin.py:467
 msgid "yes, short"
 msgstr "是,简短"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "km/h"
 msgstr "公里/小时"
 
-#: ..\plugin.py:474 ..\plugin_original.py:473
+#: ..\plugin.py:474
 msgid "m/s"
 msgstr "米/秒"
 
-#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491 ..\plugin_original.py:480
-#: ..\plugin_original.py:485 ..\plugin_original.py:490
+#: ..\plugin.py:481 ..\plugin.py:486 ..\plugin.py:491
 msgid "60"
 msgstr "60"
 
-#: ..\plugin.py:493 ..\plugin_original.py:492
+#: ..\plugin.py:493
 msgid "Coversearch"
 msgstr "封面搜索"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "0"
 msgstr "0"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "180"
 msgstr "180"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "270"
 msgstr "270"
 
-#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502 ..\plugin_original.py:499
-#: ..\plugin_original.py:500 ..\plugin_original.py:501
+#: ..\plugin.py:500 ..\plugin.py:501 ..\plugin.py:502
 msgid "90"
 msgstr "90"
 
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
-#: ..\plugin_original.py:508 ..\plugin_original.py:509
-#: ..\plugin_original.py:510 ..\plugin_original.py:633
-msgid "always"
-msgstr "总是"
-
-#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin_original.py:508
-#: ..\plugin_original.py:509 ..\plugin_original.py:510
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511
 msgid "1 / min"
 msgstr "1/分钟"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:509 ..\plugin.py:510 ..\plugin.py:511 ..\plugin.py:634
+msgid "always"
+msgstr "总是"
+
+#: ..\plugin.py:512
 msgid "On+Media+Standby"
 msgstr "启用+多媒体+唤醒"
 
-#: ..\plugin.py:512 ..\plugin_original.py:511
+#: ..\plugin.py:512
 msgid "Standby"
 msgstr "待机"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "32bit - color"
 msgstr "32位-颜色"
 
-#: ..\plugin.py:514 ..\plugin_original.py:513
+#: ..\plugin.py:514
 msgid "8bit - grayscale/color"
 msgstr "8位-灰度/彩色"
 
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x InfoKey"
-msgstr "2 X信息键"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "2 x Mute"
-msgstr "2 x静音"
-
-#: ..\plugin.py:524 ..\plugin.py:525 ..\plugin_original.py:523
-#: ..\plugin_original.py:524
-msgid "Long InfoKey"
-msgstr "长按信息键"
-
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey"
 msgstr "2 x快进键"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "2 x FastForwardKey Type 2"
 msgstr "2 x快进键类型2"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey"
 msgstr "长按快进键"
 
-#: ..\plugin.py:524 ..\plugin_original.py:523
+#: ..\plugin.py:524
 msgid "Long FastForwardKey Type 2"
 msgstr "长按快进键 类型 2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x InfoKey"
+msgstr "2 X信息键"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "2 x Mute"
+msgstr "2 x静音"
+
+#: ..\plugin.py:524 ..\plugin.py:525
+msgid "Long InfoKey"
+msgstr "长按信息键"
+
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey"
 msgstr "2 X快速后退键"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "2 x FastBackwardKey Type 2"
 msgstr "2 x快退键类型2"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey"
 msgstr "长按快速后退键"
 
-#: ..\plugin.py:525 ..\plugin_original.py:524
+#: ..\plugin.py:525
 msgid "Long FastBackwardKey Type 2"
 msgstr "长按快速后退键 类型 2"
 
-#: ..\plugin.py:546 ..\plugin.py:595 ..\plugin_original.py:545
-#: ..\plugin_original.py:594
+#: ..\plugin.py:546 ..\plugin.py:595
 msgid "15min"
 msgstr "15分钟"
 
-#: ..\plugin.py:574 ..\plugin_original.py:573
+#: ..\plugin.py:574
 msgid "yes, extended"
 msgstr "是,扩展"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Console normal"
 msgstr "控制台正常"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile extensive"
 msgstr "日志文件扩展"
 
-#: ..\plugin.py:630 ..\plugin_original.py:629
+#: ..\plugin.py:630
 msgid "Logfile normal"
 msgstr "日志文件正常"
 
-#: ..\plugin.py:634 ..\plugin_original.py:633
+#: ..\plugin.py:634
 msgid "disabled"
 msgstr "已禁用"
 
-#: ..\plugin.py:637 ..\plugin.py:1285 ..\plugin_original.py:636
-#: ..\plugin_original.py:1284
-msgid "TV"
-msgstr "电视"
-
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio"
 msgstr "无线电"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "Radio+Media"
 msgstr "广播+媒体"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio"
 msgstr "电视/电台"
 
-#: ..\plugin.py:637 ..\plugin_original.py:636
+#: ..\plugin.py:637
 msgid "TV+Radio+Media"
 msgstr "电视+广播+媒体"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:637 ..\plugin.py:1285
+msgid "TV"
+msgstr "电视"
+
+#: ..\plugin.py:638
 msgid "TV (full)"
 msgstr "电视（完整）"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "normal (full)"
 msgstr "正常（满）"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (black)"
 msgstr "修剪（黑色）"
 
-#: ..\plugin.py:638 ..\plugin_original.py:637
+#: ..\plugin.py:638
 msgid "trimmed (transparent)"
 msgstr "修剪（透明）"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "MUTE or defined Keys"
 msgstr "静音或定义键"
 
-#: ..\plugin.py:641 ..\plugin_original.py:640
+#: ..\plugin.py:641
 msgid "any Key"
 msgstr "任意键"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Info"
 msgstr "信息"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:802 ..\plugin.py:1368
-#: ..\plugin.py:1380 ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:801 ..\plugin_original.py:1367
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:1380
 msgid "Time+Info"
 msgstr "时间+信息"
 
 #: ..\plugin.py:778 ..\plugin.py:790 ..\plugin.py:1368
-#: ..\plugin_original.py:777 ..\plugin_original.py:789
-#: ..\plugin_original.py:1367
 msgid "Time+Duration+Info"
 msgstr "时间+持续时间+信息"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Mini-EPG"
 msgstr "迷你EPG"
 
-#: ..\plugin.py:802 ..\plugin.py:1380 ..\plugin_original.py:801
-#: ..\plugin_original.py:1379
+#: ..\plugin.py:802 ..\plugin.py:1380
 msgid "Time+Length+Info"
 msgstr "时间+长度+信息"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half left"
 msgstr "半面向左转"
 
-#: ..\plugin.py:817 ..\plugin.py:1396 ..\plugin_original.py:816
-#: ..\plugin_original.py:1395
+#: ..\plugin.py:817 ..\plugin.py:1396
 msgid "half right"
 msgstr "半面向右转"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Frame x2"
 msgstr "框架 x2"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "Line"
 msgstr "行"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Bar"
 msgstr "没有进度条"
 
-#: ..\plugin.py:823 ..\plugin.py:1401 ..\plugin_original.py:822
-#: ..\plugin_original.py:1400
+#: ..\plugin.py:823 ..\plugin.py:1401
 msgid "no Frame"
 msgstr "无框架"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
-#: ..\plugin_original.py:824 ..\plugin_original.py:1402
-#: ..\plugin_original.py:1763
-msgid "Normal"
-msgstr "正常"
-
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Gradient"
 msgstr "渐变色"
 
-#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin_original.py:824
-#: ..\plugin_original.py:1402
+#: ..\plugin.py:825 ..\plugin.py:1403
 msgid "Shadow Edges"
 msgstr "阴影边缘"
 
-#: ..\plugin.py:834 ..\plugin.py:845 ..\plugin_original.py:833
-#: ..\plugin_original.py:844
-msgid "Name"
-msgstr "名称"
+#: ..\plugin.py:825 ..\plugin.py:1403 ..\plugin.py:1764
+msgid "Normal"
+msgstr "正常"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position below"
 msgstr "Picon+下方位置"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position left"
 msgstr "皮康+左位置"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Picon+Position right"
 msgstr "皮康+位置右"
 
-#: ..\plugin.py:834 ..\plugin_original.py:833
+#: ..\plugin.py:834
 msgid "Position"
 msgstr "位置"
 
+#: ..\plugin.py:834 ..\plugin.py:845
+msgid "Name"
+msgstr "名称"
+
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Offline"
 msgstr "离线"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online"
 msgstr "在线"
 
 #: ..\plugin.py:913 ..\plugin.py:1423 ..\plugin.py:1981
-#: ..\plugin_original.py:912 ..\plugin_original.py:1422
-#: ..\plugin_original.py:1980
 msgid "Online+Offline"
 msgstr "在线+离线"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "only use Timer"
 msgstr "仅使用定时器"
 
 #: ..\plugin.py:957 ..\plugin.py:1021 ..\plugin.py:1460 ..\plugin.py:1579
-#: ..\plugin.py:1930 ..\plugin.py:2018 ..\plugin_original.py:956
-#: ..\plugin_original.py:1020 ..\plugin_original.py:1459
-#: ..\plugin_original.py:1578 ..\plugin_original.py:1929
-#: ..\plugin_original.py:2017
+#: ..\plugin.py:1930 ..\plugin.py:2018
 msgid "use lead-time"
 msgstr "使用提前期"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "no total Timer"
 msgstr "没有总计时器"
 
 #: ..\plugin.py:958 ..\plugin.py:1022 ..\plugin.py:1461 ..\plugin.py:1580
-#: ..\plugin.py:1931 ..\plugin.py:2019 ..\plugin_original.py:957
-#: ..\plugin_original.py:1021 ..\plugin_original.py:1460
-#: ..\plugin_original.py:1579 ..\plugin_original.py:1930
-#: ..\plugin_original.py:2018
+#: ..\plugin.py:1931 ..\plugin.py:2019
 msgid "show total Timer"
 msgstr "显示总计时器"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "one line"
 msgstr "一行"
 
-#: ..\plugin.py:976 ..\plugin.py:1534 ..\plugin_original.py:975
-#: ..\plugin_original.py:1533
+#: ..\plugin.py:976 ..\plugin.py:1534
 msgid "two lines"
 msgstr "两行"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory available"
 msgstr "可用内存"
 
 #: ..\plugin.py:998 ..\plugin.py:1556 ..\plugin.py:2038
-#: ..\plugin_original.py:997 ..\plugin_original.py:1555
-#: ..\plugin_original.py:2037
 msgid "Memory free"
 msgstr "内存释放"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "cloudconvert.org"
 msgstr "cloudconvert.org"
 
-#: ..\plugin.py:1214 ..\plugin_original.py:1213
+#: ..\plugin.py:1214
 msgid "convertapi.com"
 msgstr "convertapi.com"
 
 #: ..\plugin.py:1235 ..\plugin.py:1244 ..\plugin.py:1253 ..\plugin.py:1262
 #: ..\plugin.py:1271 ..\plugin.py:1280 ..\plugin.py:1696 ..\plugin.py:1705
 #: ..\plugin.py:2241 ..\plugin.py:2250 ..\plugin.py:2259 ..\plugin.py:2268
-#: ..\plugin.py:2277 ..\plugin.py:2286 ..\plugin_original.py:1234
-#: ..\plugin_original.py:1243 ..\plugin_original.py:1252
-#: ..\plugin_original.py:1261 ..\plugin_original.py:1270
-#: ..\plugin_original.py:1279 ..\plugin_original.py:1695
-#: ..\plugin_original.py:1704 ..\plugin_original.py:2240
-#: ..\plugin_original.py:2249 ..\plugin_original.py:2258
-#: ..\plugin_original.py:2267 ..\plugin_original.py:2276
-#: ..\plugin_original.py:2285
+#: ..\plugin.py:2277 ..\plugin.py:2286
 msgid "full Screen"
 msgstr "全屏"
 
-#: ..\plugin.py:1285 ..\plugin_original.py:1284
+#: ..\plugin.py:1285
 msgid "TV+OSD"
 msgstr "电视+ OSD"
 
-#: ..\plugin.py:1763 ..\plugin_original.py:1762
+#: ..\plugin.py:1763
 msgid "yes except records"
 msgstr "是,除了录制"
 
-#: ..\plugin.py:1764 ..\plugin_original.py:1763
+#: ..\plugin.py:1764
 msgid "Google API"
 msgstr "Google API"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "E"
 msgstr "Ε"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ENE"
 msgstr "东北偏东"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "ESE"
 msgstr "东南偏东"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "N"
 msgstr "N"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NE"
 msgstr "东北方"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNE"
 msgstr "东北偏北"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NNW"
 msgstr "西北偏北"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "NW"
 msgstr "西北"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "S"
 msgstr "南"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SE"
 msgstr "东南"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSE"
 msgstr "东南偏南"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SSW"
 msgstr "西南偏南"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "SW"
 msgstr "西南"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "W"
 msgstr "西"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WNW"
 msgstr "西北偏西"
 
-#: ..\plugin.py:2679 ..\plugin_original.py:2678
+#: ..\plugin.py:2679
 msgid "WSW"
 msgstr "西南偏西"
 
-#: ..\plugin.py:4604 ..\plugin_original.py:4603
+#: ..\plugin.py:4604
 msgid "%d.%m.%Y - %H:%M"
 msgstr "%Y.%m.%d - %H:%M"
 
-#: ..\plugin.py:4605 ..\plugin_original.py:4604
+#: ..\plugin.py:4605
 msgid "%d.%m.%y %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: ..\plugin.py:5167 ..\plugin_original.py:5166
+#: ..\plugin.py:5167
 msgid "%d-%b-%Y"
 msgstr "%Y-%b-%d"
 
-#: ..\plugin.py:5293 ..\plugin_original.py:5292
+#: ..\plugin.py:5295
 msgid "Load Active Config-File"
 msgstr "加载活动配置文件"
 
-#: ..\plugin.py:5294 ..\plugin_original.py:5293
+#: ..\plugin.py:5296
 msgid "Load Defaults / Empty Config"
 msgstr "加载默认值/清空配置"
 
-#: ..\plugin.py:5295 ..\plugin_original.py:5294
+#: ..\plugin.py:5297
 msgid "Save Config to File... (%s)"
 msgstr "将配置保存到文件... (%s)"
 
-#: ..\plugin.py:5299 ..\plugin.py:5335 ..\plugin_original.py:5298
-#: ..\plugin_original.py:5334
+#: ..\plugin.py:5301 ..\plugin.py:5342
 msgid "Load File : %s"
 msgstr "加载文件：%s"
 
-#: ..\plugin.py:5308 ..\plugin_original.py:5307
+#: ..\plugin.py:5311
 msgid "Delete File?"
 msgstr "是否删除文件?"
 
-#: ..\plugin.py:5343 ..\plugin_original.py:5342
+#: ..\plugin.py:5354
 msgid "deleted"
 msgstr "已删除"
 
-#: ..\plugin.py:5368 ..\plugin_original.py:5367
+#: ..\plugin.py:5379
 msgid "currently set : %s"
 msgstr "当前设置：%s"
 
-#: ..\plugin.py:5476 ..\plugin.py:7905 ..\plugin_original.py:5475
-#: ..\plugin_original.py:7903
+#: ..\plugin.py:5381
+msgid "Select"
+msgstr "选择"
+
+#: ..\plugin.py:5488 ..\plugin.py:7912
 msgid "LCD4linux Settings"
 msgstr "LCD4linux设置"
 
-#: ..\plugin.py:5526 ..\plugin_original.py:5525
+#: ..\plugin.py:5537
+msgid "Menu"
+msgstr "菜单"
+
+#: ..\plugin.py:5538
 msgid "Cancel"
 msgstr "取消"
 
-#: ..\plugin.py:5527 ..\plugin_original.py:5526
+#: ..\plugin.py:5539
 msgid "Save"
 msgstr "保存"
 
-#: ..\plugin.py:5528 ..\plugin_original.py:5527
+#: ..\plugin.py:5540
 msgid "Restart Displays"
 msgstr "重新启动显示"
 
-#: ..\plugin.py:5529 ..\plugin.py:7906 ..\plugin_original.py:5528
-#: ..\plugin_original.py:7904
+#: ..\plugin.py:5541 ..\plugin.py:7913
 msgid "Set On >>"
 msgstr "启用 >>"
 
-#: ..\plugin.py:5612 ..\plugin_original.py:5611
+#: ..\plugin.py:5619
 msgid "no LCD1 Picture-File"
 msgstr "没有LCD1图片文件"
 
-#: ..\plugin.py:5637 ..\plugin_original.py:5636
+#: ..\plugin.py:5645
 msgid "no LCD2 Picture-File"
 msgstr "没有LCD2图片文件"
 
-#: ..\plugin.py:5663 ..\plugin_original.py:5662
+#: ..\plugin.py:5671
 msgid "no LCD3 Picture-File"
 msgstr "没有LCD3图片文件"
 
-#: ..\plugin.py:5700 ..\plugin_original.py:5699
+#: ..\plugin.py:5708
 msgid "LCD4linux enabled"
 msgstr "已启用LCD4linux"
 
-#: ..\plugin.py:5701 ..\plugin_original.py:5700
+#: ..\plugin.py:5709
 msgid "LCD 1 Type"
 msgstr "LCD 1型"
 
-#: ..\plugin.py:5702 ..\plugin_original.py:5701
+#: ..\plugin.py:5710
 msgid "- LCD 1 Rotate"
 msgstr "- LCD 1旋转"
 
-#: ..\plugin.py:5703 ..\plugin.py:6693 ..\plugin.py:7322
-#: ..\plugin_original.py:5702 ..\plugin_original.py:6691
-#: ..\plugin_original.py:7320
+#: ..\plugin.py:5711 ..\plugin.py:6702 ..\plugin.py:7332
 msgid "- LCD 1 Background Color"
 msgstr "- LCD 1背景色"
 
-#: ..\plugin.py:5704 ..\plugin.py:6694 ..\plugin.py:7323
-#: ..\plugin_original.py:5703 ..\plugin_original.py:6692
-#: ..\plugin_original.py:7321
+#: ..\plugin.py:5712 ..\plugin.py:6703 ..\plugin.py:7333
 msgid "- LCD 1 Background-Picture [ok]>"
 msgstr "- LCD 1背景图片 [ok]>"
 
-#: ..\plugin.py:5705 ..\plugin.py:6695 ..\plugin.py:7324
-#: ..\plugin_original.py:5704 ..\plugin_original.py:6693
-#: ..\plugin_original.py:7322
+#: ..\plugin.py:5713 ..\plugin.py:6704 ..\plugin.py:7334
 msgid "- LCD 1 Brightness"
 msgstr "- LCD 1亮度"
 
-#: ..\plugin.py:5706 ..\plugin.py:6696 ..\plugin.py:7325
-#: ..\plugin_original.py:5705 ..\plugin_original.py:6694
-#: ..\plugin_original.py:7323
+#: ..\plugin.py:5714 ..\plugin.py:6705 ..\plugin.py:7335
 msgid "- LCD 1 Night Reduction"
 msgstr "- LCD 1夜间还原"
 
-#: ..\plugin.py:5707 ..\plugin_original.py:5706
+#: ..\plugin.py:5715
 msgid "- LCD 1 Refresh"
 msgstr "- LCD 1刷新"
 
-#: ..\plugin.py:5708 ..\plugin_original.py:5707
+#: ..\plugin.py:5716
 msgid "LCD 2 Type"
 msgstr "LCD 2型"
 
-#: ..\plugin.py:5710 ..\plugin_original.py:5709
+#: ..\plugin.py:5718
 msgid "- LCD 2 Rotate"
 msgstr "- LCD 2旋转"
 
-#: ..\plugin.py:5711 ..\plugin.py:6697 ..\plugin.py:7326
-#: ..\plugin_original.py:5710 ..\plugin_original.py:6695
-#: ..\plugin_original.py:7324
+#: ..\plugin.py:5719 ..\plugin.py:6706 ..\plugin.py:7336
 msgid "- LCD 2 Background Color"
 msgstr "- LCD 2背景色"
 
-#: ..\plugin.py:5712 ..\plugin.py:6698 ..\plugin.py:7327
-#: ..\plugin_original.py:5711 ..\plugin_original.py:6696
-#: ..\plugin_original.py:7325
+#: ..\plugin.py:5720 ..\plugin.py:6707 ..\plugin.py:7337
 msgid "- LCD 2 Background-Picture [ok]>"
 msgstr "- LCD 2背景图片[ok]>"
 
-#: ..\plugin.py:5713 ..\plugin.py:6699 ..\plugin.py:7328
-#: ..\plugin_original.py:5712 ..\plugin_original.py:6697
-#: ..\plugin_original.py:7326
+#: ..\plugin.py:5721 ..\plugin.py:6708 ..\plugin.py:7338
 msgid "- LCD 2 Brightness"
 msgstr "- LCD 2亮度"
 
-#: ..\plugin.py:5714 ..\plugin.py:6700 ..\plugin.py:7329
-#: ..\plugin_original.py:5713 ..\plugin_original.py:6698
-#: ..\plugin_original.py:7327
+#: ..\plugin.py:5722 ..\plugin.py:6709 ..\plugin.py:7339
 msgid "- LCD 2 Night Reduction"
 msgstr "- LCD 2夜间还原"
 
-#: ..\plugin.py:5715 ..\plugin_original.py:5714
+#: ..\plugin.py:5723
 msgid "- LCD 2 Refresh"
 msgstr "- LCD 2刷新"
 
-#: ..\plugin.py:5716 ..\plugin_original.py:5715
+#: ..\plugin.py:5724
 msgid "LCD 3 Type"
 msgstr "LCD 3型"
 
-#: ..\plugin.py:5718 ..\plugin_original.py:5717
+#: ..\plugin.py:5726
 msgid "- LCD 3 Rotate"
 msgstr "- LCD 3旋转"
 
-#: ..\plugin.py:5719 ..\plugin.py:6701 ..\plugin.py:7330
-#: ..\plugin_original.py:5718 ..\plugin_original.py:6699
-#: ..\plugin_original.py:7328
+#: ..\plugin.py:5727 ..\plugin.py:6710 ..\plugin.py:7340
 msgid "- LCD 3 Background Color"
 msgstr "- LCD 3背景色"
 
-#: ..\plugin.py:5720 ..\plugin.py:6702 ..\plugin.py:7331
-#: ..\plugin_original.py:5719 ..\plugin_original.py:6700
-#: ..\plugin_original.py:7329
+#: ..\plugin.py:5728 ..\plugin.py:6711 ..\plugin.py:7341
 msgid "- LCD 3 Background-Picture [ok]>"
 msgstr "- LCD 3背景图片 [ok]>"
 
-#: ..\plugin.py:5721 ..\plugin.py:6703 ..\plugin.py:7332
-#: ..\plugin_original.py:5720 ..\plugin_original.py:6701
-#: ..\plugin_original.py:7330
+#: ..\plugin.py:5729 ..\plugin.py:6712 ..\plugin.py:7342
 msgid "- LCD 3 Brightness"
 msgstr "- LCD 3亮度"
 
-#: ..\plugin.py:5722 ..\plugin.py:6704 ..\plugin.py:7333
-#: ..\plugin_original.py:5721 ..\plugin_original.py:6702
-#: ..\plugin_original.py:7331
+#: ..\plugin.py:5730 ..\plugin.py:6713 ..\plugin.py:7343
 msgid "- LCD 3 Night Reduction"
 msgstr "- LCD 3夜间还原"
 
-#: ..\plugin.py:5723 ..\plugin_original.py:5722
+#: ..\plugin.py:5731
 msgid "- LCD 3 Refresh"
 msgstr "- LCD 3刷新"
 
-#: ..\plugin.py:5725 ..\plugin_original.py:5724
+#: ..\plugin.py:5733
 msgid "Box-Skin-LCD Dimension"
 msgstr "盒式LCD尺寸"
 
-#: ..\plugin.py:5726 ..\plugin_original.py:5725
+#: ..\plugin.py:5734
 msgid "Box-Skin-LCD Offset"
 msgstr "Box-Skin-LCD偏移"
 
-#: ..\plugin.py:5727 ..\plugin_original.py:5726
+#: ..\plugin.py:5735
 msgid "Box-Skin-LCD Color"
 msgstr "盒式液晶显示器颜色"
 
-#: ..\plugin.py:5728 ..\plugin_original.py:5727
+#: ..\plugin.py:5736
 msgid "Box-Skin-LCD Enable On-Mode"
 msgstr "Box-Skin-LCD启用开启模式"
 
-#: ..\plugin.py:5729 ..\plugin_original.py:5728
+#: ..\plugin.py:5737
 msgid "Box-Skin-LCD Enable Media-Mode"
 msgstr "Box-Skin-LCD启用媒体模式"
 
-#: ..\plugin.py:5730 ..\plugin_original.py:5729
+#: ..\plugin.py:5738
 msgid "Box-Skin-LCD Enable Idle-Mode"
 msgstr "Box-Skin-LCD启用空闲模式"
 
-#: ..\plugin.py:5731 ..\plugin_original.py:5730
+#: ..\plugin.py:5739
 msgid "OSD [display time]"
 msgstr "OSD [显示时间]"
 
-#: ..\plugin.py:5734 ..\plugin.py:5741 ..\plugin.py:5951 ..\plugin.py:5956
-#: ..\plugin.py:5969 ..\plugin.py:5981 ..\plugin.py:5996 ..\plugin.py:6011
-#: ..\plugin.py:6023 ..\plugin.py:6033 ..\plugin.py:6046 ..\plugin.py:6059
-#: ..\plugin.py:6072 ..\plugin.py:6086 ..\plugin.py:6102 ..\plugin.py:6116
-#: ..\plugin.py:6130 ..\plugin.py:6142 ..\plugin.py:6154 ..\plugin.py:6166
-#: ..\plugin.py:6176 ..\plugin.py:6190 ..\plugin.py:6200 ..\plugin.py:6207
-#: ..\plugin.py:6218 ..\plugin.py:6228 ..\plugin.py:6246 ..\plugin.py:6258
-#: ..\plugin.py:6276 ..\plugin.py:6284 ..\plugin.py:6295 ..\plugin.py:6306
-#: ..\plugin.py:6315 ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6371
-#: ..\plugin.py:6381 ..\plugin.py:6394 ..\plugin.py:6406 ..\plugin.py:6416
-#: ..\plugin.py:6425 ..\plugin.py:6436 ..\plugin.py:6447 ..\plugin.py:6458
-#: ..\plugin.py:6469 ..\plugin.py:6482 ..\plugin.py:6492 ..\plugin.py:6502
-#: ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532 ..\plugin.py:6542
-#: ..\plugin.py:6557 ..\plugin.py:6572 ..\plugin.py:6585 ..\plugin.py:6599
-#: ..\plugin.py:6614 ..\plugin.py:6627 ..\plugin.py:6637 ..\plugin.py:6649
-#: ..\plugin.py:6661 ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:6688
-#: ..\plugin.py:6709 ..\plugin.py:6714 ..\plugin.py:6726 ..\plugin.py:6738
-#: ..\plugin.py:6752 ..\plugin.py:6764 ..\plugin.py:6777 ..\plugin.py:6790
-#: ..\plugin.py:6806 ..\plugin.py:6816 ..\plugin.py:6823 ..\plugin.py:6838
-#: ..\plugin.py:6853 ..\plugin.py:6866 ..\plugin.py:6879 ..\plugin.py:6889
-#: ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6924 ..\plugin.py:6942
-#: ..\plugin.py:6953 ..\plugin.py:6971 ..\plugin.py:6979 ..\plugin.py:6990
-#: ..\plugin.py:7001 ..\plugin.py:7010 ..\plugin.py:7033 ..\plugin.py:7056
-#: ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7089 ..\plugin.py:7101
-#: ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7133 ..\plugin.py:7143
-#: ..\plugin.py:7160 ..\plugin.py:7169 ..\plugin.py:7184 ..\plugin.py:7199
-#: ..\plugin.py:7212 ..\plugin.py:7226 ..\plugin.py:7241 ..\plugin.py:7254
-#: ..\plugin.py:7264 ..\plugin.py:7276 ..\plugin.py:7288 ..\plugin.py:7297
-#: ..\plugin.py:7306 ..\plugin.py:7337 ..\plugin.py:7352 ..\plugin.py:7367
-#: ..\plugin.py:7382 ..\plugin.py:7396 ..\plugin.py:7409 ..\plugin.py:7422
-#: ..\plugin.py:7432 ..\plugin.py:7450 ..\plugin.py:7461 ..\plugin.py:7479
-#: ..\plugin.py:7487 ..\plugin.py:7498 ..\plugin.py:7509 ..\plugin.py:7518
-#: ..\plugin.py:7541 ..\plugin.py:7564 ..\plugin.py:7574 ..\plugin.py:7584
-#: ..\plugin.py:7597 ..\plugin.py:7609 ..\plugin.py:7618 ..\plugin.py:7629
-#: ..\plugin.py:7640 ..\plugin.py:7651 ..\plugin.py:7662 ..\plugin.py:7675
-#: ..\plugin.py:7685 ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715
-#: ..\plugin.py:7725 ..\plugin.py:7735 ..\plugin.py:7750 ..\plugin.py:7765
-#: ..\plugin.py:7778 ..\plugin.py:7792 ..\plugin.py:7807 ..\plugin.py:7820
-#: ..\plugin.py:7830 ..\plugin.py:7842 ..\plugin.py:7854 ..\plugin.py:7863
-#: ..\plugin.py:7872 ..\plugin_original.py:5733 ..\plugin_original.py:5740
-#: ..\plugin_original.py:5949 ..\plugin_original.py:5954
-#: ..\plugin_original.py:5967 ..\plugin_original.py:5979
-#: ..\plugin_original.py:5994 ..\plugin_original.py:6009
-#: ..\plugin_original.py:6021 ..\plugin_original.py:6031
-#: ..\plugin_original.py:6044 ..\plugin_original.py:6057
-#: ..\plugin_original.py:6070 ..\plugin_original.py:6084
-#: ..\plugin_original.py:6100 ..\plugin_original.py:6114
-#: ..\plugin_original.py:6128 ..\plugin_original.py:6140
-#: ..\plugin_original.py:6152 ..\plugin_original.py:6164
-#: ..\plugin_original.py:6174 ..\plugin_original.py:6188
-#: ..\plugin_original.py:6198 ..\plugin_original.py:6205
-#: ..\plugin_original.py:6216 ..\plugin_original.py:6226
-#: ..\plugin_original.py:6244 ..\plugin_original.py:6256
-#: ..\plugin_original.py:6274 ..\plugin_original.py:6282
-#: ..\plugin_original.py:6293 ..\plugin_original.py:6304
-#: ..\plugin_original.py:6313 ..\plugin_original.py:6336
-#: ..\plugin_original.py:6359 ..\plugin_original.py:6369
-#: ..\plugin_original.py:6379 ..\plugin_original.py:6392
-#: ..\plugin_original.py:6404 ..\plugin_original.py:6414
-#: ..\plugin_original.py:6423 ..\plugin_original.py:6434
-#: ..\plugin_original.py:6445 ..\plugin_original.py:6456
-#: ..\plugin_original.py:6467 ..\plugin_original.py:6480
-#: ..\plugin_original.py:6490 ..\plugin_original.py:6500
-#: ..\plugin_original.py:6510 ..\plugin_original.py:6520
-#: ..\plugin_original.py:6530 ..\plugin_original.py:6540
-#: ..\plugin_original.py:6555 ..\plugin_original.py:6570
-#: ..\plugin_original.py:6583 ..\plugin_original.py:6597
-#: ..\plugin_original.py:6612 ..\plugin_original.py:6625
-#: ..\plugin_original.py:6635 ..\plugin_original.py:6647
-#: ..\plugin_original.py:6659 ..\plugin_original.py:6668
-#: ..\plugin_original.py:6677 ..\plugin_original.py:6686
-#: ..\plugin_original.py:6707 ..\plugin_original.py:6712
-#: ..\plugin_original.py:6724 ..\plugin_original.py:6736
-#: ..\plugin_original.py:6750 ..\plugin_original.py:6762
-#: ..\plugin_original.py:6775 ..\plugin_original.py:6788
-#: ..\plugin_original.py:6804 ..\plugin_original.py:6814
-#: ..\plugin_original.py:6821 ..\plugin_original.py:6836
-#: ..\plugin_original.py:6851 ..\plugin_original.py:6864
-#: ..\plugin_original.py:6877 ..\plugin_original.py:6887
-#: ..\plugin_original.py:6901 ..\plugin_original.py:6912
-#: ..\plugin_original.py:6922 ..\plugin_original.py:6940
-#: ..\plugin_original.py:6951 ..\plugin_original.py:6969
-#: ..\plugin_original.py:6977 ..\plugin_original.py:6988
-#: ..\plugin_original.py:6999 ..\plugin_original.py:7008
-#: ..\plugin_original.py:7031 ..\plugin_original.py:7054
-#: ..\plugin_original.py:7064 ..\plugin_original.py:7074
-#: ..\plugin_original.py:7087 ..\plugin_original.py:7099
-#: ..\plugin_original.py:7110 ..\plugin_original.py:7121
-#: ..\plugin_original.py:7131 ..\plugin_original.py:7141
-#: ..\plugin_original.py:7158 ..\plugin_original.py:7167
-#: ..\plugin_original.py:7182 ..\plugin_original.py:7197
-#: ..\plugin_original.py:7210 ..\plugin_original.py:7224
-#: ..\plugin_original.py:7239 ..\plugin_original.py:7252
-#: ..\plugin_original.py:7262 ..\plugin_original.py:7274
-#: ..\plugin_original.py:7286 ..\plugin_original.py:7295
-#: ..\plugin_original.py:7304 ..\plugin_original.py:7335
-#: ..\plugin_original.py:7350 ..\plugin_original.py:7365
-#: ..\plugin_original.py:7380 ..\plugin_original.py:7394
-#: ..\plugin_original.py:7407 ..\plugin_original.py:7420
-#: ..\plugin_original.py:7430 ..\plugin_original.py:7448
-#: ..\plugin_original.py:7459 ..\plugin_original.py:7477
-#: ..\plugin_original.py:7485 ..\plugin_original.py:7496
-#: ..\plugin_original.py:7507 ..\plugin_original.py:7516
-#: ..\plugin_original.py:7539 ..\plugin_original.py:7562
-#: ..\plugin_original.py:7572 ..\plugin_original.py:7582
-#: ..\plugin_original.py:7595 ..\plugin_original.py:7607
-#: ..\plugin_original.py:7616 ..\plugin_original.py:7627
-#: ..\plugin_original.py:7638 ..\plugin_original.py:7649
-#: ..\plugin_original.py:7660 ..\plugin_original.py:7673
-#: ..\plugin_original.py:7683 ..\plugin_original.py:7693
-#: ..\plugin_original.py:7703 ..\plugin_original.py:7713
-#: ..\plugin_original.py:7723 ..\plugin_original.py:7733
-#: ..\plugin_original.py:7748 ..\plugin_original.py:7763
-#: ..\plugin_original.py:7776 ..\plugin_original.py:7790
-#: ..\plugin_original.py:7805 ..\plugin_original.py:7818
-#: ..\plugin_original.py:7828 ..\plugin_original.py:7840
-#: ..\plugin_original.py:7852 ..\plugin_original.py:7861
-#: ..\plugin_original.py:7870
+#: ..\plugin.py:5741 ..\plugin.py:5748 ..\plugin.py:5959 ..\plugin.py:5964
+#: ..\plugin.py:5977 ..\plugin.py:5989 ..\plugin.py:6004 ..\plugin.py:6019
+#: ..\plugin.py:6031 ..\plugin.py:6041 ..\plugin.py:6054 ..\plugin.py:6067
+#: ..\plugin.py:6080 ..\plugin.py:6094 ..\plugin.py:6110 ..\plugin.py:6124
+#: ..\plugin.py:6138 ..\plugin.py:6150 ..\plugin.py:6162 ..\plugin.py:6174
+#: ..\plugin.py:6184 ..\plugin.py:6198 ..\plugin.py:6208 ..\plugin.py:6215
+#: ..\plugin.py:6226 ..\plugin.py:6236 ..\plugin.py:6254 ..\plugin.py:6266
+#: ..\plugin.py:6284 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6314
+#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:6369 ..\plugin.py:6379
+#: ..\plugin.py:6389 ..\plugin.py:6402 ..\plugin.py:6414 ..\plugin.py:6424
+#: ..\plugin.py:6433 ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466
+#: ..\plugin.py:6477 ..\plugin.py:6490 ..\plugin.py:6500 ..\plugin.py:6510
+#: ..\plugin.py:6520 ..\plugin.py:6530 ..\plugin.py:6540 ..\plugin.py:6550
+#: ..\plugin.py:6565 ..\plugin.py:6580 ..\plugin.py:6593 ..\plugin.py:6607
+#: ..\plugin.py:6622 ..\plugin.py:6635 ..\plugin.py:6645 ..\plugin.py:6657
+#: ..\plugin.py:6669 ..\plugin.py:6678 ..\plugin.py:6687 ..\plugin.py:6696
+#: ..\plugin.py:6718 ..\plugin.py:6723 ..\plugin.py:6735 ..\plugin.py:6747
+#: ..\plugin.py:6761 ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6799
+#: ..\plugin.py:6815 ..\plugin.py:6825 ..\plugin.py:6832 ..\plugin.py:6847
+#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6888 ..\plugin.py:6898
+#: ..\plugin.py:6912 ..\plugin.py:6923 ..\plugin.py:6933 ..\plugin.py:6951
+#: ..\plugin.py:6962 ..\plugin.py:6980 ..\plugin.py:6988 ..\plugin.py:6999
+#: ..\plugin.py:7010 ..\plugin.py:7019 ..\plugin.py:7042 ..\plugin.py:7065
+#: ..\plugin.py:7075 ..\plugin.py:7085 ..\plugin.py:7098 ..\plugin.py:7110
+#: ..\plugin.py:7121 ..\plugin.py:7132 ..\plugin.py:7142 ..\plugin.py:7152
+#: ..\plugin.py:7169 ..\plugin.py:7178 ..\plugin.py:7193 ..\plugin.py:7208
+#: ..\plugin.py:7221 ..\plugin.py:7235 ..\plugin.py:7250 ..\plugin.py:7263
+#: ..\plugin.py:7273 ..\plugin.py:7285 ..\plugin.py:7297 ..\plugin.py:7306
+#: ..\plugin.py:7315 ..\plugin.py:7347 ..\plugin.py:7362 ..\plugin.py:7377
+#: ..\plugin.py:7392 ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7432
+#: ..\plugin.py:7442 ..\plugin.py:7460 ..\plugin.py:7471 ..\plugin.py:7489
+#: ..\plugin.py:7497 ..\plugin.py:7508 ..\plugin.py:7519 ..\plugin.py:7528
+#: ..\plugin.py:7551 ..\plugin.py:7574 ..\plugin.py:7584 ..\plugin.py:7594
+#: ..\plugin.py:7607 ..\plugin.py:7619 ..\plugin.py:7628 ..\plugin.py:7639
+#: ..\plugin.py:7650 ..\plugin.py:7661 ..\plugin.py:7672 ..\plugin.py:7685
+#: ..\plugin.py:7695 ..\plugin.py:7705 ..\plugin.py:7715 ..\plugin.py:7725
+#: ..\plugin.py:7735 ..\plugin.py:7745 ..\plugin.py:7760 ..\plugin.py:7775
+#: ..\plugin.py:7788 ..\plugin.py:7802 ..\plugin.py:7817 ..\plugin.py:7830
+#: ..\plugin.py:7840 ..\plugin.py:7852 ..\plugin.py:7864 ..\plugin.py:7873
+#: ..\plugin.py:7882
 msgid "- which LCD"
 msgstr "- 创建LCD"
 
-#: ..\plugin.py:5735 ..\plugin_original.py:5734
+#: ..\plugin.py:5742
 msgid "- Show in Mode"
 msgstr "- 以模式显示"
 
-#: ..\plugin.py:5736 ..\plugin_original.py:5735
+#: ..\plugin.py:5743
 msgid "- OSD Size"
 msgstr "- OSD尺寸"
 
-#: ..\plugin.py:5737 ..\plugin_original.py:5736
+#: ..\plugin.py:5744
 msgid "- Background/Transparency"
 msgstr "- 背景/透明度"
 
-#: ..\plugin.py:5738 ..\plugin_original.py:5737
+#: ..\plugin.py:5745
 msgid "- Fast Grab lower quality"
 msgstr "- 快速抓取低质量"
 
-#: ..\plugin.py:5739 ..\plugin_original.py:5738
+#: ..\plugin.py:5746
 msgid "Popup Text"
 msgstr "弹出式文本"
 
-#: ..\plugin.py:5742 ..\plugin_original.py:5741
+#: ..\plugin.py:5749
 msgid "- Clear Key"
 msgstr "- 清除键"
 
-#: ..\plugin.py:5743 ..\plugin.py:6012 ..\plugin.py:6024 ..\plugin.py:6035
-#: ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074 ..\plugin.py:6143
-#: ..\plugin.py:6155 ..\plugin.py:6167 ..\plugin.py:6177 ..\plugin.py:6201
-#: ..\plugin.py:6208 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6247
-#: ..\plugin.py:6259 ..\plugin.py:6277 ..\plugin.py:6317 ..\plugin.py:6340
-#: ..\plugin.py:6383 ..\plugin.py:6395 ..\plugin.py:6408 ..\plugin.py:6417
-#: ..\plugin.py:6427 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
-#: ..\plugin.py:6543 ..\plugin.py:6558 ..\plugin.py:6573 ..\plugin.py:6586
-#: ..\plugin.py:6639 ..\plugin.py:6651 ..\plugin.py:6715 ..\plugin.py:6727
-#: ..\plugin.py:6740 ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779
-#: ..\plugin.py:6817 ..\plugin.py:6880 ..\plugin.py:6890 ..\plugin.py:6904
-#: ..\plugin.py:6915 ..\plugin.py:6925 ..\plugin.py:6943 ..\plugin.py:6954
-#: ..\plugin.py:6972 ..\plugin.py:7012 ..\plugin.py:7035 ..\plugin.py:7078
-#: ..\plugin.py:7090 ..\plugin.py:7103 ..\plugin.py:7114 ..\plugin.py:7161
-#: ..\plugin.py:7170 ..\plugin.py:7185 ..\plugin.py:7200 ..\plugin.py:7213
-#: ..\plugin.py:7266 ..\plugin.py:7278 ..\plugin.py:7383 ..\plugin.py:7423
-#: ..\plugin.py:7433 ..\plugin.py:7451 ..\plugin.py:7462 ..\plugin.py:7480
-#: ..\plugin.py:7520 ..\plugin.py:7543 ..\plugin.py:7586 ..\plugin.py:7598
-#: ..\plugin.py:7610 ..\plugin.py:7620 ..\plugin.py:7631 ..\plugin.py:7642
-#: ..\plugin.py:7653 ..\plugin.py:7736 ..\plugin.py:7751 ..\plugin.py:7766
-#: ..\plugin.py:7779 ..\plugin.py:7832 ..\plugin.py:7844
-#: ..\plugin_original.py:5742 ..\plugin_original.py:6010
-#: ..\plugin_original.py:6022 ..\plugin_original.py:6033
-#: ..\plugin_original.py:6046 ..\plugin_original.py:6059
-#: ..\plugin_original.py:6072 ..\plugin_original.py:6141
-#: ..\plugin_original.py:6153 ..\plugin_original.py:6165
-#: ..\plugin_original.py:6175 ..\plugin_original.py:6199
-#: ..\plugin_original.py:6206 ..\plugin_original.py:6217
-#: ..\plugin_original.py:6227 ..\plugin_original.py:6245
-#: ..\plugin_original.py:6257 ..\plugin_original.py:6275
-#: ..\plugin_original.py:6315 ..\plugin_original.py:6338
-#: ..\plugin_original.py:6381 ..\plugin_original.py:6393
-#: ..\plugin_original.py:6406 ..\plugin_original.py:6415
-#: ..\plugin_original.py:6425 ..\plugin_original.py:6436
-#: ..\plugin_original.py:6447 ..\plugin_original.py:6458
-#: ..\plugin_original.py:6541 ..\plugin_original.py:6556
-#: ..\plugin_original.py:6571 ..\plugin_original.py:6584
-#: ..\plugin_original.py:6637 ..\plugin_original.py:6649
-#: ..\plugin_original.py:6713 ..\plugin_original.py:6725
-#: ..\plugin_original.py:6738 ..\plugin_original.py:6751
-#: ..\plugin_original.py:6764 ..\plugin_original.py:6777
-#: ..\plugin_original.py:6815 ..\plugin_original.py:6878
-#: ..\plugin_original.py:6888 ..\plugin_original.py:6902
-#: ..\plugin_original.py:6913 ..\plugin_original.py:6923
-#: ..\plugin_original.py:6941 ..\plugin_original.py:6952
-#: ..\plugin_original.py:6970 ..\plugin_original.py:7010
-#: ..\plugin_original.py:7033 ..\plugin_original.py:7076
-#: ..\plugin_original.py:7088 ..\plugin_original.py:7101
-#: ..\plugin_original.py:7112 ..\plugin_original.py:7159
-#: ..\plugin_original.py:7168 ..\plugin_original.py:7183
-#: ..\plugin_original.py:7198 ..\plugin_original.py:7211
-#: ..\plugin_original.py:7264 ..\plugin_original.py:7276
-#: ..\plugin_original.py:7381 ..\plugin_original.py:7421
-#: ..\plugin_original.py:7431 ..\plugin_original.py:7449
-#: ..\plugin_original.py:7460 ..\plugin_original.py:7478
-#: ..\plugin_original.py:7518 ..\plugin_original.py:7541
-#: ..\plugin_original.py:7584 ..\plugin_original.py:7596
-#: ..\plugin_original.py:7608 ..\plugin_original.py:7618
-#: ..\plugin_original.py:7629 ..\plugin_original.py:7640
-#: ..\plugin_original.py:7651 ..\plugin_original.py:7734
-#: ..\plugin_original.py:7749 ..\plugin_original.py:7764
-#: ..\plugin_original.py:7777 ..\plugin_original.py:7830
-#: ..\plugin_original.py:7842
+#: ..\plugin.py:5750 ..\plugin.py:6020 ..\plugin.py:6032 ..\plugin.py:6043
+#: ..\plugin.py:6056 ..\plugin.py:6069 ..\plugin.py:6082 ..\plugin.py:6151
+#: ..\plugin.py:6163 ..\plugin.py:6175 ..\plugin.py:6185 ..\plugin.py:6209
+#: ..\plugin.py:6216 ..\plugin.py:6227 ..\plugin.py:6237 ..\plugin.py:6255
+#: ..\plugin.py:6267 ..\plugin.py:6285 ..\plugin.py:6325 ..\plugin.py:6348
+#: ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6416 ..\plugin.py:6425
+#: ..\plugin.py:6435 ..\plugin.py:6446 ..\plugin.py:6457 ..\plugin.py:6468
+#: ..\plugin.py:6551 ..\plugin.py:6566 ..\plugin.py:6581 ..\plugin.py:6594
+#: ..\plugin.py:6647 ..\plugin.py:6659 ..\plugin.py:6724 ..\plugin.py:6736
+#: ..\plugin.py:6749 ..\plugin.py:6762 ..\plugin.py:6775 ..\plugin.py:6788
+#: ..\plugin.py:6826 ..\plugin.py:6889 ..\plugin.py:6899 ..\plugin.py:6913
+#: ..\plugin.py:6924 ..\plugin.py:6934 ..\plugin.py:6952 ..\plugin.py:6963
+#: ..\plugin.py:6981 ..\plugin.py:7021 ..\plugin.py:7044 ..\plugin.py:7087
+#: ..\plugin.py:7099 ..\plugin.py:7112 ..\plugin.py:7123 ..\plugin.py:7170
+#: ..\plugin.py:7179 ..\plugin.py:7194 ..\plugin.py:7209 ..\plugin.py:7222
+#: ..\plugin.py:7275 ..\plugin.py:7287 ..\plugin.py:7393 ..\plugin.py:7433
+#: ..\plugin.py:7443 ..\plugin.py:7461 ..\plugin.py:7472 ..\plugin.py:7490
+#: ..\plugin.py:7530 ..\plugin.py:7553 ..\plugin.py:7596 ..\plugin.py:7608
+#: ..\plugin.py:7620 ..\plugin.py:7630 ..\plugin.py:7641 ..\plugin.py:7652
+#: ..\plugin.py:7663 ..\plugin.py:7746 ..\plugin.py:7761 ..\plugin.py:7776
+#: ..\plugin.py:7789 ..\plugin.py:7842 ..\plugin.py:7854
 msgid "- Font Size"
 msgstr "- 字体大小"
 
-#: ..\plugin.py:5744 ..\plugin.py:5958 ..\plugin.py:5971 ..\plugin.py:5988
-#: ..\plugin.py:6003 ..\plugin.py:6014 ..\plugin.py:6025 ..\plugin.py:6037
-#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6090
-#: ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6132 ..\plugin.py:6144
-#: ..\plugin.py:6156 ..\plugin.py:6168 ..\plugin.py:6181 ..\plugin.py:6192
-#: ..\plugin.py:6202 ..\plugin.py:6209 ..\plugin.py:6220 ..\plugin.py:6230
-#: ..\plugin.py:6248 ..\plugin.py:6260 ..\plugin.py:6278 ..\plugin.py:6285
-#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6316 ..\plugin.py:6339
-#: ..\plugin.py:6362 ..\plugin.py:6372 ..\plugin.py:6384 ..\plugin.py:6396
-#: ..\plugin.py:6409 ..\plugin.py:6418 ..\plugin.py:6428 ..\plugin.py:6439
-#: ..\plugin.py:6450 ..\plugin.py:6461 ..\plugin.py:6471 ..\plugin.py:6486
-#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
-#: ..\plugin.py:6536 ..\plugin.py:6544 ..\plugin.py:6559 ..\plugin.py:6577
-#: ..\plugin.py:6587 ..\plugin.py:6600 ..\plugin.py:6616 ..\plugin.py:6629
-#: ..\plugin.py:6640 ..\plugin.py:6652 ..\plugin.py:6683 ..\plugin.py:6717
-#: ..\plugin.py:6729 ..\plugin.py:6742 ..\plugin.py:6755 ..\plugin.py:6768
-#: ..\plugin.py:6781 ..\plugin.py:6794 ..\plugin.py:6808 ..\plugin.py:6818
-#: ..\plugin.py:6830 ..\plugin.py:6845 ..\plugin.py:6857 ..\plugin.py:6870
-#: ..\plugin.py:6881 ..\plugin.py:6894 ..\plugin.py:6905 ..\plugin.py:6916
-#: ..\plugin.py:6926 ..\plugin.py:6944 ..\plugin.py:6955 ..\plugin.py:6973
-#: ..\plugin.py:6980 ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7011
-#: ..\plugin.py:7034 ..\plugin.py:7057 ..\plugin.py:7067 ..\plugin.py:7079
-#: ..\plugin.py:7091 ..\plugin.py:7104 ..\plugin.py:7115 ..\plugin.py:7127
-#: ..\plugin.py:7137 ..\plugin.py:7146 ..\plugin.py:7162 ..\plugin.py:7171
-#: ..\plugin.py:7186 ..\plugin.py:7204 ..\plugin.py:7214 ..\plugin.py:7227
-#: ..\plugin.py:7243 ..\plugin.py:7256 ..\plugin.py:7267 ..\plugin.py:7279
-#: ..\plugin.py:7310 ..\plugin.py:7359 ..\plugin.py:7374 ..\plugin.py:7387
-#: ..\plugin.py:7400 ..\plugin.py:7413 ..\plugin.py:7424 ..\plugin.py:7434
-#: ..\plugin.py:7452 ..\plugin.py:7463 ..\plugin.py:7481 ..\plugin.py:7488
-#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7519 ..\plugin.py:7542
-#: ..\plugin.py:7565 ..\plugin.py:7575 ..\plugin.py:7587 ..\plugin.py:7599
-#: ..\plugin.py:7611 ..\plugin.py:7621 ..\plugin.py:7632 ..\plugin.py:7643
-#: ..\plugin.py:7654 ..\plugin.py:7664 ..\plugin.py:7679 ..\plugin.py:7689
-#: ..\plugin.py:7699 ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729
-#: ..\plugin.py:7737 ..\plugin.py:7752 ..\plugin.py:7770 ..\plugin.py:7780
-#: ..\plugin.py:7793 ..\plugin.py:7809 ..\plugin.py:7822 ..\plugin.py:7833
-#: ..\plugin.py:7845 ..\plugin.py:7876 ..\plugin_original.py:5743
-#: ..\plugin_original.py:5956 ..\plugin_original.py:5969
-#: ..\plugin_original.py:5986 ..\plugin_original.py:6001
-#: ..\plugin_original.py:6012 ..\plugin_original.py:6023
-#: ..\plugin_original.py:6035 ..\plugin_original.py:6048
-#: ..\plugin_original.py:6061 ..\plugin_original.py:6074
-#: ..\plugin_original.py:6088 ..\plugin_original.py:6105
-#: ..\plugin_original.py:6119 ..\plugin_original.py:6130
-#: ..\plugin_original.py:6142 ..\plugin_original.py:6154
-#: ..\plugin_original.py:6166 ..\plugin_original.py:6179
-#: ..\plugin_original.py:6190 ..\plugin_original.py:6200
-#: ..\plugin_original.py:6207 ..\plugin_original.py:6218
-#: ..\plugin_original.py:6228 ..\plugin_original.py:6246
-#: ..\plugin_original.py:6258 ..\plugin_original.py:6276
-#: ..\plugin_original.py:6283 ..\plugin_original.py:6294
-#: ..\plugin_original.py:6305 ..\plugin_original.py:6314
-#: ..\plugin_original.py:6337 ..\plugin_original.py:6360
-#: ..\plugin_original.py:6370 ..\plugin_original.py:6382
-#: ..\plugin_original.py:6394 ..\plugin_original.py:6407
-#: ..\plugin_original.py:6416 ..\plugin_original.py:6426
-#: ..\plugin_original.py:6437 ..\plugin_original.py:6448
-#: ..\plugin_original.py:6459 ..\plugin_original.py:6469
-#: ..\plugin_original.py:6484 ..\plugin_original.py:6494
-#: ..\plugin_original.py:6504 ..\plugin_original.py:6514
-#: ..\plugin_original.py:6524 ..\plugin_original.py:6534
-#: ..\plugin_original.py:6542 ..\plugin_original.py:6557
-#: ..\plugin_original.py:6575 ..\plugin_original.py:6585
-#: ..\plugin_original.py:6598 ..\plugin_original.py:6614
-#: ..\plugin_original.py:6627 ..\plugin_original.py:6638
-#: ..\plugin_original.py:6650 ..\plugin_original.py:6681
-#: ..\plugin_original.py:6715 ..\plugin_original.py:6727
-#: ..\plugin_original.py:6740 ..\plugin_original.py:6753
-#: ..\plugin_original.py:6766 ..\plugin_original.py:6779
-#: ..\plugin_original.py:6792 ..\plugin_original.py:6806
-#: ..\plugin_original.py:6816 ..\plugin_original.py:6828
-#: ..\plugin_original.py:6843 ..\plugin_original.py:6855
-#: ..\plugin_original.py:6868 ..\plugin_original.py:6879
-#: ..\plugin_original.py:6892 ..\plugin_original.py:6903
-#: ..\plugin_original.py:6914 ..\plugin_original.py:6924
-#: ..\plugin_original.py:6942 ..\plugin_original.py:6953
-#: ..\plugin_original.py:6971 ..\plugin_original.py:6978
-#: ..\plugin_original.py:6989 ..\plugin_original.py:7000
-#: ..\plugin_original.py:7009 ..\plugin_original.py:7032
-#: ..\plugin_original.py:7055 ..\plugin_original.py:7065
-#: ..\plugin_original.py:7077 ..\plugin_original.py:7089
-#: ..\plugin_original.py:7102 ..\plugin_original.py:7113
-#: ..\plugin_original.py:7125 ..\plugin_original.py:7135
-#: ..\plugin_original.py:7144 ..\plugin_original.py:7160
-#: ..\plugin_original.py:7169 ..\plugin_original.py:7184
-#: ..\plugin_original.py:7202 ..\plugin_original.py:7212
-#: ..\plugin_original.py:7225 ..\plugin_original.py:7241
-#: ..\plugin_original.py:7254 ..\plugin_original.py:7265
-#: ..\plugin_original.py:7277 ..\plugin_original.py:7308
-#: ..\plugin_original.py:7357 ..\plugin_original.py:7372
-#: ..\plugin_original.py:7385 ..\plugin_original.py:7398
-#: ..\plugin_original.py:7411 ..\plugin_original.py:7422
-#: ..\plugin_original.py:7432 ..\plugin_original.py:7450
-#: ..\plugin_original.py:7461 ..\plugin_original.py:7479
-#: ..\plugin_original.py:7486 ..\plugin_original.py:7497
-#: ..\plugin_original.py:7508 ..\plugin_original.py:7517
-#: ..\plugin_original.py:7540 ..\plugin_original.py:7563
-#: ..\plugin_original.py:7573 ..\plugin_original.py:7585
-#: ..\plugin_original.py:7597 ..\plugin_original.py:7609
-#: ..\plugin_original.py:7619 ..\plugin_original.py:7630
-#: ..\plugin_original.py:7641 ..\plugin_original.py:7652
-#: ..\plugin_original.py:7662 ..\plugin_original.py:7677
-#: ..\plugin_original.py:7687 ..\plugin_original.py:7697
-#: ..\plugin_original.py:7707 ..\plugin_original.py:7717
-#: ..\plugin_original.py:7727 ..\plugin_original.py:7735
-#: ..\plugin_original.py:7750 ..\plugin_original.py:7768
-#: ..\plugin_original.py:7778 ..\plugin_original.py:7791
-#: ..\plugin_original.py:7807 ..\plugin_original.py:7820
-#: ..\plugin_original.py:7831 ..\plugin_original.py:7843
-#: ..\plugin_original.py:7874
+#: ..\plugin.py:5751 ..\plugin.py:5966 ..\plugin.py:5979 ..\plugin.py:5996
+#: ..\plugin.py:6011 ..\plugin.py:6022 ..\plugin.py:6033 ..\plugin.py:6045
+#: ..\plugin.py:6058 ..\plugin.py:6071 ..\plugin.py:6084 ..\plugin.py:6098
+#: ..\plugin.py:6115 ..\plugin.py:6129 ..\plugin.py:6140 ..\plugin.py:6152
+#: ..\plugin.py:6164 ..\plugin.py:6176 ..\plugin.py:6189 ..\plugin.py:6200
+#: ..\plugin.py:6210 ..\plugin.py:6217 ..\plugin.py:6228 ..\plugin.py:6238
+#: ..\plugin.py:6256 ..\plugin.py:6268 ..\plugin.py:6286 ..\plugin.py:6293
+#: ..\plugin.py:6304 ..\plugin.py:6315 ..\plugin.py:6324 ..\plugin.py:6347
+#: ..\plugin.py:6370 ..\plugin.py:6380 ..\plugin.py:6392 ..\plugin.py:6404
+#: ..\plugin.py:6417 ..\plugin.py:6426 ..\plugin.py:6436 ..\plugin.py:6447
+#: ..\plugin.py:6458 ..\plugin.py:6469 ..\plugin.py:6479 ..\plugin.py:6494
+#: ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524 ..\plugin.py:6534
+#: ..\plugin.py:6544 ..\plugin.py:6552 ..\plugin.py:6567 ..\plugin.py:6585
+#: ..\plugin.py:6595 ..\plugin.py:6608 ..\plugin.py:6624 ..\plugin.py:6637
+#: ..\plugin.py:6648 ..\plugin.py:6660 ..\plugin.py:6691 ..\plugin.py:6726
+#: ..\plugin.py:6738 ..\plugin.py:6751 ..\plugin.py:6764 ..\plugin.py:6777
+#: ..\plugin.py:6790 ..\plugin.py:6803 ..\plugin.py:6817 ..\plugin.py:6827
+#: ..\plugin.py:6839 ..\plugin.py:6854 ..\plugin.py:6866 ..\plugin.py:6879
+#: ..\plugin.py:6890 ..\plugin.py:6903 ..\plugin.py:6914 ..\plugin.py:6925
+#: ..\plugin.py:6935 ..\plugin.py:6953 ..\plugin.py:6964 ..\plugin.py:6982
+#: ..\plugin.py:6989 ..\plugin.py:7000 ..\plugin.py:7011 ..\plugin.py:7020
+#: ..\plugin.py:7043 ..\plugin.py:7066 ..\plugin.py:7076 ..\plugin.py:7088
+#: ..\plugin.py:7100 ..\plugin.py:7113 ..\plugin.py:7124 ..\plugin.py:7136
+#: ..\plugin.py:7146 ..\plugin.py:7155 ..\plugin.py:7171 ..\plugin.py:7180
+#: ..\plugin.py:7195 ..\plugin.py:7213 ..\plugin.py:7223 ..\plugin.py:7236
+#: ..\plugin.py:7252 ..\plugin.py:7265 ..\plugin.py:7276 ..\plugin.py:7288
+#: ..\plugin.py:7319 ..\plugin.py:7369 ..\plugin.py:7384 ..\plugin.py:7397
+#: ..\plugin.py:7410 ..\plugin.py:7423 ..\plugin.py:7434 ..\plugin.py:7444
+#: ..\plugin.py:7462 ..\plugin.py:7473 ..\plugin.py:7491 ..\plugin.py:7498
+#: ..\plugin.py:7509 ..\plugin.py:7520 ..\plugin.py:7529 ..\plugin.py:7552
+#: ..\plugin.py:7575 ..\plugin.py:7585 ..\plugin.py:7597 ..\plugin.py:7609
+#: ..\plugin.py:7621 ..\plugin.py:7631 ..\plugin.py:7642 ..\plugin.py:7653
+#: ..\plugin.py:7664 ..\plugin.py:7674 ..\plugin.py:7689 ..\plugin.py:7699
+#: ..\plugin.py:7709 ..\plugin.py:7719 ..\plugin.py:7729 ..\plugin.py:7739
+#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7780 ..\plugin.py:7790
+#: ..\plugin.py:7803 ..\plugin.py:7819 ..\plugin.py:7832 ..\plugin.py:7843
+#: ..\plugin.py:7855 ..\plugin.py:7886
 msgid "- Position"
 msgstr "- 位置"
 
-#: ..\plugin.py:5745 ..\plugin.py:5959 ..\plugin.py:5972 ..\plugin.py:5989
-#: ..\plugin.py:6004 ..\plugin.py:6015 ..\plugin.py:6026 ..\plugin.py:6038
-#: ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077 ..\plugin.py:6091
-#: ..\plugin.py:6108 ..\plugin.py:6122 ..\plugin.py:6133 ..\plugin.py:6145
-#: ..\plugin.py:6157 ..\plugin.py:6169 ..\plugin.py:6182 ..\plugin.py:6193
-#: ..\plugin.py:6203 ..\plugin.py:6211 ..\plugin.py:6221 ..\plugin.py:6231
-#: ..\plugin.py:6249 ..\plugin.py:6261 ..\plugin.py:6279 ..\plugin.py:6287
-#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6318 ..\plugin.py:6341
-#: ..\plugin.py:6364 ..\plugin.py:6374 ..\plugin.py:6385 ..\plugin.py:6397
-#: ..\plugin.py:6410 ..\plugin.py:6419 ..\plugin.py:6429 ..\plugin.py:6440
-#: ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6472 ..\plugin.py:6487
-#: ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517 ..\plugin.py:6527
-#: ..\plugin.py:6537 ..\plugin.py:6545 ..\plugin.py:6560 ..\plugin.py:6578
-#: ..\plugin.py:6588 ..\plugin.py:6602 ..\plugin.py:6617 ..\plugin.py:6630
-#: ..\plugin.py:6641 ..\plugin.py:6653 ..\plugin.py:6684 ..\plugin.py:6718
-#: ..\plugin.py:6730 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
-#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6809 ..\plugin.py:6819
-#: ..\plugin.py:6831 ..\plugin.py:6846 ..\plugin.py:6858 ..\plugin.py:6871
-#: ..\plugin.py:6882 ..\plugin.py:6895 ..\plugin.py:6907 ..\plugin.py:6917
-#: ..\plugin.py:6927 ..\plugin.py:6945 ..\plugin.py:6956 ..\plugin.py:6974
-#: ..\plugin.py:6982 ..\plugin.py:6993 ..\plugin.py:7004 ..\plugin.py:7013
-#: ..\plugin.py:7036 ..\plugin.py:7059 ..\plugin.py:7069 ..\plugin.py:7080
-#: ..\plugin.py:7092 ..\plugin.py:7105 ..\plugin.py:7116 ..\plugin.py:7128
-#: ..\plugin.py:7138 ..\plugin.py:7147 ..\plugin.py:7163 ..\plugin.py:7172
-#: ..\plugin.py:7187 ..\plugin.py:7205 ..\plugin.py:7215 ..\plugin.py:7229
-#: ..\plugin.py:7244 ..\plugin.py:7257 ..\plugin.py:7268 ..\plugin.py:7280
-#: ..\plugin.py:7311 ..\plugin.py:7360 ..\plugin.py:7375 ..\plugin.py:7388
-#: ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7425 ..\plugin.py:7435
-#: ..\plugin.py:7453 ..\plugin.py:7464 ..\plugin.py:7482 ..\plugin.py:7490
-#: ..\plugin.py:7501 ..\plugin.py:7512 ..\plugin.py:7521 ..\plugin.py:7544
-#: ..\plugin.py:7567 ..\plugin.py:7577 ..\plugin.py:7588 ..\plugin.py:7600
-#: ..\plugin.py:7612 ..\plugin.py:7622 ..\plugin.py:7633 ..\plugin.py:7644
-#: ..\plugin.py:7655 ..\plugin.py:7665 ..\plugin.py:7680 ..\plugin.py:7690
-#: ..\plugin.py:7700 ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730
-#: ..\plugin.py:7738 ..\plugin.py:7753 ..\plugin.py:7771 ..\plugin.py:7781
-#: ..\plugin.py:7795 ..\plugin.py:7810 ..\plugin.py:7823 ..\plugin.py:7834
-#: ..\plugin.py:7846 ..\plugin.py:7877 ..\plugin_original.py:5744
-#: ..\plugin_original.py:5957 ..\plugin_original.py:5970
-#: ..\plugin_original.py:5987 ..\plugin_original.py:6002
-#: ..\plugin_original.py:6013 ..\plugin_original.py:6024
-#: ..\plugin_original.py:6036 ..\plugin_original.py:6049
-#: ..\plugin_original.py:6062 ..\plugin_original.py:6075
-#: ..\plugin_original.py:6089 ..\plugin_original.py:6106
-#: ..\plugin_original.py:6120 ..\plugin_original.py:6131
-#: ..\plugin_original.py:6143 ..\plugin_original.py:6155
-#: ..\plugin_original.py:6167 ..\plugin_original.py:6180
-#: ..\plugin_original.py:6191 ..\plugin_original.py:6201
-#: ..\plugin_original.py:6209 ..\plugin_original.py:6219
-#: ..\plugin_original.py:6229 ..\plugin_original.py:6247
-#: ..\plugin_original.py:6259 ..\plugin_original.py:6277
-#: ..\plugin_original.py:6285 ..\plugin_original.py:6296
-#: ..\plugin_original.py:6307 ..\plugin_original.py:6316
-#: ..\plugin_original.py:6339 ..\plugin_original.py:6362
-#: ..\plugin_original.py:6372 ..\plugin_original.py:6383
-#: ..\plugin_original.py:6395 ..\plugin_original.py:6408
-#: ..\plugin_original.py:6417 ..\plugin_original.py:6427
-#: ..\plugin_original.py:6438 ..\plugin_original.py:6449
-#: ..\plugin_original.py:6460 ..\plugin_original.py:6470
-#: ..\plugin_original.py:6485 ..\plugin_original.py:6495
-#: ..\plugin_original.py:6505 ..\plugin_original.py:6515
-#: ..\plugin_original.py:6525 ..\plugin_original.py:6535
-#: ..\plugin_original.py:6543 ..\plugin_original.py:6558
-#: ..\plugin_original.py:6576 ..\plugin_original.py:6586
-#: ..\plugin_original.py:6600 ..\plugin_original.py:6615
-#: ..\plugin_original.py:6628 ..\plugin_original.py:6639
-#: ..\plugin_original.py:6651 ..\plugin_original.py:6682
-#: ..\plugin_original.py:6716 ..\plugin_original.py:6728
-#: ..\plugin_original.py:6741 ..\plugin_original.py:6754
-#: ..\plugin_original.py:6767 ..\plugin_original.py:6780
-#: ..\plugin_original.py:6793 ..\plugin_original.py:6807
-#: ..\plugin_original.py:6817 ..\plugin_original.py:6829
-#: ..\plugin_original.py:6844 ..\plugin_original.py:6856
-#: ..\plugin_original.py:6869 ..\plugin_original.py:6880
-#: ..\plugin_original.py:6893 ..\plugin_original.py:6905
-#: ..\plugin_original.py:6915 ..\plugin_original.py:6925
-#: ..\plugin_original.py:6943 ..\plugin_original.py:6954
-#: ..\plugin_original.py:6972 ..\plugin_original.py:6980
-#: ..\plugin_original.py:6991 ..\plugin_original.py:7002
-#: ..\plugin_original.py:7011 ..\plugin_original.py:7034
-#: ..\plugin_original.py:7057 ..\plugin_original.py:7067
-#: ..\plugin_original.py:7078 ..\plugin_original.py:7090
-#: ..\plugin_original.py:7103 ..\plugin_original.py:7114
-#: ..\plugin_original.py:7126 ..\plugin_original.py:7136
-#: ..\plugin_original.py:7145 ..\plugin_original.py:7161
-#: ..\plugin_original.py:7170 ..\plugin_original.py:7185
-#: ..\plugin_original.py:7203 ..\plugin_original.py:7213
-#: ..\plugin_original.py:7227 ..\plugin_original.py:7242
-#: ..\plugin_original.py:7255 ..\plugin_original.py:7266
-#: ..\plugin_original.py:7278 ..\plugin_original.py:7309
-#: ..\plugin_original.py:7358 ..\plugin_original.py:7373
-#: ..\plugin_original.py:7386 ..\plugin_original.py:7399
-#: ..\plugin_original.py:7412 ..\plugin_original.py:7423
-#: ..\plugin_original.py:7433 ..\plugin_original.py:7451
-#: ..\plugin_original.py:7462 ..\plugin_original.py:7480
-#: ..\plugin_original.py:7488 ..\plugin_original.py:7499
-#: ..\plugin_original.py:7510 ..\plugin_original.py:7519
-#: ..\plugin_original.py:7542 ..\plugin_original.py:7565
-#: ..\plugin_original.py:7575 ..\plugin_original.py:7586
-#: ..\plugin_original.py:7598 ..\plugin_original.py:7610
-#: ..\plugin_original.py:7620 ..\plugin_original.py:7631
-#: ..\plugin_original.py:7642 ..\plugin_original.py:7653
-#: ..\plugin_original.py:7663 ..\plugin_original.py:7678
-#: ..\plugin_original.py:7688 ..\plugin_original.py:7698
-#: ..\plugin_original.py:7708 ..\plugin_original.py:7718
-#: ..\plugin_original.py:7728 ..\plugin_original.py:7736
-#: ..\plugin_original.py:7751 ..\plugin_original.py:7769
-#: ..\plugin_original.py:7779 ..\plugin_original.py:7793
-#: ..\plugin_original.py:7808 ..\plugin_original.py:7821
-#: ..\plugin_original.py:7832 ..\plugin_original.py:7844
-#: ..\plugin_original.py:7875
+#: ..\plugin.py:5752 ..\plugin.py:5967 ..\plugin.py:5980 ..\plugin.py:5997
+#: ..\plugin.py:6012 ..\plugin.py:6023 ..\plugin.py:6034 ..\plugin.py:6046
+#: ..\plugin.py:6059 ..\plugin.py:6072 ..\plugin.py:6085 ..\plugin.py:6099
+#: ..\plugin.py:6116 ..\plugin.py:6130 ..\plugin.py:6141 ..\plugin.py:6153
+#: ..\plugin.py:6165 ..\plugin.py:6177 ..\plugin.py:6190 ..\plugin.py:6201
+#: ..\plugin.py:6211 ..\plugin.py:6219 ..\plugin.py:6229 ..\plugin.py:6239
+#: ..\plugin.py:6257 ..\plugin.py:6269 ..\plugin.py:6287 ..\plugin.py:6295
+#: ..\plugin.py:6306 ..\plugin.py:6317 ..\plugin.py:6326 ..\plugin.py:6349
+#: ..\plugin.py:6372 ..\plugin.py:6382 ..\plugin.py:6393 ..\plugin.py:6405
+#: ..\plugin.py:6418 ..\plugin.py:6427 ..\plugin.py:6437 ..\plugin.py:6448
+#: ..\plugin.py:6459 ..\plugin.py:6470 ..\plugin.py:6480 ..\plugin.py:6495
+#: ..\plugin.py:6505 ..\plugin.py:6515 ..\plugin.py:6525 ..\plugin.py:6535
+#: ..\plugin.py:6545 ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6586
+#: ..\plugin.py:6596 ..\plugin.py:6610 ..\plugin.py:6625 ..\plugin.py:6638
+#: ..\plugin.py:6649 ..\plugin.py:6661 ..\plugin.py:6692 ..\plugin.py:6727
+#: ..\plugin.py:6739 ..\plugin.py:6752 ..\plugin.py:6765 ..\plugin.py:6778
+#: ..\plugin.py:6791 ..\plugin.py:6804 ..\plugin.py:6818 ..\plugin.py:6828
+#: ..\plugin.py:6840 ..\plugin.py:6855 ..\plugin.py:6867 ..\plugin.py:6880
+#: ..\plugin.py:6891 ..\plugin.py:6904 ..\plugin.py:6916 ..\plugin.py:6926
+#: ..\plugin.py:6936 ..\plugin.py:6954 ..\plugin.py:6965 ..\plugin.py:6983
+#: ..\plugin.py:6991 ..\plugin.py:7002 ..\plugin.py:7013 ..\plugin.py:7022
+#: ..\plugin.py:7045 ..\plugin.py:7068 ..\plugin.py:7078 ..\plugin.py:7089
+#: ..\plugin.py:7101 ..\plugin.py:7114 ..\plugin.py:7125 ..\plugin.py:7137
+#: ..\plugin.py:7147 ..\plugin.py:7156 ..\plugin.py:7172 ..\plugin.py:7181
+#: ..\plugin.py:7196 ..\plugin.py:7214 ..\plugin.py:7224 ..\plugin.py:7238
+#: ..\plugin.py:7253 ..\plugin.py:7266 ..\plugin.py:7277 ..\plugin.py:7289
+#: ..\plugin.py:7320 ..\plugin.py:7370 ..\plugin.py:7385 ..\plugin.py:7398
+#: ..\plugin.py:7411 ..\plugin.py:7424 ..\plugin.py:7435 ..\plugin.py:7445
+#: ..\plugin.py:7463 ..\plugin.py:7474 ..\plugin.py:7492 ..\plugin.py:7500
+#: ..\plugin.py:7511 ..\plugin.py:7522 ..\plugin.py:7531 ..\plugin.py:7554
+#: ..\plugin.py:7577 ..\plugin.py:7587 ..\plugin.py:7598 ..\plugin.py:7610
+#: ..\plugin.py:7622 ..\plugin.py:7632 ..\plugin.py:7643 ..\plugin.py:7654
+#: ..\plugin.py:7665 ..\plugin.py:7675 ..\plugin.py:7690 ..\plugin.py:7700
+#: ..\plugin.py:7710 ..\plugin.py:7720 ..\plugin.py:7730 ..\plugin.py:7740
+#: ..\plugin.py:7748 ..\plugin.py:7763 ..\plugin.py:7781 ..\plugin.py:7791
+#: ..\plugin.py:7805 ..\plugin.py:7820 ..\plugin.py:7833 ..\plugin.py:7844
+#: ..\plugin.py:7856 ..\plugin.py:7887
 msgid "- Alignment"
 msgstr "- 对齐"
 
-#: ..\plugin.py:5746 ..\plugin.py:5823 ..\plugin.py:5825 ..\plugin.py:5827
-#: ..\plugin.py:5829 ..\plugin.py:5831 ..\plugin.py:5952 ..\plugin.py:5991
-#: ..\plugin.py:6006 ..\plugin.py:6018 ..\plugin.py:6027 ..\plugin.py:6041
-#: ..\plugin.py:6054 ..\plugin.py:6067 ..\plugin.py:6080 ..\plugin.py:6093
-#: ..\plugin.py:6111 ..\plugin.py:6125 ..\plugin.py:6136 ..\plugin.py:6147
-#: ..\plugin.py:6159 ..\plugin.py:6185 ..\plugin.py:6196 ..\plugin.py:6213
-#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6251 ..\plugin.py:6263
-#: ..\plugin.py:6290 ..\plugin.py:6301 ..\plugin.py:6312 ..\plugin.py:6327
-#: ..\plugin.py:6350 ..\plugin.py:6389 ..\plugin.py:6399 ..\plugin.py:6412
-#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6441 ..\plugin.py:6452
-#: ..\plugin.py:6463 ..\plugin.py:6547 ..\plugin.py:6589 ..\plugin.py:6607
-#: ..\plugin.py:6622 ..\plugin.py:6643 ..\plugin.py:6655 ..\plugin.py:6666
-#: ..\plugin.py:6675 ..\plugin.py:6710 ..\plugin.py:6721 ..\plugin.py:6733
-#: ..\plugin.py:6746 ..\plugin.py:6759 ..\plugin.py:6772 ..\plugin.py:6785
-#: ..\plugin.py:6797 ..\plugin.py:6812 ..\plugin.py:6833 ..\plugin.py:6848
-#: ..\plugin.py:6861 ..\plugin.py:6874 ..\plugin.py:6898 ..\plugin.py:6909
-#: ..\plugin.py:6919 ..\plugin.py:6929 ..\plugin.py:6947 ..\plugin.py:6958
-#: ..\plugin.py:6985 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7022
-#: ..\plugin.py:7045 ..\plugin.py:7084 ..\plugin.py:7094 ..\plugin.py:7106
-#: ..\plugin.py:7117 ..\plugin.py:7165 ..\plugin.py:7174 ..\plugin.py:7216
-#: ..\plugin.py:7234 ..\plugin.py:7249 ..\plugin.py:7270 ..\plugin.py:7282
-#: ..\plugin.py:7293 ..\plugin.py:7302 ..\plugin.py:7338 ..\plugin.py:7362
-#: ..\plugin.py:7377 ..\plugin.py:7391 ..\plugin.py:7404 ..\plugin.py:7417
-#: ..\plugin.py:7437 ..\plugin.py:7455 ..\plugin.py:7466 ..\plugin.py:7493
-#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7530 ..\plugin.py:7553
-#: ..\plugin.py:7592 ..\plugin.py:7602 ..\plugin.py:7614 ..\plugin.py:7623
-#: ..\plugin.py:7634 ..\plugin.py:7645 ..\plugin.py:7656 ..\plugin.py:7740
-#: ..\plugin.py:7782 ..\plugin.py:7800 ..\plugin.py:7815 ..\plugin.py:7836
-#: ..\plugin.py:7848 ..\plugin.py:7859 ..\plugin.py:7868
-#: ..\plugin_original.py:5745 ..\plugin_original.py:5821
-#: ..\plugin_original.py:5823 ..\plugin_original.py:5825
-#: ..\plugin_original.py:5827 ..\plugin_original.py:5829
-#: ..\plugin_original.py:5950 ..\plugin_original.py:5989
-#: ..\plugin_original.py:6004 ..\plugin_original.py:6016
-#: ..\plugin_original.py:6025 ..\plugin_original.py:6039
-#: ..\plugin_original.py:6052 ..\plugin_original.py:6065
-#: ..\plugin_original.py:6078 ..\plugin_original.py:6091
-#: ..\plugin_original.py:6109 ..\plugin_original.py:6123
-#: ..\plugin_original.py:6134 ..\plugin_original.py:6145
-#: ..\plugin_original.py:6157 ..\plugin_original.py:6183
-#: ..\plugin_original.py:6194 ..\plugin_original.py:6211
-#: ..\plugin_original.py:6221 ..\plugin_original.py:6231
-#: ..\plugin_original.py:6249 ..\plugin_original.py:6261
-#: ..\plugin_original.py:6288 ..\plugin_original.py:6299
-#: ..\plugin_original.py:6310 ..\plugin_original.py:6325
-#: ..\plugin_original.py:6348 ..\plugin_original.py:6387
-#: ..\plugin_original.py:6397 ..\plugin_original.py:6410
-#: ..\plugin_original.py:6419 ..\plugin_original.py:6428
-#: ..\plugin_original.py:6439 ..\plugin_original.py:6450
-#: ..\plugin_original.py:6461 ..\plugin_original.py:6545
-#: ..\plugin_original.py:6587 ..\plugin_original.py:6605
-#: ..\plugin_original.py:6620 ..\plugin_original.py:6641
-#: ..\plugin_original.py:6653 ..\plugin_original.py:6664
-#: ..\plugin_original.py:6673 ..\plugin_original.py:6708
-#: ..\plugin_original.py:6719 ..\plugin_original.py:6731
-#: ..\plugin_original.py:6744 ..\plugin_original.py:6757
-#: ..\plugin_original.py:6770 ..\plugin_original.py:6783
-#: ..\plugin_original.py:6795 ..\plugin_original.py:6810
-#: ..\plugin_original.py:6831 ..\plugin_original.py:6846
-#: ..\plugin_original.py:6859 ..\plugin_original.py:6872
-#: ..\plugin_original.py:6896 ..\plugin_original.py:6907
-#: ..\plugin_original.py:6917 ..\plugin_original.py:6927
-#: ..\plugin_original.py:6945 ..\plugin_original.py:6956
-#: ..\plugin_original.py:6983 ..\plugin_original.py:6994
-#: ..\plugin_original.py:7005 ..\plugin_original.py:7020
-#: ..\plugin_original.py:7043 ..\plugin_original.py:7082
-#: ..\plugin_original.py:7092 ..\plugin_original.py:7104
-#: ..\plugin_original.py:7115 ..\plugin_original.py:7163
-#: ..\plugin_original.py:7172 ..\plugin_original.py:7214
-#: ..\plugin_original.py:7232 ..\plugin_original.py:7247
-#: ..\plugin_original.py:7268 ..\plugin_original.py:7280
-#: ..\plugin_original.py:7291 ..\plugin_original.py:7300
-#: ..\plugin_original.py:7336 ..\plugin_original.py:7360
-#: ..\plugin_original.py:7375 ..\plugin_original.py:7389
-#: ..\plugin_original.py:7402 ..\plugin_original.py:7415
-#: ..\plugin_original.py:7435 ..\plugin_original.py:7453
-#: ..\plugin_original.py:7464 ..\plugin_original.py:7491
-#: ..\plugin_original.py:7502 ..\plugin_original.py:7513
-#: ..\plugin_original.py:7528 ..\plugin_original.py:7551
-#: ..\plugin_original.py:7590 ..\plugin_original.py:7600
-#: ..\plugin_original.py:7612 ..\plugin_original.py:7621
-#: ..\plugin_original.py:7632 ..\plugin_original.py:7643
-#: ..\plugin_original.py:7654 ..\plugin_original.py:7738
-#: ..\plugin_original.py:7780 ..\plugin_original.py:7798
-#: ..\plugin_original.py:7813 ..\plugin_original.py:7834
-#: ..\plugin_original.py:7846 ..\plugin_original.py:7857
-#: ..\plugin_original.py:7866
+#: ..\plugin.py:5753 ..\plugin.py:5830 ..\plugin.py:5832 ..\plugin.py:5834
+#: ..\plugin.py:5836 ..\plugin.py:5838 ..\plugin.py:5960 ..\plugin.py:5999
+#: ..\plugin.py:6014 ..\plugin.py:6026 ..\plugin.py:6035 ..\plugin.py:6049
+#: ..\plugin.py:6062 ..\plugin.py:6075 ..\plugin.py:6088 ..\plugin.py:6101
+#: ..\plugin.py:6119 ..\plugin.py:6133 ..\plugin.py:6144 ..\plugin.py:6155
+#: ..\plugin.py:6167 ..\plugin.py:6193 ..\plugin.py:6204 ..\plugin.py:6221
+#: ..\plugin.py:6231 ..\plugin.py:6241 ..\plugin.py:6259 ..\plugin.py:6271
+#: ..\plugin.py:6298 ..\plugin.py:6309 ..\plugin.py:6320 ..\plugin.py:6335
+#: ..\plugin.py:6358 ..\plugin.py:6397 ..\plugin.py:6407 ..\plugin.py:6420
+#: ..\plugin.py:6429 ..\plugin.py:6438 ..\plugin.py:6449 ..\plugin.py:6460
+#: ..\plugin.py:6471 ..\plugin.py:6555 ..\plugin.py:6597 ..\plugin.py:6615
+#: ..\plugin.py:6630 ..\plugin.py:6651 ..\plugin.py:6663 ..\plugin.py:6674
+#: ..\plugin.py:6683 ..\plugin.py:6719 ..\plugin.py:6730 ..\plugin.py:6742
+#: ..\plugin.py:6755 ..\plugin.py:6768 ..\plugin.py:6781 ..\plugin.py:6794
+#: ..\plugin.py:6806 ..\plugin.py:6821 ..\plugin.py:6842 ..\plugin.py:6857
+#: ..\plugin.py:6870 ..\plugin.py:6883 ..\plugin.py:6907 ..\plugin.py:6918
+#: ..\plugin.py:6928 ..\plugin.py:6938 ..\plugin.py:6956 ..\plugin.py:6967
+#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7016 ..\plugin.py:7031
+#: ..\plugin.py:7054 ..\plugin.py:7093 ..\plugin.py:7103 ..\plugin.py:7115
+#: ..\plugin.py:7126 ..\plugin.py:7174 ..\plugin.py:7183 ..\plugin.py:7225
+#: ..\plugin.py:7243 ..\plugin.py:7258 ..\plugin.py:7279 ..\plugin.py:7291
+#: ..\plugin.py:7302 ..\plugin.py:7311 ..\plugin.py:7348 ..\plugin.py:7372
+#: ..\plugin.py:7387 ..\plugin.py:7401 ..\plugin.py:7414 ..\plugin.py:7427
+#: ..\plugin.py:7447 ..\plugin.py:7465 ..\plugin.py:7476 ..\plugin.py:7503
+#: ..\plugin.py:7514 ..\plugin.py:7525 ..\plugin.py:7540 ..\plugin.py:7563
+#: ..\plugin.py:7602 ..\plugin.py:7612 ..\plugin.py:7624 ..\plugin.py:7633
+#: ..\plugin.py:7644 ..\plugin.py:7655 ..\plugin.py:7666 ..\plugin.py:7750
+#: ..\plugin.py:7792 ..\plugin.py:7810 ..\plugin.py:7825 ..\plugin.py:7846
+#: ..\plugin.py:7858 ..\plugin.py:7869 ..\plugin.py:7878
 msgid "- Color"
 msgstr "- 颜色"
 
-#: ..\plugin.py:5747 ..\plugin.py:6028 ..\plugin.py:6252 ..\plugin.py:6400
-#: ..\plugin.py:6413 ..\plugin.py:6422 ..\plugin.py:6431 ..\plugin.py:6442
-#: ..\plugin.py:6453 ..\plugin.py:6464 ..\plugin.py:6548 ..\plugin.py:6590
-#: ..\plugin.py:6644 ..\plugin.py:6656 ..\plugin.py:6667 ..\plugin.py:6676
-#: ..\plugin.py:6948 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
-#: ..\plugin.py:7166 ..\plugin.py:7175 ..\plugin.py:7217 ..\plugin.py:7271
-#: ..\plugin.py:7283 ..\plugin.py:7294 ..\plugin.py:7303 ..\plugin.py:7456
-#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7624 ..\plugin.py:7635
-#: ..\plugin.py:7646 ..\plugin.py:7657 ..\plugin.py:7741 ..\plugin.py:7783
-#: ..\plugin.py:7837 ..\plugin.py:7849 ..\plugin.py:7860 ..\plugin.py:7869
-#: ..\plugin_original.py:5746 ..\plugin_original.py:6026
-#: ..\plugin_original.py:6250 ..\plugin_original.py:6398
-#: ..\plugin_original.py:6411 ..\plugin_original.py:6420
-#: ..\plugin_original.py:6429 ..\plugin_original.py:6440
-#: ..\plugin_original.py:6451 ..\plugin_original.py:6462
-#: ..\plugin_original.py:6546 ..\plugin_original.py:6588
-#: ..\plugin_original.py:6642 ..\plugin_original.py:6654
-#: ..\plugin_original.py:6665 ..\plugin_original.py:6674
-#: ..\plugin_original.py:6946 ..\plugin_original.py:7093
-#: ..\plugin_original.py:7105 ..\plugin_original.py:7116
-#: ..\plugin_original.py:7164 ..\plugin_original.py:7173
-#: ..\plugin_original.py:7215 ..\plugin_original.py:7269
-#: ..\plugin_original.py:7281 ..\plugin_original.py:7292
-#: ..\plugin_original.py:7301 ..\plugin_original.py:7454
-#: ..\plugin_original.py:7601 ..\plugin_original.py:7613
-#: ..\plugin_original.py:7622 ..\plugin_original.py:7633
-#: ..\plugin_original.py:7644 ..\plugin_original.py:7655
-#: ..\plugin_original.py:7739 ..\plugin_original.py:7781
-#: ..\plugin_original.py:7835 ..\plugin_original.py:7847
-#: ..\plugin_original.py:7858 ..\plugin_original.py:7867
+#: ..\plugin.py:5754 ..\plugin.py:6036 ..\plugin.py:6260 ..\plugin.py:6408
+#: ..\plugin.py:6421 ..\plugin.py:6430 ..\plugin.py:6439 ..\plugin.py:6450
+#: ..\plugin.py:6461 ..\plugin.py:6472 ..\plugin.py:6556 ..\plugin.py:6598
+#: ..\plugin.py:6652 ..\plugin.py:6664 ..\plugin.py:6675 ..\plugin.py:6684
+#: ..\plugin.py:6957 ..\plugin.py:7104 ..\plugin.py:7116 ..\plugin.py:7127
+#: ..\plugin.py:7175 ..\plugin.py:7184 ..\plugin.py:7226 ..\plugin.py:7280
+#: ..\plugin.py:7292 ..\plugin.py:7303 ..\plugin.py:7312 ..\plugin.py:7466
+#: ..\plugin.py:7613 ..\plugin.py:7625 ..\plugin.py:7634 ..\plugin.py:7645
+#: ..\plugin.py:7656 ..\plugin.py:7667 ..\plugin.py:7751 ..\plugin.py:7793
+#: ..\plugin.py:7847 ..\plugin.py:7859 ..\plugin.py:7870 ..\plugin.py:7879
 msgid "- Background Color"
 msgstr "- 背景色"
 
-#: ..\plugin.py:5748 ..\plugin.py:5993 ..\plugin.py:6008 ..\plugin.py:6020
-#: ..\plugin.py:6030 ..\plugin.py:6043 ..\plugin.py:6056 ..\plugin.py:6069
-#: ..\plugin.py:6082 ..\plugin.py:6099 ..\plugin.py:6113 ..\plugin.py:6127
-#: ..\plugin.py:6151 ..\plugin.py:6163 ..\plugin.py:6173 ..\plugin.py:6187
-#: ..\plugin.py:6215 ..\plugin.py:6225 ..\plugin.py:6235 ..\plugin.py:6254
-#: ..\plugin.py:6265 ..\plugin.py:6292 ..\plugin.py:6303 ..\plugin.py:6335
-#: ..\plugin.py:6358 ..\plugin.py:6391 ..\plugin.py:6403 ..\plugin.py:6433
-#: ..\plugin.py:6444 ..\plugin.py:6455 ..\plugin.py:6466 ..\plugin.py:6554
-#: ..\plugin.py:6569 ..\plugin.py:6582 ..\plugin.py:6596 ..\plugin.py:6611
-#: ..\plugin.py:6624 ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:6723
-#: ..\plugin.py:6735 ..\plugin.py:6748 ..\plugin.py:6761 ..\plugin.py:6774
-#: ..\plugin.py:6787 ..\plugin.py:6803 ..\plugin.py:6835 ..\plugin.py:6850
-#: ..\plugin.py:6863 ..\plugin.py:6876 ..\plugin.py:6886 ..\plugin.py:6900
-#: ..\plugin.py:6911 ..\plugin.py:6921 ..\plugin.py:6931 ..\plugin.py:6950
-#: ..\plugin.py:6960 ..\plugin.py:6987 ..\plugin.py:6998 ..\plugin.py:7030
-#: ..\plugin.py:7053 ..\plugin.py:7086 ..\plugin.py:7098 ..\plugin.py:7109
-#: ..\plugin.py:7120 ..\plugin.py:7181 ..\plugin.py:7196 ..\plugin.py:7209
-#: ..\plugin.py:7223 ..\plugin.py:7238 ..\plugin.py:7251 ..\plugin.py:7273
-#: ..\plugin.py:7285 ..\plugin.py:7364 ..\plugin.py:7379 ..\plugin.py:7393
-#: ..\plugin.py:7406 ..\plugin.py:7419 ..\plugin.py:7429 ..\plugin.py:7439
-#: ..\plugin.py:7458 ..\plugin.py:7468 ..\plugin.py:7495 ..\plugin.py:7506
-#: ..\plugin.py:7538 ..\plugin.py:7561 ..\plugin.py:7594 ..\plugin.py:7606
-#: ..\plugin.py:7626 ..\plugin.py:7637 ..\plugin.py:7648 ..\plugin.py:7659
-#: ..\plugin.py:7747 ..\plugin.py:7762 ..\plugin.py:7775 ..\plugin.py:7789
-#: ..\plugin.py:7804 ..\plugin.py:7817 ..\plugin.py:7839 ..\plugin.py:7851
-#: ..\plugin_original.py:5747 ..\plugin_original.py:5991
-#: ..\plugin_original.py:6006 ..\plugin_original.py:6018
-#: ..\plugin_original.py:6028 ..\plugin_original.py:6041
-#: ..\plugin_original.py:6054 ..\plugin_original.py:6067
-#: ..\plugin_original.py:6080 ..\plugin_original.py:6097
-#: ..\plugin_original.py:6111 ..\plugin_original.py:6125
-#: ..\plugin_original.py:6149 ..\plugin_original.py:6161
-#: ..\plugin_original.py:6171 ..\plugin_original.py:6185
-#: ..\plugin_original.py:6213 ..\plugin_original.py:6223
-#: ..\plugin_original.py:6233 ..\plugin_original.py:6252
-#: ..\plugin_original.py:6263 ..\plugin_original.py:6290
-#: ..\plugin_original.py:6301 ..\plugin_original.py:6333
-#: ..\plugin_original.py:6356 ..\plugin_original.py:6389
-#: ..\plugin_original.py:6401 ..\plugin_original.py:6431
-#: ..\plugin_original.py:6442 ..\plugin_original.py:6453
-#: ..\plugin_original.py:6464 ..\plugin_original.py:6552
-#: ..\plugin_original.py:6567 ..\plugin_original.py:6580
-#: ..\plugin_original.py:6594 ..\plugin_original.py:6609
-#: ..\plugin_original.py:6622 ..\plugin_original.py:6644
-#: ..\plugin_original.py:6656 ..\plugin_original.py:6721
-#: ..\plugin_original.py:6733 ..\plugin_original.py:6746
-#: ..\plugin_original.py:6759 ..\plugin_original.py:6772
-#: ..\plugin_original.py:6785 ..\plugin_original.py:6801
-#: ..\plugin_original.py:6833 ..\plugin_original.py:6848
-#: ..\plugin_original.py:6861 ..\plugin_original.py:6874
-#: ..\plugin_original.py:6884 ..\plugin_original.py:6898
-#: ..\plugin_original.py:6909 ..\plugin_original.py:6919
-#: ..\plugin_original.py:6929 ..\plugin_original.py:6948
-#: ..\plugin_original.py:6958 ..\plugin_original.py:6985
-#: ..\plugin_original.py:6996 ..\plugin_original.py:7028
-#: ..\plugin_original.py:7051 ..\plugin_original.py:7084
-#: ..\plugin_original.py:7096 ..\plugin_original.py:7107
-#: ..\plugin_original.py:7118 ..\plugin_original.py:7179
-#: ..\plugin_original.py:7194 ..\plugin_original.py:7207
-#: ..\plugin_original.py:7221 ..\plugin_original.py:7236
-#: ..\plugin_original.py:7249 ..\plugin_original.py:7271
-#: ..\plugin_original.py:7283 ..\plugin_original.py:7362
-#: ..\plugin_original.py:7377 ..\plugin_original.py:7391
-#: ..\plugin_original.py:7404 ..\plugin_original.py:7417
-#: ..\plugin_original.py:7427 ..\plugin_original.py:7437
-#: ..\plugin_original.py:7456 ..\plugin_original.py:7466
-#: ..\plugin_original.py:7493 ..\plugin_original.py:7504
-#: ..\plugin_original.py:7536 ..\plugin_original.py:7559
-#: ..\plugin_original.py:7592 ..\plugin_original.py:7604
-#: ..\plugin_original.py:7624 ..\plugin_original.py:7635
-#: ..\plugin_original.py:7646 ..\plugin_original.py:7657
-#: ..\plugin_original.py:7745 ..\plugin_original.py:7760
-#: ..\plugin_original.py:7773 ..\plugin_original.py:7787
-#: ..\plugin_original.py:7802 ..\plugin_original.py:7815
-#: ..\plugin_original.py:7837 ..\plugin_original.py:7849
+#: ..\plugin.py:5755 ..\plugin.py:6001 ..\plugin.py:6016 ..\plugin.py:6028
+#: ..\plugin.py:6038 ..\plugin.py:6051 ..\plugin.py:6064 ..\plugin.py:6077
+#: ..\plugin.py:6090 ..\plugin.py:6107 ..\plugin.py:6121 ..\plugin.py:6135
+#: ..\plugin.py:6159 ..\plugin.py:6171 ..\plugin.py:6181 ..\plugin.py:6195
+#: ..\plugin.py:6223 ..\plugin.py:6233 ..\plugin.py:6243 ..\plugin.py:6262
+#: ..\plugin.py:6273 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6343
+#: ..\plugin.py:6366 ..\plugin.py:6399 ..\plugin.py:6411 ..\plugin.py:6441
+#: ..\plugin.py:6452 ..\plugin.py:6463 ..\plugin.py:6474 ..\plugin.py:6562
+#: ..\plugin.py:6577 ..\plugin.py:6590 ..\plugin.py:6604 ..\plugin.py:6619
+#: ..\plugin.py:6632 ..\plugin.py:6654 ..\plugin.py:6666 ..\plugin.py:6732
+#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
+#: ..\plugin.py:6796 ..\plugin.py:6812 ..\plugin.py:6844 ..\plugin.py:6859
+#: ..\plugin.py:6872 ..\plugin.py:6885 ..\plugin.py:6895 ..\plugin.py:6909
+#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6940 ..\plugin.py:6959
+#: ..\plugin.py:6969 ..\plugin.py:6996 ..\plugin.py:7007 ..\plugin.py:7039
+#: ..\plugin.py:7062 ..\plugin.py:7095 ..\plugin.py:7107 ..\plugin.py:7118
+#: ..\plugin.py:7129 ..\plugin.py:7190 ..\plugin.py:7205 ..\plugin.py:7218
+#: ..\plugin.py:7232 ..\plugin.py:7247 ..\plugin.py:7260 ..\plugin.py:7282
+#: ..\plugin.py:7294 ..\plugin.py:7374 ..\plugin.py:7389 ..\plugin.py:7403
+#: ..\plugin.py:7416 ..\plugin.py:7429 ..\plugin.py:7439 ..\plugin.py:7449
+#: ..\plugin.py:7468 ..\plugin.py:7478 ..\plugin.py:7505 ..\plugin.py:7516
+#: ..\plugin.py:7548 ..\plugin.py:7571 ..\plugin.py:7604 ..\plugin.py:7616
+#: ..\plugin.py:7636 ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7669
+#: ..\plugin.py:7757 ..\plugin.py:7772 ..\plugin.py:7785 ..\plugin.py:7799
+#: ..\plugin.py:7814 ..\plugin.py:7827 ..\plugin.py:7849 ..\plugin.py:7861
 msgid "- Font"
 msgstr "- 字体"
 
-#: ..\plugin.py:5751 ..\plugin_original.py:5750
+#: ..\plugin.py:5758
 msgid "Active Screen"
 msgstr "活动画面"
 
-#: ..\plugin.py:5752 ..\plugin_original.py:5751
+#: ..\plugin.py:5759
 msgid "Screen Switch Select - Screen"
 msgstr "屏幕开关选择-屏幕"
 
-#: ..\plugin.py:5753
+#: ..\plugin.py:5760
 msgid "Screen Default after mode change - Screen"
 msgstr "模式更改后的屏幕默认值 - 屏幕"
 
-#: ..\plugin.py:5754 ..\plugin_original.py:5752
+#: ..\plugin.py:5761
 msgid "Screen Switch Select - LCD"
 msgstr "屏幕开关选择-LCD"
 
-#: ..\plugin.py:5755 ..\plugin_original.py:5753
+#: ..\plugin.py:5762
 msgid "Screens used for Changing"
 msgstr "用于更换的屏幕"
 
-#: ..\plugin.py:5756 ..\plugin.py:7340 ..\plugin_original.py:5754
-#: ..\plugin_original.py:7338
+#: ..\plugin.py:5763 ..\plugin.py:7350
 msgid "Screen 1 Changing Time"
 msgstr "屏幕1更改时间"
 
-#: ..\plugin.py:5758 ..\plugin.py:7342 ..\plugin_original.py:5756
-#: ..\plugin_original.py:7340
+#: ..\plugin.py:5765 ..\plugin.py:7352
 msgid "- Screen 2 Changing Time"
 msgstr "- 屏幕2更改时间"
 
-#: ..\plugin.py:5759 ..\plugin.py:7343 ..\plugin_original.py:5757
-#: ..\plugin_original.py:7341
+#: ..\plugin.py:5766 ..\plugin.py:7353
 msgid "- Screen 3 Changing Time"
 msgstr "- 屏幕3更改时间"
 
-#: ..\plugin.py:5760 ..\plugin.py:7344 ..\plugin_original.py:5758
-#: ..\plugin_original.py:7342
+#: ..\plugin.py:5767 ..\plugin.py:7354
 msgid "- Screen 4 Changing Time"
 msgstr "- 屏幕4更改时间"
 
-#: ..\plugin.py:5761 ..\plugin.py:7345 ..\plugin_original.py:5759
-#: ..\plugin_original.py:7343
+#: ..\plugin.py:5768 ..\plugin.py:7355
 msgid "- Screen 5 Changing Time"
 msgstr "- 屏幕5更改时间"
 
-#: ..\plugin.py:5762 ..\plugin.py:7346 ..\plugin_original.py:5760
-#: ..\plugin_original.py:7344
+#: ..\plugin.py:5769 ..\plugin.py:7356
 msgid "- Screen 6 Changing Time"
 msgstr "- 屏幕6更改时间"
 
-#: ..\plugin.py:5763 ..\plugin.py:7347 ..\plugin_original.py:5761
-#: ..\plugin_original.py:7345
+#: ..\plugin.py:5770 ..\plugin.py:7357
 msgid "- Screen 7 Changing Time"
 msgstr "- 屏幕7更改时间"
 
-#: ..\plugin.py:5764 ..\plugin.py:7348 ..\plugin_original.py:5762
-#: ..\plugin_original.py:7346
+#: ..\plugin.py:5771 ..\plugin.py:7358
 msgid "- Screen 8 Changing Time"
 msgstr "- 屏幕8更改时间"
 
-#: ..\plugin.py:5765 ..\plugin.py:7349 ..\plugin_original.py:5763
-#: ..\plugin_original.py:7347
+#: ..\plugin.py:5772 ..\plugin.py:7359
 msgid "- Screen 9 Changing Time"
 msgstr "- 屏幕9更改时间"
 
-#: ..\plugin.py:5766 ..\plugin_original.py:5764
+#: ..\plugin.py:5773
 msgid "Picture Changing Time"
 msgstr "图片更改时间"
 
-#: ..\plugin.py:5767 ..\plugin_original.py:5765
+#: ..\plugin.py:5774
 msgid "Picture Sort"
 msgstr "图片排序"
 
-#: ..\plugin.py:5768 ..\plugin_original.py:5766
+#: ..\plugin.py:5775
 msgid "Picture Directory Recursive"
 msgstr "图片目录递归"
 
-#: ..\plugin.py:5769 ..\plugin_original.py:5767
+#: ..\plugin.py:5776
 msgid "Picture Quality for Resizing"
 msgstr "调整画质的图像质量"
 
-#: ..\plugin.py:5771 ..\plugin_original.py:5769
+#: ..\plugin.py:5778
 msgid "Picture Quick Update Time [s]"
 msgstr "图片快速更新时间[s]"
 
-#: ..\plugin.py:5773 ..\plugin_original.py:5771
+#: ..\plugin.py:5780
 msgid "Picture Type [only Picture]"
 msgstr "图片类型[仅图片]"
 
-#: ..\plugin.py:5774 ..\plugin_original.py:5772
+#: ..\plugin.py:5781
 msgid "Background-Picture Type"
 msgstr "背景图片类型"
 
-#: ..\plugin.py:5775 ..\plugin_original.py:5773
+#: ..\plugin.py:5782
 msgid "Weather API"
 msgstr "天气 API"
 
-#: ..\plugin.py:5776 ..\plugin_original.py:5774
+#: ..\plugin.py:5783
 msgid "Weather API-Key OpenWeatherMap"
 msgstr "天气API键打开天气图"
 
-#: ..\plugin.py:5777 ..\plugin_original.py:5775
+#: ..\plugin.py:5784
 msgid "Weather API-ID Key WeatherUnlocked"
 msgstr "天气API-ID密钥天气解锁"
 
-#: ..\plugin.py:5778 ..\plugin_original.py:5776
+#: ..\plugin.py:5785
 msgid "Weather City"
 msgstr "天气城市"
 
-#: ..\plugin.py:5779 ..\plugin_original.py:5777
+#: ..\plugin.py:5786
 msgid "Weather City 2"
 msgstr "天气城市2"
 
-#: ..\plugin.py:5780 ..\plugin_original.py:5778
+#: ..\plugin.py:5787
 msgid "Weather-Icon-Path [ok]>"
 msgstr "天气图标路径 [ok]>"
 
-#: ..\plugin.py:5781 ..\plugin_original.py:5779
+#: ..\plugin.py:5788
 msgid "Weather-Icon Zoom"
 msgstr "天气图标放大"
 
-#: ..\plugin.py:5782 ..\plugin_original.py:5780
+#: ..\plugin.py:5789
 msgid "Weather Low Temperature Color"
 msgstr "天气低温色"
 
-#: ..\plugin.py:5783 ..\plugin_original.py:5781
+#: ..\plugin.py:5790
 msgid "Weather High Temperature Color"
 msgstr "天气高温色"
 
-#: ..\plugin.py:5784 ..\plugin_original.py:5782
+#: ..\plugin.py:5791
 msgid "Weather Transparency"
 msgstr "天气透明度"
 
-#: ..\plugin.py:5785 ..\plugin_original.py:5783
+#: ..\plugin.py:5792
 msgid "Weather Wind speed unit"
 msgstr "天气风速单位"
 
-#: ..\plugin.py:5786 ..\plugin_original.py:5784
+#: ..\plugin.py:5793
 msgid "Weather Wind Info Lines"
 msgstr "天气线"
 
-#: ..\plugin.py:5787 ..\plugin_original.py:5785
+#: ..\plugin.py:5794
 msgid "Weather Rain Chance"
 msgstr "天气雨"
 
-#: ..\plugin.py:5789 ..\plugin_original.py:5787
+#: ..\plugin.py:5796
 msgid "- Rain Zoom"
 msgstr "- 雨缩放"
 
-#: ..\plugin.py:5790 ..\plugin_original.py:5788
+#: ..\plugin.py:5797
 msgid "- Rain Color"
 msgstr "- 雨色"
 
-#: ..\plugin.py:5791 ..\plugin_original.py:5789
+#: ..\plugin.py:5798
 msgid "- Rain use Color 2 from"
 msgstr "- 从雨中使用颜色2"
 
-#: ..\plugin.py:5792 ..\plugin_original.py:5790
+#: ..\plugin.py:5799
 msgid "- Rain Color 2"
 msgstr "- 雨色2"
 
-#: ..\plugin.py:5793 ..\plugin_original.py:5791
+#: ..\plugin.py:5800
 msgid "Weather Humidity Color"
 msgstr "天气 湿度 颜色"
 
-#: ..\plugin.py:5794 ..\plugin_original.py:5792
+#: ..\plugin.py:5801
 msgid "Weather Lines"
 msgstr "天气线"
 
-#: ..\plugin.py:5795 ..\plugin_original.py:5793
+#: ..\plugin.py:5802
 msgid "Weather Trendarrows"
 msgstr "天气趋势箭头"
 
-#: ..\plugin.py:5796 ..\plugin_original.py:5794
+#: ..\plugin.py:5803
 msgid "Weather Extra Infos"
 msgstr "天气额外信息"
 
-#: ..\plugin.py:5798 ..\plugin_original.py:5796
+#: ..\plugin.py:5805
 msgid "- Extra Zoom"
 msgstr "- 额外缩放"
 
-#: ..\plugin.py:5799 ..\plugin_original.py:5797
+#: ..\plugin.py:5806
 msgid "- Show chill temperature from difference"
 msgstr "- 显示温差"
 
-#: ..\plugin.py:5800 ..\plugin_original.py:5798
+#: ..\plugin.py:5807
 msgid "- Extra Color City"
 msgstr "- 城市的附加颜色"
 
-#: ..\plugin.py:5801 ..\plugin_original.py:5799
+#: ..\plugin.py:5808
 msgid "- Extra Color Chill"
 msgstr "- 额外颜色冷色"
 
-#: ..\plugin.py:5802 ..\plugin_original.py:5800
+#: ..\plugin.py:5809
 msgid "Netatmo CO2 Min Range"
 msgstr "Netatmo CO2最小范围"
 
-#: ..\plugin.py:5803 ..\plugin_original.py:5801
+#: ..\plugin.py:5810
 msgid "Netatmo CO2 Max Range"
 msgstr "Netatmo CO2最大范围"
 
-#: ..\plugin.py:5804 ..\plugin_original.py:5802
+#: ..\plugin.py:5811
 msgid "Meteo URL"
 msgstr "气象网址"
 
-#: ..\plugin.py:5805 ..\plugin_original.py:5803
+#: ..\plugin.py:5812
 msgid "Moon-Icon-Path [ok]>"
 msgstr "月亮图标路径 [ok]>"
 
-#: ..\plugin.py:5806 ..\plugin_original.py:5804
+#: ..\plugin.py:5813
 msgid "Recording Picture [ok]>"
 msgstr "录制图片 [ok]>"
 
-#: ..\plugin.py:5807 ..\plugin_original.py:5805
+#: ..\plugin.py:5814
 msgid "Double-button switches"
 msgstr "双按钮开关"
 
-#: ..\plugin.py:5808 ..\plugin_original.py:5806
+#: ..\plugin.py:5815
 msgid "Key for Screen Change"
 msgstr "屏幕切换键"
 
-#: ..\plugin.py:5809 ..\plugin_original.py:5807
+#: ..\plugin.py:5816
 msgid "Key for Screen On/Off"
 msgstr "屏幕开/关键"
 
-#: ..\plugin.py:5810 ..\plugin_original.py:5808
+#: ..\plugin.py:5817
 msgid "FritzCall Picture Path [ok]>"
 msgstr "FritzCall图片路径 [ok]>"
 
-#: ..\plugin.py:5811 ..\plugin_original.py:5809
+#: ..\plugin.py:5818
 msgid "FritzCall Number of Lines per Entry"
 msgstr "FritzCall每个条目的行数"
 
-#: ..\plugin.py:5812 ..\plugin_original.py:5810
+#: ..\plugin.py:5819
 msgid "FritzCall Number of List Entries"
 msgstr "FritzCall列表条目数"
 
-#: ..\plugin.py:5813 ..\plugin_original.py:5811
+#: ..\plugin.py:5820
 msgid "FritzCall Number of Pictures"
 msgstr "FritzCall图片数"
 
-#: ..\plugin.py:5814 ..\plugin_original.py:5812
+#: ..\plugin.py:5821
 msgid "FritzCall Picture Orientation"
 msgstr "FritzCall图像定向"
 
-#: ..\plugin.py:5815 ..\plugin_original.py:5813
+#: ..\plugin.py:5822
 msgid "FritzCall Picture Transparency"
 msgstr "FritzCall图片透明度"
 
-#: ..\plugin.py:5816 ..\plugin_original.py:5814
+#: ..\plugin.py:5823
 msgid "FritzCall Pictures Search"
 msgstr "FritzCall图片搜索"
 
-#: ..\plugin.py:5817 ..\plugin_original.py:5815
+#: ..\plugin.py:5824
 msgid "FritzCall remove Calls after hours"
 msgstr "FritzCall在(小时)后取消呼叫"
 
-#: ..\plugin.py:5818 ..\plugin_original.py:5816
+#: ..\plugin.py:5825
 msgid "FritzCall Popup-Time"
 msgstr "FritzCall弹出时间"
 
-#: ..\plugin.py:5819 ..\plugin_original.py:5817
+#: ..\plugin.py:5826
 msgid "FritzCall Popup LCD"
 msgstr "FritzCall弹出式液晶屏"
 
-#: ..\plugin.py:5820 ..\plugin_original.py:5818
+#: ..\plugin.py:5827
 msgid "FritzCall Popup Color"
 msgstr "FritzCall弹出窗口的颜色"
 
-#: ..\plugin.py:5821 ..\plugin_original.py:5819
+#: ..\plugin.py:5828
 msgid "FritzCall Frame Picture [ok]>"
 msgstr "FritzCall相框图片 [ok]>"
 
-#: ..\plugin.py:5822 ..\plugin_original.py:5820
+#: ..\plugin.py:5829
 msgid "Calendar ics-Path [ok]>"
 msgstr "日历象形图路径[ok]>"
 
-#: ..\plugin.py:5824 ..\plugin.py:5826 ..\plugin.py:5828
-#: ..\plugin_original.py:5822 ..\plugin_original.py:5824
-#: ..\plugin_original.py:5826
+#: ..\plugin.py:5831 ..\plugin.py:5833 ..\plugin.py:5835
 msgid "Calendar ics-URL"
 msgstr "日历象形图互联网地址"
 
-#: ..\plugin.py:5830 ..\plugin_original.py:5828
+#: ..\plugin.py:5837
 msgid "Calendar planerFS"
 msgstr "日历调度程序FS"
 
-#: ..\plugin.py:5832 ..\plugin_original.py:5830
+#: ..\plugin.py:5839
 msgid "Calendar Saturday Color"
 msgstr "日历中的星期六颜色"
 
-#: ..\plugin.py:5833 ..\plugin_original.py:5831
+#: ..\plugin.py:5840
 msgid "Calendar Sunday Color"
 msgstr "日历中的星期日颜色"
 
-#: ..\plugin.py:5834 ..\plugin_original.py:5832
+#: ..\plugin.py:5841
 msgid "Calendar Line Thickness"
 msgstr "日历线条粗细"
 
-#: ..\plugin.py:5835 ..\plugin_original.py:5833
+#: ..\plugin.py:5842
 msgid "Calendar Day Event Preview"
 msgstr "日历日活动预览"
 
-#: ..\plugin.py:5836 ..\plugin_original.py:5834
+#: ..\plugin.py:5843
 msgid "Calendar Timezone Correction"
 msgstr "日历时区修正"
 
-#: ..\plugin.py:5837 ..\plugin_original.py:5835
+#: ..\plugin.py:5844
 msgid "Calendar Transparency"
 msgstr "日历透明度"
 
-#: ..\plugin.py:5838 ..\plugin_original.py:5836
+#: ..\plugin.py:5845
 msgid "Calendar Poll Interval"
 msgstr "日历轮询间隔"
 
-#: ..\plugin.py:5839 ..\plugin_original.py:5837
+#: ..\plugin.py:5846
 msgid "Tuner Color"
 msgstr "调谐器颜色"
 
-#: ..\plugin.py:5840 ..\plugin_original.py:5838
+#: ..\plugin.py:5847
 msgid "Tuner Color Active"
 msgstr "调谐器颜色有效"
 
-#: ..\plugin.py:5841 ..\plugin_original.py:5839
+#: ..\plugin.py:5848
 msgid "Tuner Color On"
 msgstr "调谐器颜色开启"
 
-#: ..\plugin.py:5842 ..\plugin_original.py:5840
+#: ..\plugin.py:5849
 msgid "Service search first"
 msgstr "服务搜索优先"
 
-#: ..\plugin.py:5843 ..\plugin_original.py:5841
+#: ..\plugin.py:5850
 msgid "DVB-T Signal-Quality Correction"
 msgstr "DVB-T信号质量校正"
 
-#: ..\plugin.py:5844 ..\plugin_original.py:5842
+#: ..\plugin.py:5851
 msgid "Font global [ok]>"
 msgstr "字体全局 [ok]>"
 
-#: ..\plugin.py:5845 ..\plugin_original.py:5843
+#: ..\plugin.py:5852
 msgid "Font 1 [ok]>"
 msgstr "字体1 [ok]>"
 
-#: ..\plugin.py:5846 ..\plugin_original.py:5844
+#: ..\plugin.py:5853
 msgid "Font 2 [ok]>"
 msgstr "字体 2 [ok]>"
 
-#: ..\plugin.py:5847 ..\plugin_original.py:5845
+#: ..\plugin.py:5854
 msgid "Font 3 [ok]>"
 msgstr "字体 3 [ok]>"
 
-#: ..\plugin.py:5848 ..\plugin_original.py:5846
+#: ..\plugin.py:5855
 msgid "Font 4 [ok]>"
 msgstr "字体 4 [ok]>"
 
-#: ..\plugin.py:5849 ..\plugin_original.py:5847
+#: ..\plugin.py:5856
 msgid "Font 5 [ok]>"
 msgstr "字体 5 [ok]>"
 
-#: ..\plugin.py:5850 ..\plugin_original.py:5848
+#: ..\plugin.py:5857
 msgid "Mail 1 Connect"
 msgstr "邮件1连接"
 
-#: ..\plugin.py:5851 ..\plugin_original.py:5849
+#: ..\plugin.py:5858
 msgid "Mail 1 Server"
 msgstr "邮件1服务器"
 
-#: ..\plugin.py:5852 ..\plugin_original.py:5850
+#: ..\plugin.py:5859
 msgid "Mail 1 [Displayname:]Username"
 msgstr "邮件1 [显示名称:]用户名"
 
-#: ..\plugin.py:5853 ..\plugin_original.py:5851
+#: ..\plugin.py:5860
 msgid "Mail 1 Password"
 msgstr "邮件1密码"
 
-#: ..\plugin.py:5854 ..\plugin_original.py:5852
+#: ..\plugin.py:5861
 msgid "Mail 2 Connect"
 msgstr "邮件2连接"
 
-#: ..\plugin.py:5855 ..\plugin_original.py:5853
+#: ..\plugin.py:5862
 msgid "Mail 2 Server"
 msgstr "邮件2服务器"
 
-#: ..\plugin.py:5856 ..\plugin_original.py:5854
+#: ..\plugin.py:5863
 msgid "Mail 2 [Displayname:]Username"
 msgstr "邮件2 [显示名称:]用户名"
 
-#: ..\plugin.py:5857 ..\plugin_original.py:5855
+#: ..\plugin.py:5864
 msgid "Mail 2 Password"
 msgstr "邮件2密码"
 
-#: ..\plugin.py:5858 ..\plugin_original.py:5856
+#: ..\plugin.py:5865
 msgid "Mail 3 Connect"
 msgstr "邮件3连接"
 
-#: ..\plugin.py:5859 ..\plugin_original.py:5857
+#: ..\plugin.py:5866
 msgid "Mail 3 Server"
 msgstr "邮件3服务器"
 
-#: ..\plugin.py:5860 ..\plugin_original.py:5858
+#: ..\plugin.py:5867
 msgid "Mail 3 [Displayname:]Username"
 msgstr "邮件3 [显示名称:]用户名"
 
-#: ..\plugin.py:5861 ..\plugin_original.py:5859
+#: ..\plugin.py:5868
 msgid "Mail 3 Password"
 msgstr "邮件3密码"
 
-#: ..\plugin.py:5862 ..\plugin_original.py:5860
+#: ..\plugin.py:5869
 msgid "Mail 4 Connect"
 msgstr "邮件4连接"
 
-#: ..\plugin.py:5863 ..\plugin_original.py:5861
+#: ..\plugin.py:5870
 msgid "Mail 4 Server"
 msgstr "邮件4服务器"
 
-#: ..\plugin.py:5864 ..\plugin_original.py:5862
+#: ..\plugin.py:5871
 msgid "Mail 4 [Displayname:]Username"
 msgstr "邮件4 [显示名称:]用户名"
 
-#: ..\plugin.py:5865 ..\plugin_original.py:5863
+#: ..\plugin.py:5872
 msgid "Mail 4 Password"
 msgstr "邮件4密码"
 
-#: ..\plugin.py:5866 ..\plugin_original.py:5864
+#: ..\plugin.py:5873
 msgid "Mail 5 Connect"
 msgstr "邮件5连接"
 
-#: ..\plugin.py:5867 ..\plugin_original.py:5865
+#: ..\plugin.py:5874
 msgid "Mail 5 Server"
 msgstr "邮件5服务器"
 
-#: ..\plugin.py:5868 ..\plugin_original.py:5866
+#: ..\plugin.py:5875
 msgid "Mail 5 [Displayname:]Username"
 msgstr "邮件5 [显示名称:]用户名"
 
-#: ..\plugin.py:5869 ..\plugin_original.py:5867
+#: ..\plugin.py:5876
 msgid "Mail 5 Password"
 msgstr "邮件5密码"
 
-#: ..\plugin.py:5870 ..\plugin_original.py:5868
+#: ..\plugin.py:5877
 msgid "Mail Poll Interval"
 msgstr "邮件轮询间隔"
 
-#: ..\plugin.py:5871 ..\plugin_original.py:5869
+#: ..\plugin.py:5878
 msgid "Mail IMAP limit to last days"
 msgstr "邮寄IMAP限制到最后几天"
 
-#: ..\plugin.py:5872 ..\plugin_original.py:5870
+#: ..\plugin.py:5879
 msgid "Mail Show Empty Mailboxes"
 msgstr "邮件显示空邮箱"
 
-#: ..\plugin.py:5873 ..\plugin_original.py:5871
+#: ..\plugin.py:5880
 msgid "Mail Show Date"
 msgstr "邮件显示日期"
 
-#: ..\plugin.py:5874 ..\plugin_original.py:5872
+#: ..\plugin.py:5881
 msgid "Mail Hide Mailadress"
 msgstr "邮件隐藏邮件地址"
 
-#: ..\plugin.py:5875 ..\plugin_original.py:5873
+#: ..\plugin.py:5882
 msgid "Remote Box 1 [Displayname:]IP/Name"
 msgstr "远程文件夹1 [显示名称:] IP /名称"
 
-#: ..\plugin.py:5876 ..\plugin_original.py:5874
+#: ..\plugin.py:5883
 msgid "Remote Box 2 [Displayname:]IP/Name"
 msgstr "Remote Box 2 [显示名称:] IP /名称"
 
-#: ..\plugin.py:5877 ..\plugin_original.py:5875
+#: ..\plugin.py:5884
 msgid "Remote Box 3 [Displayname:]IP/Name"
 msgstr "遥控器3 [显示名称:] IP /名称"
 
-#: ..\plugin.py:5878 ..\plugin_original.py:5876
+#: ..\plugin.py:5885
 msgid "Remote Box 4 [Displayname:]IP/Name"
 msgstr "Remote Box 4 [显示名称:] IP /名称"
 
-#: ..\plugin.py:5879 ..\plugin_original.py:5877
+#: ..\plugin.py:5886
 msgid "Remote Box 5 [Displayname:]IP/Name"
 msgstr "Remote Box 5 [显示名称:] IP /名称"
 
-#: ..\plugin.py:5880 ..\plugin_original.py:5878
+#: ..\plugin.py:5887
 msgid "Remote Box Poll every Minutes"
 msgstr "每分钟进行一次远程箱投票"
 
-#: ..\plugin.py:5881 ..\plugin_original.py:5879
+#: ..\plugin.py:5888
 msgid "Remote Box Timer [Displayname:]IP/Name"
 msgstr "远程盒定时器[显示名称:] IP /名称"
 
-#: ..\plugin.py:5882 ..\plugin_original.py:5880
+#: ..\plugin.py:5889
 msgid "Remote Box Timer Poll every Minutes"
 msgstr "每隔一分钟的远程Box Timer轮询"
 
-#: ..\plugin.py:5883 ..\plugin_original.py:5881
+#: ..\plugin.py:5890
 msgid "WWW Converter Poll Interval"
 msgstr "WWW转换器轮询间隔"
 
-#: ..\plugin.py:5884 ..\plugin_original.py:5882
+#: ..\plugin.py:5891
 msgid "WWW Converter Usage"
 msgstr "WWW转换器使用"
 
-#: ..\plugin.py:5885 ..\plugin_original.py:5883
+#: ..\plugin.py:5892
 msgid "WWW ApiKey from cloudconvert.org"
 msgstr "来自cloudconvert.org的WWW ApiKey"
 
-#: ..\plugin.py:5886 ..\plugin_original.py:5884
+#: ..\plugin.py:5893
 msgid "WWW ApiKey from convertapi.com"
 msgstr "来自convertapi.com的WWW ApiKey"
 
-#: ..\plugin.py:5887 ..\plugin_original.py:5885
+#: ..\plugin.py:5894
 msgid "WebIF Refresh [s]"
 msgstr "WebIF刷新[s]"
 
-#: ..\plugin.py:5888 ..\plugin_original.py:5886
+#: ..\plugin.py:5895
 msgid "WebIF Refresh Type"
 msgstr "WebIF刷新类型"
 
-#: ..\plugin.py:5889 ..\plugin_original.py:5887
+#: ..\plugin.py:5896
 msgid "WebIF Init Delay"
 msgstr "WebIF初始化延迟"
 
-#: ..\plugin.py:5891 ..\plugin_original.py:5889
+#: ..\plugin.py:5898
 msgid "WebIF IP Deny"
 msgstr "WebIF IP拒绝"
 
-#: ..\plugin.py:5892 ..\plugin_original.py:5890
+#: ..\plugin.py:5899
 msgid "WebIF Design"
 msgstr "WebIF设计"
 
-#: ..\plugin.py:5893 ..\plugin_original.py:5891
+#: ..\plugin.py:5900
 msgid "Save as Picture for WebIF"
 msgstr "另存为WebIF图片"
 
-#: ..\plugin.py:5894 ..\plugin_original.py:5892
+#: ..\plugin.py:5901
 msgid "MJPEG Stream LCD 1 enable"
 msgstr "MJPEG流LCD 1启用"
 
-#: ..\plugin.py:5895 ..\plugin_original.py:5893
+#: ..\plugin.py:5902
 msgid "MJPEG Stream LCD 1 Port"
 msgstr "MJPEG流LCD 1端口"
 
-#: ..\plugin.py:5896 ..\plugin_original.py:5894
+#: ..\plugin.py:5903
 msgid "MJPEG Stream LCD 1 Virtual Brightness"
 msgstr "MJPEG流LCD 1虚拟亮度"
 
-#: ..\plugin.py:5897 ..\plugin_original.py:5895
+#: ..\plugin.py:5904
 msgid "MJPEG Stream LCD 2 enable"
 msgstr "MJPEG流LCD 2启用"
 
-#: ..\plugin.py:5898 ..\plugin_original.py:5896
+#: ..\plugin.py:5905
 msgid "MJPEG Stream LCD 2 Port"
 msgstr "MJPEG流LCD 2端口"
 
-#: ..\plugin.py:5899 ..\plugin_original.py:5897
+#: ..\plugin.py:5906
 msgid "MJPEG Stream LCD 2 Virtual Brightness"
 msgstr "MJPEG Stream LCD 2虚拟亮度"
 
-#: ..\plugin.py:5900 ..\plugin_original.py:5898
+#: ..\plugin.py:5907
 msgid "MJPEG Stream LCD 3 enable"
 msgstr "MJPEG流LCD 3启用"
 
-#: ..\plugin.py:5901 ..\plugin_original.py:5899
+#: ..\plugin.py:5908
 msgid "MJPEG Stream LCD 3 Port"
 msgstr "MJPEG流LCD 3端口"
 
-#: ..\plugin.py:5902 ..\plugin_original.py:5900
+#: ..\plugin.py:5909
 msgid "MJPEG Stream LCD 3 Virtual Brightness"
 msgstr "MJPEG流LCD 3虚拟亮度"
 
-#: ..\plugin.py:5904 ..\plugin_original.py:5902
+#: ..\plugin.py:5911
 msgid "MJPEG Cycle"
 msgstr "MJPEG循环"
 
-#: ..\plugin.py:5905 ..\plugin_original.py:5903
+#: ..\plugin.py:5912
 msgid "MJPEG Restart on Error"
 msgstr "出错时MJPEG重新启动"
 
-#: ..\plugin.py:5906 ..\plugin_original.py:5904
+#: ..\plugin.py:5913
 msgid "MJPEG Header Mode"
 msgstr "MJPEG标题模式"
 
-#: ..\plugin.py:5907 ..\plugin_original.py:5905
+#: ..\plugin.py:5914
 msgid "Show Streams '4097; 5001...5003' in Mode"
 msgstr "Zài móshì zhōng xiǎnshì liú"
 
-#: ..\plugin.py:5908 ..\plugin_original.py:5906
+#: ..\plugin.py:5915
 msgid "Sonos IP"
 msgstr "Sonos IP地址"
 
-#: ..\plugin.py:5909 ..\plugin_original.py:5907
+#: ..\plugin.py:5916
 msgid "Sonos Ping Timeout [ms]"
 msgstr "休眠Ping超时[毫秒]"
 
-#: ..\plugin.py:5910 ..\plugin_original.py:5908
+#: ..\plugin.py:5917
 msgid "Sonos Play Check"
 msgstr "休眠播放检查"
 
-#: ..\plugin.py:5911 ..\plugin_original.py:5909
+#: ..\plugin.py:5918
 msgid "Sonos Refresh [s]"
 msgstr "休眠更新间隔[秒]"
 
-#: ..\plugin.py:5912 ..\plugin_original.py:5910
+#: ..\plugin.py:5919
 msgid "BlueSound IP"
 msgstr "BlueSound IP"
 
-#: ..\plugin.py:5913 ..\plugin_original.py:5911
+#: ..\plugin.py:5920
 msgid "BlueSound Ping Timeout [ms]"
 msgstr "BlueSound Ping 超时 [ms]"
 
-#: ..\plugin.py:5914 ..\plugin_original.py:5912
+#: ..\plugin.py:5921
 msgid "BlueSound Play Check"
 msgstr "BlueSound 玩检查"
 
-#: ..\plugin.py:5915 ..\plugin_original.py:5913
+#: ..\plugin.py:5922
 msgid "BlueSound Refresh [s]"
 msgstr "BlueSound刷新 [s]"
 
-#: ..\plugin.py:5916 ..\plugin_original.py:5914
+#: ..\plugin.py:5923
 msgid "MusicCast IP"
 msgstr "音乐广播IP"
 
-#: ..\plugin.py:5917 ..\plugin_original.py:5915
+#: ..\plugin.py:5924
 msgid "MusicCast Server IP [optional]"
 msgstr "MusicCast服务器IP [可选]"
 
-#: ..\plugin.py:5918 ..\plugin_original.py:5916
+#: ..\plugin.py:5925
 msgid "MusicCast Ping Timeout [ms]"
 msgstr "音乐播放Ping超时 [毫秒]"
 
-#: ..\plugin.py:5919 ..\plugin_original.py:5917
+#: ..\plugin.py:5926
 msgid "MusicCast Play Check"
 msgstr "MusicCast播放检查"
 
-#: ..\plugin.py:5920 ..\plugin_original.py:5918
+#: ..\plugin.py:5927
 msgid "MusicCast Refresh [s]"
 msgstr "MusicCast刷新[s]"
 
-#: ..\plugin.py:5921 ..\plugin_original.py:5919
+#: ..\plugin.py:5928
 msgid "MusicCast Cover"
 msgstr "音乐广告封面"
 
-#: ..\plugin.py:5922 ..\plugin_original.py:5920
+#: ..\plugin.py:5929
 msgid "LCD Custom Width"
 msgstr "LCD自定义宽度"
 
-#: ..\plugin.py:5923 ..\plugin_original.py:5921
+#: ..\plugin.py:5930
 msgid "LCD Custom Height"
 msgstr "LCD自定义高度"
 
-#: ..\plugin.py:5924 ..\plugin_original.py:5922
+#: ..\plugin.py:5931
 msgid "LCD Custom Width 2"
 msgstr "LCD自定义宽度2"
 
-#: ..\plugin.py:5925 ..\plugin_original.py:5923
+#: ..\plugin.py:5932
 msgid "LCD Custom Height 2"
 msgstr "LCD自定义高度2"
 
-#: ..\plugin.py:5926 ..\plugin_original.py:5924
+#: ..\plugin.py:5933
 msgid "LCD Off when shutdown"
 msgstr "关机时液晶屏关闭"
 
-#: ..\plugin.py:5927 ..\plugin_original.py:5925
+#: ..\plugin.py:5934
 msgid "Timing ! calc all Times to Time/5*2 in Fastmode"
 msgstr "时机！在快速模式下计算所有时间到时间/ 5 * 2"
 
-#: ..\plugin.py:5928 ..\plugin_original.py:5926
+#: ..\plugin.py:5935
 msgid "Display Delay [ms]"
 msgstr "显示延迟[毫秒]"
 
-#: ..\plugin.py:5929 ..\plugin_original.py:5927
+#: ..\plugin.py:5936
 msgid "Threads per LCD"
 msgstr "每个LCD的线程数"
 
-#: ..\plugin.py:5930 ..\plugin_original.py:5928
+#: ..\plugin.py:5937
 msgid "Show Crash Corner"
 msgstr "显示崩溃角"
 
-#: ..\plugin.py:5931 ..\plugin_original.py:5929
+#: ..\plugin.py:5938
 msgid "Show 'no ....' Messages"
 msgstr "显示“否 ....”消息"
 
-#: ..\plugin.py:5932 ..\plugin_original.py:5930
+#: ..\plugin.py:5939
 msgid "Storage-Devices: Force Read"
 msgstr "存储设备：强制读取"
 
-#: ..\plugin.py:5933 ..\plugin_original.py:5931
+#: ..\plugin.py:5940
 msgid "Storage-Devices: Color Back"
 msgstr "存储设备：彩色背"
 
-#: ..\plugin.py:5934 ..\plugin_original.py:5932
+#: ..\plugin.py:5941
 msgid "Storage-Devices: Color Bar"
 msgstr "存储设备：颜色栏"
 
-#: ..\plugin.py:5935 ..\plugin_original.py:5933
+#: ..\plugin.py:5942
 msgid "Storage-Devices: Color Full"
 msgstr "存储设备：全彩色"
 
-#: ..\plugin.py:5936 ..\plugin_original.py:5934
+#: ..\plugin.py:5943
 msgid "Network Check active"
 msgstr "网络检查处于活动状态"
 
-#: ..\plugin.py:5937 ..\plugin_original.py:5935
+#: ..\plugin.py:5944
 msgid "Switch FrameBuffer [if possible]"
 msgstr "切换帧缓冲区 [如果可能]"
 
-#: ..\plugin.py:5938 ..\plugin_original.py:5936
+#: ..\plugin.py:5945
 msgid "Config Backup Path [ok]>"
 msgstr "配置备份路径[ok]>"
 
-#: ..\plugin.py:5939 ..\plugin_original.py:5937
+#: ..\plugin.py:5946
 msgid "Config Restore All Settings"
 msgstr "配置还原所有设置"
 
-#: ..\plugin.py:5940 ..\plugin_original.py:5938
+#: ..\plugin.py:5947
 msgid "Debug-Logging > /tmp/L4log.txt"
 msgstr "调试日志 > /tmp/L4log.txt"
 
-#: ..\plugin.py:5944 ..\plugin.py:7317 ..\plugin_original.py:5942
-#: ..\plugin_original.py:7315
+#: ..\plugin.py:5952 ..\plugin.py:7327
 msgid "- Backlight Off [disable set Off=On]"
 msgstr "- 背光关闭[禁用设置关闭=打开]"
 
-#: ..\plugin.py:5945 ..\plugin.py:7318 ..\plugin_original.py:5943
-#: ..\plugin_original.py:7316
+#: ..\plugin.py:5953 ..\plugin.py:7328
 msgid "- Backlight On"
 msgstr "- 背光开启"
 
-#: ..\plugin.py:5946 ..\plugin.py:7319 ..\plugin_original.py:5944
-#: ..\plugin_original.py:7317
+#: ..\plugin.py:5954 ..\plugin.py:7329
 msgid "- Backlight Weekend Off [disable set Off=On]"
 msgstr "- 周末背光关闭 [禁用设置关闭=打开]"
 
-#: ..\plugin.py:5947 ..\plugin.py:7320 ..\plugin_original.py:5945
-#: ..\plugin_original.py:7318
+#: ..\plugin.py:5955 ..\plugin.py:7330
 msgid "- Backlight Weekend On"
 msgstr "- 背光周末开启"
 
-#: ..\plugin.py:5948 ..\plugin.py:6705 ..\plugin.py:7321
-#: ..\plugin_original.py:5946 ..\plugin_original.py:6703
-#: ..\plugin_original.py:7319
+#: ..\plugin.py:5956 ..\plugin.py:6714 ..\plugin.py:7331
 msgid "- LCD Auto-OFF"
 msgstr "- LCD自动关闭"
 
-#: ..\plugin.py:5949 ..\plugin.py:6707 ..\plugin.py:7335
-#: ..\plugin_original.py:5947 ..\plugin_original.py:6705
-#: ..\plugin_original.py:7333
+#: ..\plugin.py:5957 ..\plugin.py:6716 ..\plugin.py:7345
 msgid "Background"
 msgstr "背景"
 
-#: ..\plugin.py:5953 ..\plugin.py:6711 ..\plugin.py:7339
-#: ..\plugin_original.py:5951 ..\plugin_original.py:6709
-#: ..\plugin_original.py:7337
+#: ..\plugin.py:5961 ..\plugin.py:6720 ..\plugin.py:7349
 msgid "- Picture [ok]>"
 msgstr "- 图片 [ok]>"
 
-#: ..\plugin.py:5957 ..\plugin.py:5970 ..\plugin_original.py:5955
-#: ..\plugin_original.py:5968
+#: ..\plugin.py:5965 ..\plugin.py:5978
 msgid "- Picon Size"
 msgstr "- Picon大小"
 
-#: ..\plugin.py:5960 ..\plugin.py:5973 ..\plugin.py:5990 ..\plugin.py:6005
-#: ..\plugin.py:6017 ..\plugin.py:6040 ..\plugin.py:6053 ..\plugin.py:6066
-#: ..\plugin.py:6079 ..\plugin.py:6109 ..\plugin.py:6123 ..\plugin.py:6135
-#: ..\plugin.py:6146 ..\plugin.py:6158 ..\plugin.py:6170 ..\plugin.py:6184
-#: ..\plugin.py:6195 ..\plugin.py:6204 ..\plugin.py:6212 ..\plugin.py:6222
-#: ..\plugin.py:6232 ..\plugin.py:6250 ..\plugin.py:6262 ..\plugin.py:6280
-#: ..\plugin.py:6288 ..\plugin.py:6299 ..\plugin.py:6310 ..\plugin.py:6319
-#: ..\plugin.py:6342 ..\plugin.py:6366 ..\plugin.py:6376 ..\plugin.py:6388
-#: ..\plugin.py:6398 ..\plugin.py:6411 ..\plugin.py:6420 ..\plugin.py:6546
-#: ..\plugin.py:6580 ..\plugin.py:6603 ..\plugin.py:6618 ..\plugin.py:6631
-#: ..\plugin.py:6642 ..\plugin.py:6654 ..\plugin.py:6685 ..\plugin.py:6720
-#: ..\plugin.py:6732 ..\plugin.py:6745 ..\plugin.py:6758 ..\plugin.py:6771
-#: ..\plugin.py:6784 ..\plugin.py:6811 ..\plugin.py:6820 ..\plugin.py:6832
-#: ..\plugin.py:6847 ..\plugin.py:6859 ..\plugin.py:6872 ..\plugin.py:6883
-#: ..\plugin.py:6897 ..\plugin.py:6908 ..\plugin.py:6918 ..\plugin.py:6928
-#: ..\plugin.py:6946 ..\plugin.py:6957 ..\plugin.py:6975 ..\plugin.py:6983
-#: ..\plugin.py:6994 ..\plugin.py:7005 ..\plugin.py:7014 ..\plugin.py:7037
-#: ..\plugin.py:7061 ..\plugin.py:7071 ..\plugin.py:7083 ..\plugin.py:7093
-#: ..\plugin.py:7164 ..\plugin.py:7173 ..\plugin.py:7207 ..\plugin.py:7230
-#: ..\plugin.py:7245 ..\plugin.py:7258 ..\plugin.py:7269 ..\plugin.py:7281
-#: ..\plugin.py:7312 ..\plugin.py:7361 ..\plugin.py:7376 ..\plugin.py:7390
-#: ..\plugin.py:7402 ..\plugin.py:7415 ..\plugin.py:7426 ..\plugin.py:7436
-#: ..\plugin.py:7454 ..\plugin.py:7465 ..\plugin.py:7483 ..\plugin.py:7491
-#: ..\plugin.py:7502 ..\plugin.py:7513 ..\plugin.py:7522 ..\plugin.py:7545
-#: ..\plugin.py:7569 ..\plugin.py:7579 ..\plugin.py:7591 ..\plugin.py:7601
-#: ..\plugin.py:7613 ..\plugin.py:7739 ..\plugin.py:7773 ..\plugin.py:7796
-#: ..\plugin.py:7811 ..\plugin.py:7824 ..\plugin.py:7835 ..\plugin.py:7847
-#: ..\plugin.py:7878 ..\plugin_original.py:5958 ..\plugin_original.py:5971
-#: ..\plugin_original.py:5988 ..\plugin_original.py:6003
-#: ..\plugin_original.py:6015 ..\plugin_original.py:6038
-#: ..\plugin_original.py:6051 ..\plugin_original.py:6064
-#: ..\plugin_original.py:6077 ..\plugin_original.py:6107
-#: ..\plugin_original.py:6121 ..\plugin_original.py:6133
-#: ..\plugin_original.py:6144 ..\plugin_original.py:6156
-#: ..\plugin_original.py:6168 ..\plugin_original.py:6182
-#: ..\plugin_original.py:6193 ..\plugin_original.py:6202
-#: ..\plugin_original.py:6210 ..\plugin_original.py:6220
-#: ..\plugin_original.py:6230 ..\plugin_original.py:6248
-#: ..\plugin_original.py:6260 ..\plugin_original.py:6278
-#: ..\plugin_original.py:6286 ..\plugin_original.py:6297
-#: ..\plugin_original.py:6308 ..\plugin_original.py:6317
-#: ..\plugin_original.py:6340 ..\plugin_original.py:6364
-#: ..\plugin_original.py:6374 ..\plugin_original.py:6386
-#: ..\plugin_original.py:6396 ..\plugin_original.py:6409
-#: ..\plugin_original.py:6418 ..\plugin_original.py:6544
-#: ..\plugin_original.py:6578 ..\plugin_original.py:6601
-#: ..\plugin_original.py:6616 ..\plugin_original.py:6629
-#: ..\plugin_original.py:6640 ..\plugin_original.py:6652
-#: ..\plugin_original.py:6683 ..\plugin_original.py:6718
-#: ..\plugin_original.py:6730 ..\plugin_original.py:6743
-#: ..\plugin_original.py:6756 ..\plugin_original.py:6769
-#: ..\plugin_original.py:6782 ..\plugin_original.py:6809
-#: ..\plugin_original.py:6818 ..\plugin_original.py:6830
-#: ..\plugin_original.py:6845 ..\plugin_original.py:6857
-#: ..\plugin_original.py:6870 ..\plugin_original.py:6881
-#: ..\plugin_original.py:6895 ..\plugin_original.py:6906
-#: ..\plugin_original.py:6916 ..\plugin_original.py:6926
-#: ..\plugin_original.py:6944 ..\plugin_original.py:6955
-#: ..\plugin_original.py:6973 ..\plugin_original.py:6981
-#: ..\plugin_original.py:6992 ..\plugin_original.py:7003
-#: ..\plugin_original.py:7012 ..\plugin_original.py:7035
-#: ..\plugin_original.py:7059 ..\plugin_original.py:7069
-#: ..\plugin_original.py:7081 ..\plugin_original.py:7091
-#: ..\plugin_original.py:7162 ..\plugin_original.py:7171
-#: ..\plugin_original.py:7205 ..\plugin_original.py:7228
-#: ..\plugin_original.py:7243 ..\plugin_original.py:7256
-#: ..\plugin_original.py:7267 ..\plugin_original.py:7279
-#: ..\plugin_original.py:7310 ..\plugin_original.py:7359
-#: ..\plugin_original.py:7374 ..\plugin_original.py:7388
-#: ..\plugin_original.py:7400 ..\plugin_original.py:7413
-#: ..\plugin_original.py:7424 ..\plugin_original.py:7434
-#: ..\plugin_original.py:7452 ..\plugin_original.py:7463
-#: ..\plugin_original.py:7481 ..\plugin_original.py:7489
-#: ..\plugin_original.py:7500 ..\plugin_original.py:7511
-#: ..\plugin_original.py:7520 ..\plugin_original.py:7543
-#: ..\plugin_original.py:7567 ..\plugin_original.py:7577
-#: ..\plugin_original.py:7589 ..\plugin_original.py:7599
-#: ..\plugin_original.py:7611 ..\plugin_original.py:7737
-#: ..\plugin_original.py:7771 ..\plugin_original.py:7794
-#: ..\plugin_original.py:7809 ..\plugin_original.py:7822
-#: ..\plugin_original.py:7833 ..\plugin_original.py:7845
-#: ..\plugin_original.py:7876
+#: ..\plugin.py:5968 ..\plugin.py:5981 ..\plugin.py:5998 ..\plugin.py:6013
+#: ..\plugin.py:6025 ..\plugin.py:6048 ..\plugin.py:6061 ..\plugin.py:6074
+#: ..\plugin.py:6087 ..\plugin.py:6117 ..\plugin.py:6131 ..\plugin.py:6143
+#: ..\plugin.py:6154 ..\plugin.py:6166 ..\plugin.py:6178 ..\plugin.py:6192
+#: ..\plugin.py:6203 ..\plugin.py:6212 ..\plugin.py:6220 ..\plugin.py:6230
+#: ..\plugin.py:6240 ..\plugin.py:6258 ..\plugin.py:6270 ..\plugin.py:6288
+#: ..\plugin.py:6296 ..\plugin.py:6307 ..\plugin.py:6318 ..\plugin.py:6327
+#: ..\plugin.py:6350 ..\plugin.py:6374 ..\plugin.py:6384 ..\plugin.py:6396
+#: ..\plugin.py:6406 ..\plugin.py:6419 ..\plugin.py:6428 ..\plugin.py:6554
+#: ..\plugin.py:6588 ..\plugin.py:6611 ..\plugin.py:6626 ..\plugin.py:6639
+#: ..\plugin.py:6650 ..\plugin.py:6662 ..\plugin.py:6693 ..\plugin.py:6729
+#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
+#: ..\plugin.py:6793 ..\plugin.py:6820 ..\plugin.py:6829 ..\plugin.py:6841
+#: ..\plugin.py:6856 ..\plugin.py:6868 ..\plugin.py:6881 ..\plugin.py:6892
+#: ..\plugin.py:6906 ..\plugin.py:6917 ..\plugin.py:6927 ..\plugin.py:6937
+#: ..\plugin.py:6955 ..\plugin.py:6966 ..\plugin.py:6984 ..\plugin.py:6992
+#: ..\plugin.py:7003 ..\plugin.py:7014 ..\plugin.py:7023 ..\plugin.py:7046
+#: ..\plugin.py:7070 ..\plugin.py:7080 ..\plugin.py:7092 ..\plugin.py:7102
+#: ..\plugin.py:7173 ..\plugin.py:7182 ..\plugin.py:7216 ..\plugin.py:7239
+#: ..\plugin.py:7254 ..\plugin.py:7267 ..\plugin.py:7278 ..\plugin.py:7290
+#: ..\plugin.py:7321 ..\plugin.py:7371 ..\plugin.py:7386 ..\plugin.py:7400
+#: ..\plugin.py:7412 ..\plugin.py:7425 ..\plugin.py:7436 ..\plugin.py:7446
+#: ..\plugin.py:7464 ..\plugin.py:7475 ..\plugin.py:7493 ..\plugin.py:7501
+#: ..\plugin.py:7512 ..\plugin.py:7523 ..\plugin.py:7532 ..\plugin.py:7555
+#: ..\plugin.py:7579 ..\plugin.py:7589 ..\plugin.py:7601 ..\plugin.py:7611
+#: ..\plugin.py:7623 ..\plugin.py:7749 ..\plugin.py:7783 ..\plugin.py:7806
+#: ..\plugin.py:7821 ..\plugin.py:7834 ..\plugin.py:7845 ..\plugin.py:7857
+#: ..\plugin.py:7888
 msgid "- Split Screen"
 msgstr "- 分屏"
 
-#: ..\plugin.py:5961 ..\plugin.py:5974 ..\plugin_original.py:5959
-#: ..\plugin_original.py:5972
+#: ..\plugin.py:5969 ..\plugin.py:5982
 msgid "- Full Screen"
 msgstr "- 全屏显示"
 
-#: ..\plugin.py:5962 ..\plugin.py:5975 ..\plugin_original.py:5960
-#: ..\plugin_original.py:5973
+#: ..\plugin.py:5970 ..\plugin.py:5983
 msgid "- Text Size"
 msgstr "- 文本大小"
 
-#: ..\plugin.py:5963 ..\plugin.py:6489 ..\plugin.py:6499 ..\plugin.py:6509
-#: ..\plugin.py:6519 ..\plugin.py:6529 ..\plugin.py:6539 ..\plugin.py:7130
-#: ..\plugin.py:7140 ..\plugin.py:7153 ..\plugin.py:7682 ..\plugin.py:7692
-#: ..\plugin.py:7702 ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732
-#: ..\plugin_original.py:5961 ..\plugin_original.py:6487
-#: ..\plugin_original.py:6497 ..\plugin_original.py:6507
-#: ..\plugin_original.py:6517 ..\plugin_original.py:6527
-#: ..\plugin_original.py:6537 ..\plugin_original.py:7128
-#: ..\plugin_original.py:7138 ..\plugin_original.py:7151
-#: ..\plugin_original.py:7680 ..\plugin_original.py:7690
-#: ..\plugin_original.py:7700 ..\plugin_original.py:7710
-#: ..\plugin_original.py:7720 ..\plugin_original.py:7730
+#: ..\plugin.py:5971 ..\plugin.py:6497 ..\plugin.py:6507 ..\plugin.py:6517
+#: ..\plugin.py:6527 ..\plugin.py:6537 ..\plugin.py:6547 ..\plugin.py:7139
+#: ..\plugin.py:7149 ..\plugin.py:7162 ..\plugin.py:7692 ..\plugin.py:7702
+#: ..\plugin.py:7712 ..\plugin.py:7722 ..\plugin.py:7732 ..\plugin.py:7742
 msgid "- Transparency"
 msgstr "- 透明度"
 
-#: ..\plugin.py:5964 ..\plugin.py:5976 ..\plugin.py:6149 ..\plugin.py:6161
-#: ..\plugin_original.py:5962 ..\plugin_original.py:5974
-#: ..\plugin_original.py:6147 ..\plugin_original.py:6159
+#: ..\plugin.py:5972 ..\plugin.py:5984 ..\plugin.py:6157 ..\plugin.py:6169
 msgid "- Picon Path [ok]>"
 msgstr "- Picon路径 [ok]>"
 
-#: ..\plugin.py:5965 ..\plugin.py:5977 ..\plugin_original.py:5963
-#: ..\plugin_original.py:5975
+#: ..\plugin.py:5973 ..\plugin.py:5985
 msgid "- Picon Path 2 [ok]>"
 msgstr "- Picon路径2[ok]>"
 
-#: ..\plugin.py:5966 ..\plugin.py:5978 ..\plugin_original.py:5964
-#: ..\plugin_original.py:5976
+#: ..\plugin.py:5974 ..\plugin.py:5986
 msgid "- Picon Cache Path [ok]>"
 msgstr "- Picon缓存路径 [ok]>"
 
-#: ..\plugin.py:5967 ..\plugin_original.py:5965
+#: ..\plugin.py:5975
 msgid "Picon 2"
 msgstr "Picon 2"
 
-#: ..\plugin.py:5979 ..\plugin.py:6821 ..\plugin.py:7350
-#: ..\plugin_original.py:5977 ..\plugin_original.py:6819
-#: ..\plugin_original.py:7348
+#: ..\plugin.py:5987 ..\plugin.py:6830 ..\plugin.py:7360
 msgid "Clock"
 msgstr "时钟"
 
-#: ..\plugin.py:5982 ..\plugin.py:5997 ..\plugin.py:6680 ..\plugin.py:7307
-#: ..\plugin.py:7873 ..\plugin_original.py:5980 ..\plugin_original.py:5995
-#: ..\plugin_original.py:6678 ..\plugin_original.py:7305
-#: ..\plugin_original.py:7871
+#: ..\plugin.py:5990 ..\plugin.py:6005 ..\plugin.py:6688 ..\plugin.py:6833
+#: ..\plugin.py:6848 ..\plugin.py:7316 ..\plugin.py:7363 ..\plugin.py:7378
+#: ..\plugin.py:7883
 msgid "-  Type"
 msgstr "-  类型"
 
-#: ..\plugin.py:5984 ..\plugin.py:5999 ..\plugin.py:6826 ..\plugin.py:6841
-#: ..\plugin.py:7355 ..\plugin.py:7370 ..\plugin_original.py:5982
-#: ..\plugin_original.py:5997 ..\plugin_original.py:6824
-#: ..\plugin_original.py:6839 ..\plugin_original.py:7353
-#: ..\plugin_original.py:7368
+#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6835 ..\plugin.py:6850
+#: ..\plugin.py:7365 ..\plugin.py:7380
 msgid "- Analog Clock"
 msgstr "- 模拟时钟"
 
-#: ..\plugin.py:5986 ..\plugin.py:6001 ..\plugin.py:6828 ..\plugin.py:6843
-#: ..\plugin.py:7357 ..\plugin.py:7372 ..\plugin_original.py:5984
-#: ..\plugin_original.py:5999 ..\plugin_original.py:6826
-#: ..\plugin_original.py:6841 ..\plugin_original.py:7355
-#: ..\plugin_original.py:7370
+#: ..\plugin.py:5994 ..\plugin.py:6009 ..\plugin.py:6837 ..\plugin.py:6852
+#: ..\plugin.py:7367 ..\plugin.py:7382
 msgid "- Spacing"
 msgstr "- 间距"
 
-#: ..\plugin.py:5987 ..\plugin.py:6002 ..\plugin.py:6089 ..\plugin.py:6106
-#: ..\plugin.py:6120 ..\plugin.py:6131 ..\plugin.py:6191 ..\plugin.py:6363
-#: ..\plugin.py:6373 ..\plugin.py:6382 ..\plugin.py:6470 ..\plugin.py:6484
-#: ..\plugin.py:6494 ..\plugin.py:6504 ..\plugin.py:6514 ..\plugin.py:6524
-#: ..\plugin.py:6534 ..\plugin.py:6615 ..\plugin.py:6628 ..\plugin.py:6681
-#: ..\plugin.py:6793 ..\plugin.py:6807 ..\plugin.py:6829 ..\plugin.py:6844
-#: ..\plugin.py:6856 ..\plugin.py:6869 ..\plugin.py:7058 ..\plugin.py:7068
-#: ..\plugin.py:7077 ..\plugin.py:7125 ..\plugin.py:7135 ..\plugin.py:7144
-#: ..\plugin.py:7242 ..\plugin.py:7255 ..\plugin.py:7308 ..\plugin.py:7358
-#: ..\plugin.py:7373 ..\plugin.py:7399 ..\plugin.py:7412 ..\plugin.py:7566
-#: ..\plugin.py:7576 ..\plugin.py:7585 ..\plugin.py:7663 ..\plugin.py:7677
-#: ..\plugin.py:7687 ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717
-#: ..\plugin.py:7727 ..\plugin.py:7808 ..\plugin.py:7821 ..\plugin.py:7874
-#: ..\plugin_original.py:5985 ..\plugin_original.py:6000
-#: ..\plugin_original.py:6087 ..\plugin_original.py:6104
-#: ..\plugin_original.py:6118 ..\plugin_original.py:6129
-#: ..\plugin_original.py:6189 ..\plugin_original.py:6361
-#: ..\plugin_original.py:6371 ..\plugin_original.py:6380
-#: ..\plugin_original.py:6468 ..\plugin_original.py:6482
-#: ..\plugin_original.py:6492 ..\plugin_original.py:6502
-#: ..\plugin_original.py:6512 ..\plugin_original.py:6522
-#: ..\plugin_original.py:6532 ..\plugin_original.py:6613
-#: ..\plugin_original.py:6626 ..\plugin_original.py:6679
-#: ..\plugin_original.py:6791 ..\plugin_original.py:6805
-#: ..\plugin_original.py:6827 ..\plugin_original.py:6842
-#: ..\plugin_original.py:6854 ..\plugin_original.py:6867
-#: ..\plugin_original.py:7056 ..\plugin_original.py:7066
-#: ..\plugin_original.py:7075 ..\plugin_original.py:7123
-#: ..\plugin_original.py:7133 ..\plugin_original.py:7142
-#: ..\plugin_original.py:7240 ..\plugin_original.py:7253
-#: ..\plugin_original.py:7306 ..\plugin_original.py:7356
-#: ..\plugin_original.py:7371 ..\plugin_original.py:7397
-#: ..\plugin_original.py:7410 ..\plugin_original.py:7564
-#: ..\plugin_original.py:7574 ..\plugin_original.py:7583
-#: ..\plugin_original.py:7661 ..\plugin_original.py:7675
-#: ..\plugin_original.py:7685 ..\plugin_original.py:7695
-#: ..\plugin_original.py:7705 ..\plugin_original.py:7715
-#: ..\plugin_original.py:7725 ..\plugin_original.py:7806
-#: ..\plugin_original.py:7819 ..\plugin_original.py:7872
+#: ..\plugin.py:5995 ..\plugin.py:6010 ..\plugin.py:6097 ..\plugin.py:6114
+#: ..\plugin.py:6128 ..\plugin.py:6139 ..\plugin.py:6199 ..\plugin.py:6371
+#: ..\plugin.py:6381 ..\plugin.py:6390 ..\plugin.py:6478 ..\plugin.py:6492
+#: ..\plugin.py:6502 ..\plugin.py:6512 ..\plugin.py:6522 ..\plugin.py:6532
+#: ..\plugin.py:6542 ..\plugin.py:6623 ..\plugin.py:6636 ..\plugin.py:6689
+#: ..\plugin.py:6802 ..\plugin.py:6816 ..\plugin.py:6838 ..\plugin.py:6853
+#: ..\plugin.py:6865 ..\plugin.py:6878 ..\plugin.py:7067 ..\plugin.py:7077
+#: ..\plugin.py:7086 ..\plugin.py:7134 ..\plugin.py:7144 ..\plugin.py:7153
+#: ..\plugin.py:7251 ..\plugin.py:7264 ..\plugin.py:7317 ..\plugin.py:7368
+#: ..\plugin.py:7383 ..\plugin.py:7409 ..\plugin.py:7422 ..\plugin.py:7576
+#: ..\plugin.py:7586 ..\plugin.py:7595 ..\plugin.py:7673 ..\plugin.py:7687
+#: ..\plugin.py:7697 ..\plugin.py:7707 ..\plugin.py:7717 ..\plugin.py:7727
+#: ..\plugin.py:7737 ..\plugin.py:7818 ..\plugin.py:7831 ..\plugin.py:7884
 msgid "- Size"
 msgstr "- 大小"
 
-#: ..\plugin.py:5992 ..\plugin.py:6007 ..\plugin.py:6019 ..\plugin.py:6029
-#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
-#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6150 ..\plugin.py:6162
-#: ..\plugin.py:6186 ..\plugin.py:6214 ..\plugin.py:6224 ..\plugin.py:6234
-#: ..\plugin.py:6253 ..\plugin.py:6264 ..\plugin.py:6291 ..\plugin.py:6302
-#: ..\plugin.py:6334 ..\plugin.py:6357 ..\plugin.py:6390 ..\plugin.py:6402
-#: ..\plugin.py:6432 ..\plugin.py:6443 ..\plugin.py:6454 ..\plugin.py:6465
-#: ..\plugin.py:6553 ..\plugin.py:6568 ..\plugin.py:6581 ..\plugin.py:6595
-#: ..\plugin.py:6610 ..\plugin.py:6623 ..\plugin.py:6645 ..\plugin.py:6657
-#: ..\plugin.py:6722 ..\plugin.py:6734 ..\plugin.py:6747 ..\plugin.py:6760
-#: ..\plugin.py:6773 ..\plugin.py:6786 ..\plugin.py:6834 ..\plugin.py:6849
-#: ..\plugin.py:6862 ..\plugin.py:6875 ..\plugin.py:6899 ..\plugin.py:6910
-#: ..\plugin.py:6920 ..\plugin.py:6930 ..\plugin.py:6949 ..\plugin.py:6959
-#: ..\plugin.py:6986 ..\plugin.py:6997 ..\plugin.py:7029 ..\plugin.py:7052
-#: ..\plugin.py:7085 ..\plugin.py:7097 ..\plugin.py:7108 ..\plugin.py:7119
-#: ..\plugin.py:7180 ..\plugin.py:7195 ..\plugin.py:7208 ..\plugin.py:7222
-#: ..\plugin.py:7237 ..\plugin.py:7250 ..\plugin.py:7272 ..\plugin.py:7284
-#: ..\plugin.py:7363 ..\plugin.py:7378 ..\plugin.py:7392 ..\plugin.py:7405
-#: ..\plugin.py:7418 ..\plugin.py:7438 ..\plugin.py:7457 ..\plugin.py:7467
-#: ..\plugin.py:7494 ..\plugin.py:7505 ..\plugin.py:7537 ..\plugin.py:7560
-#: ..\plugin.py:7593 ..\plugin.py:7605 ..\plugin.py:7625 ..\plugin.py:7636
-#: ..\plugin.py:7647 ..\plugin.py:7658 ..\plugin.py:7746 ..\plugin.py:7761
-#: ..\plugin.py:7774 ..\plugin.py:7788 ..\plugin.py:7803 ..\plugin.py:7816
-#: ..\plugin.py:7838 ..\plugin.py:7850 ..\plugin_original.py:5990
-#: ..\plugin_original.py:6005 ..\plugin_original.py:6017
-#: ..\plugin_original.py:6027 ..\plugin_original.py:6040
-#: ..\plugin_original.py:6053 ..\plugin_original.py:6066
-#: ..\plugin_original.py:6079 ..\plugin_original.py:6110
-#: ..\plugin_original.py:6124 ..\plugin_original.py:6148
-#: ..\plugin_original.py:6160 ..\plugin_original.py:6184
-#: ..\plugin_original.py:6212 ..\plugin_original.py:6222
-#: ..\plugin_original.py:6232 ..\plugin_original.py:6251
-#: ..\plugin_original.py:6262 ..\plugin_original.py:6289
-#: ..\plugin_original.py:6300 ..\plugin_original.py:6332
-#: ..\plugin_original.py:6355 ..\plugin_original.py:6388
-#: ..\plugin_original.py:6400 ..\plugin_original.py:6430
-#: ..\plugin_original.py:6441 ..\plugin_original.py:6452
-#: ..\plugin_original.py:6463 ..\plugin_original.py:6551
-#: ..\plugin_original.py:6566 ..\plugin_original.py:6579
-#: ..\plugin_original.py:6593 ..\plugin_original.py:6608
-#: ..\plugin_original.py:6621 ..\plugin_original.py:6643
-#: ..\plugin_original.py:6655 ..\plugin_original.py:6720
-#: ..\plugin_original.py:6732 ..\plugin_original.py:6745
-#: ..\plugin_original.py:6758 ..\plugin_original.py:6771
-#: ..\plugin_original.py:6784 ..\plugin_original.py:6832
-#: ..\plugin_original.py:6847 ..\plugin_original.py:6860
-#: ..\plugin_original.py:6873 ..\plugin_original.py:6897
-#: ..\plugin_original.py:6908 ..\plugin_original.py:6918
-#: ..\plugin_original.py:6928 ..\plugin_original.py:6947
-#: ..\plugin_original.py:6957 ..\plugin_original.py:6984
-#: ..\plugin_original.py:6995 ..\plugin_original.py:7027
-#: ..\plugin_original.py:7050 ..\plugin_original.py:7083
-#: ..\plugin_original.py:7095 ..\plugin_original.py:7106
-#: ..\plugin_original.py:7117 ..\plugin_original.py:7178
-#: ..\plugin_original.py:7193 ..\plugin_original.py:7206
-#: ..\plugin_original.py:7220 ..\plugin_original.py:7235
-#: ..\plugin_original.py:7248 ..\plugin_original.py:7270
-#: ..\plugin_original.py:7282 ..\plugin_original.py:7361
-#: ..\plugin_original.py:7376 ..\plugin_original.py:7390
-#: ..\plugin_original.py:7403 ..\plugin_original.py:7416
-#: ..\plugin_original.py:7436 ..\plugin_original.py:7455
-#: ..\plugin_original.py:7465 ..\plugin_original.py:7492
-#: ..\plugin_original.py:7503 ..\plugin_original.py:7535
-#: ..\plugin_original.py:7558 ..\plugin_original.py:7591
-#: ..\plugin_original.py:7603 ..\plugin_original.py:7623
-#: ..\plugin_original.py:7634 ..\plugin_original.py:7645
-#: ..\plugin_original.py:7656 ..\plugin_original.py:7744
-#: ..\plugin_original.py:7759 ..\plugin_original.py:7772
-#: ..\plugin_original.py:7786 ..\plugin_original.py:7801
-#: ..\plugin_original.py:7814 ..\plugin_original.py:7836
-#: ..\plugin_original.py:7848
+#: ..\plugin.py:6000 ..\plugin.py:6015 ..\plugin.py:6027 ..\plugin.py:6037
+#: ..\plugin.py:6050 ..\plugin.py:6063 ..\plugin.py:6076 ..\plugin.py:6089
+#: ..\plugin.py:6120 ..\plugin.py:6134 ..\plugin.py:6158 ..\plugin.py:6170
+#: ..\plugin.py:6194 ..\plugin.py:6222 ..\plugin.py:6232 ..\plugin.py:6242
+#: ..\plugin.py:6261 ..\plugin.py:6272 ..\plugin.py:6299 ..\plugin.py:6310
+#: ..\plugin.py:6342 ..\plugin.py:6365 ..\plugin.py:6398 ..\plugin.py:6410
+#: ..\plugin.py:6440 ..\plugin.py:6451 ..\plugin.py:6462 ..\plugin.py:6473
+#: ..\plugin.py:6561 ..\plugin.py:6576 ..\plugin.py:6589 ..\plugin.py:6603
+#: ..\plugin.py:6618 ..\plugin.py:6631 ..\plugin.py:6653 ..\plugin.py:6665
+#: ..\plugin.py:6731 ..\plugin.py:6743 ..\plugin.py:6756 ..\plugin.py:6769
+#: ..\plugin.py:6782 ..\plugin.py:6795 ..\plugin.py:6843 ..\plugin.py:6858
+#: ..\plugin.py:6871 ..\plugin.py:6884 ..\plugin.py:6908 ..\plugin.py:6919
+#: ..\plugin.py:6929 ..\plugin.py:6939 ..\plugin.py:6958 ..\plugin.py:6968
+#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7038 ..\plugin.py:7061
+#: ..\plugin.py:7094 ..\plugin.py:7106 ..\plugin.py:7117 ..\plugin.py:7128
+#: ..\plugin.py:7189 ..\plugin.py:7204 ..\plugin.py:7217 ..\plugin.py:7231
+#: ..\plugin.py:7246 ..\plugin.py:7259 ..\plugin.py:7281 ..\plugin.py:7293
+#: ..\plugin.py:7373 ..\plugin.py:7388 ..\plugin.py:7402 ..\plugin.py:7415
+#: ..\plugin.py:7428 ..\plugin.py:7448 ..\plugin.py:7467 ..\plugin.py:7477
+#: ..\plugin.py:7504 ..\plugin.py:7515 ..\plugin.py:7547 ..\plugin.py:7570
+#: ..\plugin.py:7603 ..\plugin.py:7615 ..\plugin.py:7635 ..\plugin.py:7646
+#: ..\plugin.py:7657 ..\plugin.py:7668 ..\plugin.py:7756 ..\plugin.py:7771
+#: ..\plugin.py:7784 ..\plugin.py:7798 ..\plugin.py:7813 ..\plugin.py:7826
+#: ..\plugin.py:7848 ..\plugin.py:7860
 msgid "- Shadow Edges"
 msgstr "- 阴影边缘"
 
-#: ..\plugin.py:5994 ..\plugin.py:6836 ..\plugin.py:7365
-#: ..\plugin_original.py:5992 ..\plugin_original.py:6834
-#: ..\plugin_original.py:7363
+#: ..\plugin.py:6002 ..\plugin.py:6845 ..\plugin.py:7375
 msgid "Clock 2"
 msgstr "时钟2"
 
-#: ..\plugin.py:6009 ..\plugin.py:6750 ..\plugin_original.py:6007
-#: ..\plugin_original.py:6748
+#: ..\plugin.py:6017 ..\plugin.py:6759
 msgid "Program Name"
 msgstr "程序名称"
 
-#: ..\plugin.py:6013 ..\plugin.py:6036 ..\plugin.py:6049 ..\plugin.py:6062
-#: ..\plugin.py:6075 ..\plugin.py:6110 ..\plugin.py:6124 ..\plugin.py:6178
-#: ..\plugin.py:6574 ..\plugin.py:6619 ..\plugin.py:6716 ..\plugin.py:6728
-#: ..\plugin.py:6741 ..\plugin.py:6754 ..\plugin.py:6767 ..\plugin.py:6780
-#: ..\plugin.py:6860 ..\plugin.py:6873 ..\plugin.py:6891 ..\plugin.py:7201
-#: ..\plugin.py:7246 ..\plugin.py:7384 ..\plugin.py:7403 ..\plugin.py:7416
-#: ..\plugin.py:7767 ..\plugin.py:7812 ..\plugin_original.py:6011
-#: ..\plugin_original.py:6034 ..\plugin_original.py:6047
-#: ..\plugin_original.py:6060 ..\plugin_original.py:6073
-#: ..\plugin_original.py:6108 ..\plugin_original.py:6122
-#: ..\plugin_original.py:6176 ..\plugin_original.py:6572
-#: ..\plugin_original.py:6617 ..\plugin_original.py:6714
-#: ..\plugin_original.py:6726 ..\plugin_original.py:6739
-#: ..\plugin_original.py:6752 ..\plugin_original.py:6765
-#: ..\plugin_original.py:6778 ..\plugin_original.py:6858
-#: ..\plugin_original.py:6871 ..\plugin_original.py:6889
-#: ..\plugin_original.py:7199 ..\plugin_original.py:7244
-#: ..\plugin_original.py:7382 ..\plugin_original.py:7401
-#: ..\plugin_original.py:7414 ..\plugin_original.py:7765
-#: ..\plugin_original.py:7810
+#: ..\plugin.py:6021 ..\plugin.py:6044 ..\plugin.py:6057 ..\plugin.py:6070
+#: ..\plugin.py:6083 ..\plugin.py:6118 ..\plugin.py:6132 ..\plugin.py:6186
+#: ..\plugin.py:6582 ..\plugin.py:6627 ..\plugin.py:6725 ..\plugin.py:6737
+#: ..\plugin.py:6750 ..\plugin.py:6763 ..\plugin.py:6776 ..\plugin.py:6789
+#: ..\plugin.py:6869 ..\plugin.py:6882 ..\plugin.py:6900 ..\plugin.py:7210
+#: ..\plugin.py:7255 ..\plugin.py:7394 ..\plugin.py:7413 ..\plugin.py:7426
+#: ..\plugin.py:7777 ..\plugin.py:7822
 msgid "- maximum Lines"
 msgstr "- 最大行数"
 
-#: ..\plugin.py:6016 ..\plugin.py:6039 ..\plugin.py:6052 ..\plugin.py:6065
-#: ..\plugin.py:6078 ..\plugin.py:6092 ..\plugin.py:6134 ..\plugin.py:6183
-#: ..\plugin.py:6194 ..\plugin.py:6579 ..\plugin.py:6719 ..\plugin.py:6731
-#: ..\plugin.py:6744 ..\plugin.py:6757 ..\plugin.py:6770 ..\plugin.py:6783
-#: ..\plugin.py:6796 ..\plugin.py:6810 ..\plugin.py:6896 ..\plugin.py:7206
-#: ..\plugin.py:7389 ..\plugin.py:7772 ..\plugin_original.py:6014
-#: ..\plugin_original.py:6037 ..\plugin_original.py:6050
-#: ..\plugin_original.py:6063 ..\plugin_original.py:6076
-#: ..\plugin_original.py:6090 ..\plugin_original.py:6132
-#: ..\plugin_original.py:6181 ..\plugin_original.py:6192
-#: ..\plugin_original.py:6577 ..\plugin_original.py:6717
-#: ..\plugin_original.py:6729 ..\plugin_original.py:6742
-#: ..\plugin_original.py:6755 ..\plugin_original.py:6768
-#: ..\plugin_original.py:6781 ..\plugin_original.py:6794
-#: ..\plugin_original.py:6808 ..\plugin_original.py:6894
-#: ..\plugin_original.py:7204 ..\plugin_original.py:7387
-#: ..\plugin_original.py:7770
+#: ..\plugin.py:6024 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
+#: ..\plugin.py:6086 ..\plugin.py:6100 ..\plugin.py:6142 ..\plugin.py:6191
+#: ..\plugin.py:6202 ..\plugin.py:6587 ..\plugin.py:6728 ..\plugin.py:6740
+#: ..\plugin.py:6753 ..\plugin.py:6766 ..\plugin.py:6779 ..\plugin.py:6792
+#: ..\plugin.py:6805 ..\plugin.py:6819 ..\plugin.py:6905 ..\plugin.py:7215
+#: ..\plugin.py:7399 ..\plugin.py:7782
 msgid "- Length"
 msgstr "- 长度"
 
-#: ..\plugin.py:6021 ..\plugin_original.py:6019
+#: ..\plugin.py:6029
 msgid "Program Number"
 msgstr "程序号码示例"
 
-#: ..\plugin.py:6031 ..\plugin.py:6762 ..\plugin_original.py:6029
-#: ..\plugin_original.py:6760
+#: ..\plugin.py:6039 ..\plugin.py:6771
 msgid "Program Info"
 msgstr "程序信息"
 
-#: ..\plugin.py:6034 ..\plugin.py:6047 ..\plugin.py:6060 ..\plugin.py:6073
-#: ..\plugin.py:6087 ..\plugin.py:6088 ..\plugin.py:6148 ..\plugin.py:6160
-#: ..\plugin.py:6171 ..\plugin.py:6179 ..\plugin.py:6180 ..\plugin.py:6210
-#: ..\plugin.py:6236 ..\plugin.py:6266 ..\plugin.py:6281 ..\plugin.py:6325
-#: ..\plugin.py:6326 ..\plugin.py:6348 ..\plugin.py:6349 ..\plugin.py:6368
-#: ..\plugin.py:6378 ..\plugin.py:6401 ..\plugin.py:6551 ..\plugin.py:6567
-#: ..\plugin.py:6575 ..\plugin.py:6576 ..\plugin.py:6591 ..\plugin.py:6604
-#: ..\plugin.py:6605 ..\plugin.py:6621 ..\plugin.py:6632 ..\plugin.py:6689
-#: ..\plugin.py:6739 ..\plugin.py:6765 ..\plugin.py:6778 ..\plugin.py:6791
-#: ..\plugin.py:6792 ..\plugin.py:6824 ..\plugin.py:6839 ..\plugin.py:6884
-#: ..\plugin.py:6892 ..\plugin.py:6893 ..\plugin.py:6906 ..\plugin.py:6932
-#: ..\plugin.py:6961 ..\plugin.py:6976 ..\plugin.py:7020 ..\plugin.py:7021
-#: ..\plugin.py:7043 ..\plugin.py:7044 ..\plugin.py:7063 ..\plugin.py:7073
-#: ..\plugin.py:7096 ..\plugin.py:7178 ..\plugin.py:7194 ..\plugin.py:7202
-#: ..\plugin.py:7203 ..\plugin.py:7218 ..\plugin.py:7231 ..\plugin.py:7232
-#: ..\plugin.py:7248 ..\plugin.py:7259 ..\plugin.py:7353 ..\plugin.py:7368
-#: ..\plugin.py:7385 ..\plugin.py:7386 ..\plugin.py:7427 ..\plugin.py:7440
-#: ..\plugin.py:7469 ..\plugin.py:7484 ..\plugin.py:7528 ..\plugin.py:7529
-#: ..\plugin.py:7551 ..\plugin.py:7552 ..\plugin.py:7571 ..\plugin.py:7581
-#: ..\plugin.py:7604 ..\plugin.py:7744 ..\plugin.py:7760 ..\plugin.py:7768
-#: ..\plugin.py:7769 ..\plugin.py:7784 ..\plugin.py:7797 ..\plugin.py:7798
-#: ..\plugin.py:7814 ..\plugin.py:7825 ..\plugin_original.py:6032
-#: ..\plugin_original.py:6045 ..\plugin_original.py:6058
-#: ..\plugin_original.py:6071 ..\plugin_original.py:6085
-#: ..\plugin_original.py:6086 ..\plugin_original.py:6146
-#: ..\plugin_original.py:6158 ..\plugin_original.py:6169
-#: ..\plugin_original.py:6177 ..\plugin_original.py:6178
-#: ..\plugin_original.py:6208 ..\plugin_original.py:6234
-#: ..\plugin_original.py:6264 ..\plugin_original.py:6279
-#: ..\plugin_original.py:6323 ..\plugin_original.py:6324
-#: ..\plugin_original.py:6346 ..\plugin_original.py:6347
-#: ..\plugin_original.py:6366 ..\plugin_original.py:6376
-#: ..\plugin_original.py:6399 ..\plugin_original.py:6549
-#: ..\plugin_original.py:6565 ..\plugin_original.py:6573
-#: ..\plugin_original.py:6574 ..\plugin_original.py:6589
-#: ..\plugin_original.py:6602 ..\plugin_original.py:6603
-#: ..\plugin_original.py:6619 ..\plugin_original.py:6630
-#: ..\plugin_original.py:6687 ..\plugin_original.py:6737
-#: ..\plugin_original.py:6763 ..\plugin_original.py:6776
-#: ..\plugin_original.py:6789 ..\plugin_original.py:6790
-#: ..\plugin_original.py:6822 ..\plugin_original.py:6837
-#: ..\plugin_original.py:6882 ..\plugin_original.py:6890
-#: ..\plugin_original.py:6891 ..\plugin_original.py:6904
-#: ..\plugin_original.py:6930 ..\plugin_original.py:6959
-#: ..\plugin_original.py:6974 ..\plugin_original.py:7018
-#: ..\plugin_original.py:7019 ..\plugin_original.py:7041
-#: ..\plugin_original.py:7042 ..\plugin_original.py:7061
-#: ..\plugin_original.py:7071 ..\plugin_original.py:7094
-#: ..\plugin_original.py:7176 ..\plugin_original.py:7192
-#: ..\plugin_original.py:7200 ..\plugin_original.py:7201
-#: ..\plugin_original.py:7216 ..\plugin_original.py:7229
-#: ..\plugin_original.py:7230 ..\plugin_original.py:7246
-#: ..\plugin_original.py:7257 ..\plugin_original.py:7351
-#: ..\plugin_original.py:7366 ..\plugin_original.py:7383
-#: ..\plugin_original.py:7384 ..\plugin_original.py:7425
-#: ..\plugin_original.py:7438 ..\plugin_original.py:7467
-#: ..\plugin_original.py:7482 ..\plugin_original.py:7526
-#: ..\plugin_original.py:7527 ..\plugin_original.py:7549
-#: ..\plugin_original.py:7550 ..\plugin_original.py:7569
-#: ..\plugin_original.py:7579 ..\plugin_original.py:7602
-#: ..\plugin_original.py:7742 ..\plugin_original.py:7758
-#: ..\plugin_original.py:7766 ..\plugin_original.py:7767
-#: ..\plugin_original.py:7782 ..\plugin_original.py:7795
-#: ..\plugin_original.py:7796 ..\plugin_original.py:7812
-#: ..\plugin_original.py:7823
+#: ..\plugin.py:6042 ..\plugin.py:6055 ..\plugin.py:6068 ..\plugin.py:6081
+#: ..\plugin.py:6095 ..\plugin.py:6096 ..\plugin.py:6156 ..\plugin.py:6168
+#: ..\plugin.py:6179 ..\plugin.py:6187 ..\plugin.py:6188 ..\plugin.py:6218
+#: ..\plugin.py:6244 ..\plugin.py:6274 ..\plugin.py:6289 ..\plugin.py:6333
+#: ..\plugin.py:6334 ..\plugin.py:6356 ..\plugin.py:6357 ..\plugin.py:6376
+#: ..\plugin.py:6386 ..\plugin.py:6409 ..\plugin.py:6559 ..\plugin.py:6575
+#: ..\plugin.py:6583 ..\plugin.py:6584 ..\plugin.py:6599 ..\plugin.py:6612
+#: ..\plugin.py:6613 ..\plugin.py:6629 ..\plugin.py:6640 ..\plugin.py:6697
+#: ..\plugin.py:6748 ..\plugin.py:6774 ..\plugin.py:6787 ..\plugin.py:6800
+#: ..\plugin.py:6801 ..\plugin.py:6893 ..\plugin.py:6901 ..\plugin.py:6902
+#: ..\plugin.py:6915 ..\plugin.py:6941 ..\plugin.py:6970 ..\plugin.py:6985
+#: ..\plugin.py:7029 ..\plugin.py:7030 ..\plugin.py:7052 ..\plugin.py:7053
+#: ..\plugin.py:7072 ..\plugin.py:7082 ..\plugin.py:7105 ..\plugin.py:7187
+#: ..\plugin.py:7203 ..\plugin.py:7211 ..\plugin.py:7212 ..\plugin.py:7227
+#: ..\plugin.py:7240 ..\plugin.py:7241 ..\plugin.py:7257 ..\plugin.py:7268
+#: ..\plugin.py:7395 ..\plugin.py:7396 ..\plugin.py:7437 ..\plugin.py:7450
+#: ..\plugin.py:7479 ..\plugin.py:7494 ..\plugin.py:7538 ..\plugin.py:7539
+#: ..\plugin.py:7561 ..\plugin.py:7562 ..\plugin.py:7581 ..\plugin.py:7591
+#: ..\plugin.py:7614 ..\plugin.py:7754 ..\plugin.py:7770 ..\plugin.py:7778
+#: ..\plugin.py:7779 ..\plugin.py:7794 ..\plugin.py:7807 ..\plugin.py:7808
+#: ..\plugin.py:7824 ..\plugin.py:7835
 msgid "- Type"
 msgstr "- 类型"
 
-#: ..\plugin.py:6044 ..\plugin_original.py:6042
+#: ..\plugin.py:6052
 msgid "Program Info 2"
 msgstr "程序信息 2"
 
-#: ..\plugin.py:6057 ..\plugin.py:6775 ..\plugin_original.py:6055
-#: ..\plugin_original.py:6773
+#: ..\plugin.py:6065 ..\plugin.py:6784
 msgid "Next Program Info"
 msgstr "下一个程序信息"
 
-#: ..\plugin.py:6070 ..\plugin.py:6736 ..\plugin_original.py:6068
-#: ..\plugin_original.py:6734
+#: ..\plugin.py:6078 ..\plugin.py:6745
 msgid "Extended Description"
 msgstr "扩展描述"
 
-#: ..\plugin.py:6083 ..\plugin.py:6749 ..\plugin_original.py:6081
-#: ..\plugin_original.py:6747
+#: ..\plugin.py:6091 ..\plugin.py:6758
 msgid "- use Info when empty"
 msgstr "- 空时使用信息"
 
-#: ..\plugin.py:6084 ..\plugin.py:6788 ..\plugin_original.py:6082
-#: ..\plugin_original.py:6786
+#: ..\plugin.py:6092 ..\plugin.py:6797
 msgid "Progress Bar"
 msgstr "进度条"
 
-#: ..\plugin.py:6094 ..\plugin.py:6798 ..\plugin_original.py:6092
-#: ..\plugin_original.py:6796
+#: ..\plugin.py:6102 ..\plugin.py:6807
 msgid "- Color Text"
 msgstr "- 文本颜色"
 
-#: ..\plugin.py:6095 ..\plugin.py:6799 ..\plugin_original.py:6093
-#: ..\plugin_original.py:6797
+#: ..\plugin.py:6103 ..\plugin.py:6808
 msgid "- Color Background"
 msgstr "- 背景颜色"
 
-#: ..\plugin.py:6096 ..\plugin.py:6800 ..\plugin_original.py:6094
-#: ..\plugin_original.py:6798
+#: ..\plugin.py:6104 ..\plugin.py:6809
 msgid "- Border"
 msgstr "- 边界"
 
-#: ..\plugin.py:6097 ..\plugin.py:6197 ..\plugin.py:6801 ..\plugin.py:6813
-#: ..\plugin_original.py:6095 ..\plugin_original.py:6195
-#: ..\plugin_original.py:6799 ..\plugin_original.py:6811
+#: ..\plugin.py:6105 ..\plugin.py:6205 ..\plugin.py:6810 ..\plugin.py:6822
 msgid "- Shaded"
 msgstr "- 阴影"
 
-#: ..\plugin.py:6098 ..\plugin.py:6802 ..\plugin_original.py:6096
-#: ..\plugin_original.py:6800
+#: ..\plugin.py:6106 ..\plugin.py:6811
 msgid "- Unit min"
 msgstr "- 单位最小值"
 
-#: ..\plugin.py:6100 ..\plugin.py:6851 ..\plugin.py:7394
-#: ..\plugin_original.py:6098 ..\plugin_original.py:6849
-#: ..\plugin_original.py:7392
+#: ..\plugin.py:6108 ..\plugin.py:6860 ..\plugin.py:7404
 msgid "Informations"
 msgstr "信息"
 
-#: ..\plugin.py:6103 ..\plugin.py:6117 ..\plugin_original.py:6101
-#: ..\plugin_original.py:6115
+#: ..\plugin.py:6111 ..\plugin.py:6125
 msgid "- Tunerinfo"
 msgstr "- 调谐器信息"
 
-#: ..\plugin.py:6104 ..\plugin.py:6118 ..\plugin.py:6854 ..\plugin.py:6867
-#: ..\plugin.py:7397 ..\plugin.py:7410 ..\plugin_original.py:6102
-#: ..\plugin_original.py:6116 ..\plugin_original.py:6852
-#: ..\plugin_original.py:6865 ..\plugin_original.py:7395
-#: ..\plugin_original.py:7408
+#: ..\plugin.py:6112 ..\plugin.py:6126 ..\plugin.py:6863 ..\plugin.py:6876
+#: ..\plugin.py:7407 ..\plugin.py:7420
 msgid "- Sensors"
 msgstr "- 传感器"
 
-#: ..\plugin.py:6105 ..\plugin.py:6119 ..\plugin.py:6855 ..\plugin.py:6868
-#: ..\plugin.py:7398 ..\plugin.py:7411 ..\plugin_original.py:6103
-#: ..\plugin_original.py:6117 ..\plugin_original.py:6853
-#: ..\plugin_original.py:6866 ..\plugin_original.py:7396
-#: ..\plugin_original.py:7409
+#: ..\plugin.py:6113 ..\plugin.py:6127 ..\plugin.py:6864 ..\plugin.py:6877
+#: ..\plugin.py:7408 ..\plugin.py:7421
 msgid "- CPU"
 msgstr "- 处理器"
 
-#: ..\plugin.py:6114 ..\plugin.py:6864 ..\plugin.py:7407
-#: ..\plugin_original.py:6112 ..\plugin_original.py:6862
-#: ..\plugin_original.py:7405
+#: ..\plugin.py:6122 ..\plugin.py:6873 ..\plugin.py:7417
 msgid "Informations 2"
 msgstr "信息 2"
 
-#: ..\plugin.py:6128 ..\plugin_original.py:6126
+#: ..\plugin.py:6136
 msgid "Signal Quality Bar"
 msgstr "信号质量条"
 
-#: ..\plugin.py:6137 ..\plugin_original.py:6135
+#: ..\plugin.py:6145
 msgid "- Gradient"
 msgstr "- 渐变色"
 
-#: ..\plugin.py:6138 ..\plugin_original.py:6136
+#: ..\plugin.py:6146
 msgid "- Bar Range Min"
 msgstr "- 最小范围"
 
-#: ..\plugin.py:6139 ..\plugin_original.py:6137
+#: ..\plugin.py:6147
 msgid "- Bar Range Max"
 msgstr "- 最大范围"
 
-#: ..\plugin.py:6140 ..\plugin_original.py:6138
+#: ..\plugin.py:6148
 msgid "Satellite"
 msgstr "卫星"
 
-#: ..\plugin.py:6152 ..\plugin_original.py:6150
+#: ..\plugin.py:6160
 msgid "Provider"
 msgstr "供应商"
 
-#: ..\plugin.py:6164 ..\plugin.py:6877 ..\plugin.py:7420
-#: ..\plugin_original.py:6162 ..\plugin_original.py:6875
-#: ..\plugin_original.py:7418
+#: ..\plugin.py:6172 ..\plugin.py:6886 ..\plugin.py:7430
 msgid "Used Tuner"
 msgstr "使用调谐器"
 
-#: ..\plugin.py:6172 ..\plugin.py:6885 ..\plugin.py:7428
-#: ..\plugin_original.py:6170 ..\plugin_original.py:6883
-#: ..\plugin_original.py:7426
+#: ..\plugin.py:6180 ..\plugin.py:6894 ..\plugin.py:7438
 msgid "- only active Tuner"
 msgstr "- 仅活动调谐器"
 
-#: ..\plugin.py:6174 ..\plugin.py:6887 ..\plugin.py:7380
-#: ..\plugin_original.py:6172 ..\plugin_original.py:6885
-#: ..\plugin_original.py:7378
+#: ..\plugin.py:6182 ..\plugin.py:6896 ..\plugin.py:7390
 msgid "Next Timer Event"
 msgstr "下次计时器事件"
 
-#: ..\plugin.py:6188 ..\plugin.py:6804 ..\plugin_original.py:6186
-#: ..\plugin_original.py:6802
+#: ..\plugin.py:6196 ..\plugin.py:6813
 msgid "Volume"
 msgstr "体积"
 
-#: ..\plugin.py:6198 ..\plugin.py:6814 ..\plugin_original.py:6196
-#: ..\plugin_original.py:6812
+#: ..\plugin.py:6206 ..\plugin.py:6823
 msgid "Mute"
 msgstr "静音"
 
-#: ..\plugin.py:6205 ..\plugin.py:6901 ..\plugin_original.py:6203
-#: ..\plugin_original.py:6899
+#: ..\plugin.py:6213 ..\plugin.py:6910
 msgid "Audio/Video"
 msgstr "音频/视频"
 
-#: ..\plugin.py:6216 ..\plugin.py:6912 ..\plugin_original.py:6214
-#: ..\plugin_original.py:6910
+#: ..\plugin.py:6224 ..\plugin.py:6921
 msgid "Bitrate"
 msgstr "比特率"
 
-#: ..\plugin.py:6226 ..\plugin.py:6922 ..\plugin.py:7430
-#: ..\plugin_original.py:6224 ..\plugin_original.py:6920
-#: ..\plugin_original.py:7428
+#: ..\plugin.py:6234 ..\plugin.py:6931 ..\plugin.py:7440
 msgid "Online [Ping]"
 msgstr "在线[Ping]"
 
-#: ..\plugin.py:6237 ..\plugin.py:6933 ..\plugin.py:7441
-#: ..\plugin_original.py:6235 ..\plugin_original.py:6931
-#: ..\plugin_original.py:7439
+#: ..\plugin.py:6245 ..\plugin.py:6942 ..\plugin.py:7451
 msgid "- Show State"
 msgstr "- 显示状态"
 
-#: ..\plugin.py:6238 ..\plugin.py:6934 ..\plugin.py:7442
-#: ..\plugin_original.py:6236 ..\plugin_original.py:6932
-#: ..\plugin_original.py:7440
+#: ..\plugin.py:6246 ..\plugin.py:6943 ..\plugin.py:7452
 msgid "- Timeout [ms]"
 msgstr "- 超时[毫秒]"
 
-#: ..\plugin.py:6239 ..\plugin.py:6240 ..\plugin.py:6241 ..\plugin.py:6242
-#: ..\plugin.py:6243 ..\plugin.py:6935 ..\plugin.py:6936 ..\plugin.py:6937
-#: ..\plugin.py:6938 ..\plugin.py:6939 ..\plugin.py:7443 ..\plugin.py:7444
-#: ..\plugin.py:7445 ..\plugin.py:7446 ..\plugin.py:7447
-#: ..\plugin_original.py:6237 ..\plugin_original.py:6238
-#: ..\plugin_original.py:6239 ..\plugin_original.py:6240
-#: ..\plugin_original.py:6241 ..\plugin_original.py:6933
-#: ..\plugin_original.py:6934 ..\plugin_original.py:6935
-#: ..\plugin_original.py:6936 ..\plugin_original.py:6937
-#: ..\plugin_original.py:7441 ..\plugin_original.py:7442
-#: ..\plugin_original.py:7443 ..\plugin_original.py:7444
-#: ..\plugin_original.py:7445
+#: ..\plugin.py:6247 ..\plugin.py:6248 ..\plugin.py:6249 ..\plugin.py:6250
+#: ..\plugin.py:6251 ..\plugin.py:6944 ..\plugin.py:6945 ..\plugin.py:6946
+#: ..\plugin.py:6947 ..\plugin.py:6948 ..\plugin.py:7453 ..\plugin.py:7454
+#: ..\plugin.py:7455 ..\plugin.py:7456 ..\plugin.py:7457
 msgid "- Online Name:Address"
 msgstr "- 在线名称:地址"
 
-#: ..\plugin.py:6244 ..\plugin.py:6940 ..\plugin.py:7448
-#: ..\plugin_original.py:6242 ..\plugin_original.py:6938
-#: ..\plugin_original.py:7446
+#: ..\plugin.py:6252 ..\plugin.py:6949 ..\plugin.py:7458
 msgid "External IP Address"
 msgstr "外部 IP 地址"
 
-#: ..\plugin.py:6255 ..\plugin_original.py:6253
+#: ..\plugin.py:6263
 msgid "- external IP URL"
 msgstr "- 外部 IP 网址"
 
-#: ..\plugin.py:6256 ..\plugin.py:6951 ..\plugin.py:7459
-#: ..\plugin_original.py:6254 ..\plugin_original.py:6949
-#: ..\plugin_original.py:7457
+#: ..\plugin.py:6264 ..\plugin.py:6960 ..\plugin.py:7469
 msgid "Storage-Devices"
 msgstr "存储设备"
 
-#: ..\plugin.py:6267 ..\plugin.py:6962 ..\plugin.py:7470
-#: ..\plugin_original.py:6265 ..\plugin_original.py:6960
-#: ..\plugin_original.py:7468
+#: ..\plugin.py:6275 ..\plugin.py:6971 ..\plugin.py:7480
 msgid "- free Warning"
 msgstr "- 免费警告"
 
-#: ..\plugin.py:6268 ..\plugin.py:6963 ..\plugin.py:7471
-#: ..\plugin_original.py:6266 ..\plugin_original.py:6961
-#: ..\plugin_original.py:7469
+#: ..\plugin.py:6276 ..\plugin.py:6972 ..\plugin.py:7481
 msgid "- extra Info"
 msgstr "- 额外信息"
 
-#: ..\plugin.py:6269 ..\plugin.py:6270 ..\plugin.py:6271 ..\plugin.py:6272
-#: ..\plugin.py:6273 ..\plugin.py:6964 ..\plugin.py:6965 ..\plugin.py:6966
-#: ..\plugin.py:6967 ..\plugin.py:6968 ..\plugin.py:7472 ..\plugin.py:7473
-#: ..\plugin.py:7474 ..\plugin.py:7475 ..\plugin.py:7476
-#: ..\plugin_original.py:6267 ..\plugin_original.py:6268
-#: ..\plugin_original.py:6269 ..\plugin_original.py:6270
-#: ..\plugin_original.py:6271 ..\plugin_original.py:6962
-#: ..\plugin_original.py:6963 ..\plugin_original.py:6964
-#: ..\plugin_original.py:6965 ..\plugin_original.py:6966
-#: ..\plugin_original.py:7470 ..\plugin_original.py:7471
-#: ..\plugin_original.py:7472 ..\plugin_original.py:7473
-#: ..\plugin_original.py:7474
+#: ..\plugin.py:6277 ..\plugin.py:6278 ..\plugin.py:6279 ..\plugin.py:6280
+#: ..\plugin.py:6281 ..\plugin.py:6973 ..\plugin.py:6974 ..\plugin.py:6975
+#: ..\plugin.py:6976 ..\plugin.py:6977 ..\plugin.py:7482 ..\plugin.py:7483
+#: ..\plugin.py:7484 ..\plugin.py:7485 ..\plugin.py:7486
 msgid "- Device Name"
 msgstr "- 设备名称"
 
-#: ..\plugin.py:6274 ..\plugin.py:6969 ..\plugin.py:7477
-#: ..\plugin_original.py:6272 ..\plugin_original.py:6967
-#: ..\plugin_original.py:7475
+#: ..\plugin.py:6282 ..\plugin.py:6978 ..\plugin.py:7487
 msgid "HDD"
 msgstr "HDD"
 
-#: ..\plugin.py:6286 ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6601
-#: ..\plugin.py:6981 ..\plugin.py:6992 ..\plugin.py:7003 ..\plugin.py:7228
-#: ..\plugin.py:7489 ..\plugin.py:7500 ..\plugin.py:7511 ..\plugin.py:7794
-#: ..\plugin_original.py:6284 ..\plugin_original.py:6295
-#: ..\plugin_original.py:6306 ..\plugin_original.py:6599
-#: ..\plugin_original.py:6979 ..\plugin_original.py:6990
-#: ..\plugin_original.py:7001 ..\plugin_original.py:7226
-#: ..\plugin_original.py:7487 ..\plugin_original.py:7498
-#: ..\plugin_original.py:7509 ..\plugin_original.py:7792
+#: ..\plugin.py:6294 ..\plugin.py:6305 ..\plugin.py:6316 ..\plugin.py:6609
+#: ..\plugin.py:6990 ..\plugin.py:7001 ..\plugin.py:7012 ..\plugin.py:7237
+#: ..\plugin.py:7499 ..\plugin.py:7510 ..\plugin.py:7521 ..\plugin.py:7804
 msgid "- Zoom"
 msgstr "- 缩小 -"
 
-#: ..\plugin.py:6289 ..\plugin.py:6300 ..\plugin.py:6311 ..\plugin.py:6984
-#: ..\plugin.py:6995 ..\plugin.py:7006 ..\plugin.py:7492 ..\plugin.py:7503
-#: ..\plugin.py:7514 ..\plugin_original.py:6287 ..\plugin_original.py:6298
-#: ..\plugin_original.py:6309 ..\plugin_original.py:6982
-#: ..\plugin_original.py:6993 ..\plugin_original.py:7004
-#: ..\plugin_original.py:7490 ..\plugin_original.py:7501
-#: ..\plugin_original.py:7512
+#: ..\plugin.py:6297 ..\plugin.py:6308 ..\plugin.py:6319 ..\plugin.py:6993
+#: ..\plugin.py:7004 ..\plugin.py:7015 ..\plugin.py:7502 ..\plugin.py:7513
+#: ..\plugin.py:7524
 msgid "- Weather Type"
 msgstr "- 天气类型"
 
-#: ..\plugin.py:6293 ..\plugin.py:6988 ..\plugin.py:7496
-#: ..\plugin_original.py:6291 ..\plugin_original.py:6986
-#: ..\plugin_original.py:7494
+#: ..\plugin.py:6301 ..\plugin.py:6997 ..\plugin.py:7506
 msgid "Weather 2"
 msgstr "天气2"
 
-#: ..\plugin.py:6304 ..\plugin.py:6999 ..\plugin.py:7507
-#: ..\plugin_original.py:6302 ..\plugin_original.py:6997
-#: ..\plugin_original.py:7505
+#: ..\plugin.py:6312 ..\plugin.py:7008 ..\plugin.py:7517
 msgid "Meteo-Weather Station"
 msgstr "气象站"
 
-#: ..\plugin.py:6320 ..\plugin.py:6343 ..\plugin.py:6367 ..\plugin.py:6377
-#: ..\plugin.py:7015 ..\plugin.py:7038 ..\plugin.py:7062 ..\plugin.py:7072
-#: ..\plugin.py:7523 ..\plugin.py:7546 ..\plugin.py:7570 ..\plugin.py:7580
-#: ..\plugin_original.py:6318 ..\plugin_original.py:6341
-#: ..\plugin_original.py:6365 ..\plugin_original.py:6375
-#: ..\plugin_original.py:7013 ..\plugin_original.py:7036
-#: ..\plugin_original.py:7060 ..\plugin_original.py:7070
-#: ..\plugin_original.py:7521 ..\plugin_original.py:7544
-#: ..\plugin_original.py:7568 ..\plugin_original.py:7578
+#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6375 ..\plugin.py:6385
+#: ..\plugin.py:7024 ..\plugin.py:7047 ..\plugin.py:7071 ..\plugin.py:7081
+#: ..\plugin.py:7533 ..\plugin.py:7556 ..\plugin.py:7580 ..\plugin.py:7590
 msgid "- Station"
 msgstr "- 站"
 
-#: ..\plugin.py:6321 ..\plugin.py:6344 ..\plugin.py:7016 ..\plugin.py:7039
-#: ..\plugin.py:7524 ..\plugin.py:7547 ..\plugin_original.py:6319
-#: ..\plugin_original.py:6342 ..\plugin_original.py:7014
-#: ..\plugin_original.py:7037 ..\plugin_original.py:7522
-#: ..\plugin_original.py:7545
+#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:7025 ..\plugin.py:7048
+#: ..\plugin.py:7534 ..\plugin.py:7557
 msgid "- Module"
 msgstr "- 模块"
 
-#: ..\plugin.py:6322 ..\plugin.py:6345 ..\plugin.py:7017 ..\plugin.py:7040
-#: ..\plugin.py:7525 ..\plugin.py:7548 ..\plugin_original.py:6320
-#: ..\plugin_original.py:6343 ..\plugin_original.py:7015
-#: ..\plugin_original.py:7038 ..\plugin_original.py:7523
-#: ..\plugin_original.py:7546
+#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:7026 ..\plugin.py:7049
+#: ..\plugin.py:7535 ..\plugin.py:7558
 msgid "- Module userdefined"
 msgstr "- 未指定模块"
 
-#: ..\plugin.py:6323 ..\plugin.py:6346 ..\plugin.py:7018 ..\plugin.py:7041
-#: ..\plugin.py:7526 ..\plugin.py:7549 ..\plugin_original.py:6321
-#: ..\plugin_original.py:6344 ..\plugin_original.py:7016
-#: ..\plugin_original.py:7039 ..\plugin_original.py:7524
-#: ..\plugin_original.py:7547
+#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:7027 ..\plugin.py:7050
+#: ..\plugin.py:7536 ..\plugin.py:7559
 msgid "- Base"
 msgstr "- 基本"
 
-#: ..\plugin.py:6324 ..\plugin.py:6347 ..\plugin.py:7019 ..\plugin.py:7042
-#: ..\plugin.py:7527 ..\plugin.py:7550 ..\plugin_original.py:6322
-#: ..\plugin_original.py:6345 ..\plugin_original.py:7017
-#: ..\plugin_original.py:7040 ..\plugin_original.py:7525
-#: ..\plugin_original.py:7548
+#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:7028 ..\plugin.py:7051
+#: ..\plugin.py:7537 ..\plugin.py:7560
 msgid "- Name"
 msgstr "- 名称"
 
-#: ..\plugin.py:6328 ..\plugin.py:6351 ..\plugin.py:6562 ..\plugin.py:7023
-#: ..\plugin.py:7046 ..\plugin.py:7189 ..\plugin.py:7531 ..\plugin.py:7554
-#: ..\plugin.py:7755 ..\plugin_original.py:6326 ..\plugin_original.py:6349
-#: ..\plugin_original.py:6560 ..\plugin_original.py:7021
-#: ..\plugin_original.py:7044 ..\plugin_original.py:7187
-#: ..\plugin_original.py:7529 ..\plugin_original.py:7552
-#: ..\plugin_original.py:7753
+#: ..\plugin.py:6336 ..\plugin.py:6359 ..\plugin.py:6570 ..\plugin.py:7032
+#: ..\plugin.py:7055 ..\plugin.py:7198 ..\plugin.py:7541 ..\plugin.py:7564
+#: ..\plugin.py:7765
 msgid "- Color 1"
 msgstr "- 颜色 1"
 
-#: ..\plugin.py:6329 ..\plugin.py:6352 ..\plugin.py:6563 ..\plugin.py:7024
-#: ..\plugin.py:7047 ..\plugin.py:7190 ..\plugin.py:7532 ..\plugin.py:7555
-#: ..\plugin.py:7756 ..\plugin_original.py:6327 ..\plugin_original.py:6350
-#: ..\plugin_original.py:6561 ..\plugin_original.py:7022
-#: ..\plugin_original.py:7045 ..\plugin_original.py:7188
-#: ..\plugin_original.py:7530 ..\plugin_original.py:7553
-#: ..\plugin_original.py:7754
+#: ..\plugin.py:6337 ..\plugin.py:6360 ..\plugin.py:6571 ..\plugin.py:7033
+#: ..\plugin.py:7056 ..\plugin.py:7199 ..\plugin.py:7542 ..\plugin.py:7565
+#: ..\plugin.py:7766
 msgid "- Color 2"
 msgstr "- 颜色 2"
 
-#: ..\plugin.py:6330 ..\plugin.py:6353 ..\plugin.py:6564 ..\plugin.py:7025
-#: ..\plugin.py:7048 ..\plugin.py:7191 ..\plugin.py:7533 ..\plugin.py:7556
-#: ..\plugin.py:7757 ..\plugin_original.py:6328 ..\plugin_original.py:6351
-#: ..\plugin_original.py:6562 ..\plugin_original.py:7023
-#: ..\plugin_original.py:7046 ..\plugin_original.py:7189
-#: ..\plugin_original.py:7531 ..\plugin_original.py:7554
-#: ..\plugin_original.py:7755
+#: ..\plugin.py:6338 ..\plugin.py:6361 ..\plugin.py:6572 ..\plugin.py:7034
+#: ..\plugin.py:7057 ..\plugin.py:7200 ..\plugin.py:7543 ..\plugin.py:7566
+#: ..\plugin.py:7767
 msgid "- Color 3"
 msgstr "- 颜色 3"
 
-#: ..\plugin.py:6331 ..\plugin.py:6354 ..\plugin.py:6565 ..\plugin.py:7026
-#: ..\plugin.py:7049 ..\plugin.py:7192 ..\plugin.py:7534 ..\plugin.py:7557
-#: ..\plugin.py:7758 ..\plugin_original.py:6329 ..\plugin_original.py:6352
-#: ..\plugin_original.py:6563 ..\plugin_original.py:7024
-#: ..\plugin_original.py:7047 ..\plugin_original.py:7190
-#: ..\plugin_original.py:7532 ..\plugin_original.py:7555
-#: ..\plugin_original.py:7756
+#: ..\plugin.py:6339 ..\plugin.py:6362 ..\plugin.py:6573 ..\plugin.py:7035
+#: ..\plugin.py:7058 ..\plugin.py:7201 ..\plugin.py:7544 ..\plugin.py:7567
+#: ..\plugin.py:7768
 msgid "- Color 4"
 msgstr "- 颜色 4"
 
-#: ..\plugin.py:6332 ..\plugin.py:6355 ..\plugin.py:6566 ..\plugin.py:7027
-#: ..\plugin.py:7050 ..\plugin.py:7193 ..\plugin.py:7535 ..\plugin.py:7558
-#: ..\plugin.py:7759 ..\plugin_original.py:6330 ..\plugin_original.py:6353
-#: ..\plugin_original.py:6564 ..\plugin_original.py:7025
-#: ..\plugin_original.py:7048 ..\plugin_original.py:7191
-#: ..\plugin_original.py:7533 ..\plugin_original.py:7556
-#: ..\plugin_original.py:7757
+#: ..\plugin.py:6340 ..\plugin.py:6363 ..\plugin.py:6574 ..\plugin.py:7036
+#: ..\plugin.py:7059 ..\plugin.py:7202 ..\plugin.py:7545 ..\plugin.py:7568
+#: ..\plugin.py:7769
 msgid "- Color 5"
 msgstr "- 颜色 5"
 
-#: ..\plugin.py:6333 ..\plugin.py:6356 ..\plugin.py:7028 ..\plugin.py:7051
-#: ..\plugin.py:7536 ..\plugin.py:7559 ..\plugin_original.py:6331
-#: ..\plugin_original.py:6354 ..\plugin_original.py:7026
-#: ..\plugin_original.py:7049 ..\plugin_original.py:7534
-#: ..\plugin_original.py:7557
+#: ..\plugin.py:6341 ..\plugin.py:6364 ..\plugin.py:7037 ..\plugin.py:7060
+#: ..\plugin.py:7546 ..\plugin.py:7569
 msgid "- Color 6"
 msgstr "- Spalva 6"
 
-#: ..\plugin.py:6336 ..\plugin.py:7031 ..\plugin.py:7539
-#: ..\plugin_original.py:6334 ..\plugin_original.py:7029
-#: ..\plugin_original.py:7537
+#: ..\plugin.py:6344 ..\plugin.py:7040 ..\plugin.py:7549
 msgid "Netatmo 2"
 msgstr "Netatmo 2"
 
-#: ..\plugin.py:6359 ..\plugin.py:7054 ..\plugin.py:7562
-#: ..\plugin_original.py:6357 ..\plugin_original.py:7052
-#: ..\plugin_original.py:7560
+#: ..\plugin.py:6367 ..\plugin.py:7063 ..\plugin.py:7572
 msgid "Netatmo CO2 Indicator"
 msgstr "Netatmo CO2指标"
 
-#: ..\plugin.py:6365 ..\plugin.py:6375 ..\plugin.py:7060 ..\plugin.py:7070
-#: ..\plugin.py:7568 ..\plugin.py:7578 ..\plugin_original.py:6363
-#: ..\plugin_original.py:6373 ..\plugin_original.py:7058
-#: ..\plugin_original.py:7068 ..\plugin_original.py:7566
-#: ..\plugin_original.py:7576
+#: ..\plugin.py:6373 ..\plugin.py:6383 ..\plugin.py:7069 ..\plugin.py:7079
+#: ..\plugin.py:7578 ..\plugin.py:7588
 msgid "- Length [Bar]"
 msgstr "- 长度 [Bar]"
 
-#: ..\plugin.py:6369 ..\plugin.py:7064 ..\plugin.py:7572
-#: ..\plugin_original.py:6367 ..\plugin_original.py:7062
-#: ..\plugin_original.py:7570
+#: ..\plugin.py:6377 ..\plugin.py:7073 ..\plugin.py:7582
 msgid "Netatmo Comfort Indicator"
 msgstr "Netatmo舒适度指示器"
 
-#: ..\plugin.py:6379 ..\plugin.py:7074 ..\plugin.py:7582
-#: ..\plugin_original.py:6377 ..\plugin_original.py:7072
-#: ..\plugin_original.py:7580
+#: ..\plugin.py:6387 ..\plugin.py:7083 ..\plugin.py:7592
 msgid "Moonphase"
 msgstr "月相"
 
-#: ..\plugin.py:6386 ..\plugin.py:7081 ..\plugin.py:7082 ..\plugin.py:7589
-#: ..\plugin_original.py:6384 ..\plugin_original.py:7079
-#: ..\plugin_original.py:7080 ..\plugin_original.py:7587
+#: ..\plugin.py:6394 ..\plugin.py:7090 ..\plugin.py:7091 ..\plugin.py:7599
 msgid "- Infolines"
 msgstr "- 线"
 
-#: ..\plugin.py:6387 ..\plugin.py:7590 ..\plugin_original.py:6385
-#: ..\plugin_original.py:7588
+#: ..\plugin.py:6395 ..\plugin.py:7600
 msgid "- Trendarrows"
 msgstr "- 趋势箭头"
 
-#: ..\plugin.py:6392 ..\plugin.py:7087 ..\plugin.py:7595
-#: ..\plugin_original.py:6390 ..\plugin_original.py:7085
-#: ..\plugin_original.py:7593
+#: ..\plugin.py:6400 ..\plugin.py:7096 ..\plugin.py:7605
 msgid "Sunrise"
 msgstr "日出"
 
-#: ..\plugin.py:6404 ..\plugin.py:7158 ..\plugin.py:7607
-#: ..\plugin_original.py:6402 ..\plugin_original.py:7156
-#: ..\plugin_original.py:7605
+#: ..\plugin.py:6412 ..\plugin.py:7167 ..\plugin.py:7617
 msgid "Show oscam.lcd"
 msgstr "显示oscam.lcd"
 
-#: ..\plugin.py:6407 ..\plugin.py:6426 ..\plugin.py:6437 ..\plugin.py:6448
-#: ..\plugin.py:6513 ..\plugin.py:6523 ..\plugin.py:6533 ..\plugin.py:7102
-#: ..\plugin.py:7113 ..\plugin.py:7619 ..\plugin.py:7630 ..\plugin.py:7641
-#: ..\plugin.py:7706 ..\plugin.py:7716 ..\plugin.py:7726
-#: ..\plugin_original.py:6405 ..\plugin_original.py:6424
-#: ..\plugin_original.py:6435 ..\plugin_original.py:6446
-#: ..\plugin_original.py:6511 ..\plugin_original.py:6521
-#: ..\plugin_original.py:6531 ..\plugin_original.py:7100
-#: ..\plugin_original.py:7111 ..\plugin_original.py:7617
-#: ..\plugin_original.py:7628 ..\plugin_original.py:7639
-#: ..\plugin_original.py:7704 ..\plugin_original.py:7714
-#: ..\plugin_original.py:7724
+#: ..\plugin.py:6415 ..\plugin.py:6434 ..\plugin.py:6445 ..\plugin.py:6456
+#: ..\plugin.py:6521 ..\plugin.py:6531 ..\plugin.py:6541 ..\plugin.py:7111
+#: ..\plugin.py:7122 ..\plugin.py:7629 ..\plugin.py:7640 ..\plugin.py:7651
+#: ..\plugin.py:7716 ..\plugin.py:7726 ..\plugin.py:7736
 msgid "- File [ok]>"
 msgstr "- 文件路 [ok]>"
 
-#: ..\plugin.py:6414 ..\plugin_original.py:6412
+#: ..\plugin.py:6422
 msgid "Show ecm.info"
 msgstr "显示ecm.info"
 
-#: ..\plugin.py:6423 ..\plugin.py:7099 ..\plugin.py:7616
-#: ..\plugin_original.py:6421 ..\plugin_original.py:7097
-#: ..\plugin_original.py:7614
+#: ..\plugin.py:6431 ..\plugin.py:7108 ..\plugin.py:7626
 msgid "Show Textfile"
 msgstr "显示文本文件"
 
-#: ..\plugin.py:6434 ..\plugin.py:7110 ..\plugin.py:7627
-#: ..\plugin_original.py:6432 ..\plugin_original.py:7108
-#: ..\plugin_original.py:7625
+#: ..\plugin.py:6442 ..\plugin.py:7119 ..\plugin.py:7637
 msgid "Show Textfile 2"
 msgstr "显示文本文件2"
 
-#: ..\plugin.py:6445 ..\plugin.py:7638 ..\plugin_original.py:6443
-#: ..\plugin_original.py:7636
+#: ..\plugin.py:6453 ..\plugin.py:7648
 msgid "Show Textfile 3"
 msgstr "显示文本文件3"
 
-#: ..\plugin.py:6456 ..\plugin.py:7649 ..\plugin_original.py:6454
-#: ..\plugin_original.py:7647
+#: ..\plugin.py:6464 ..\plugin.py:7659
 msgid "Show HTTP Text"
 msgstr "显示HTTP文本"
 
-#: ..\plugin.py:6459 ..\plugin.py:6473 ..\plugin.py:7652 ..\plugin.py:7666
-#: ..\plugin_original.py:6457 ..\plugin_original.py:6471
-#: ..\plugin_original.py:7650 ..\plugin_original.py:7664
+#: ..\plugin.py:6467 ..\plugin.py:6481 ..\plugin.py:7662 ..\plugin.py:7676
 msgid "- URL"
 msgstr "- URL"
 
-#: ..\plugin.py:6467 ..\plugin.py:7660 ..\plugin_original.py:6465
-#: ..\plugin_original.py:7658
+#: ..\plugin.py:6475 ..\plugin.py:7670
 msgid "WWW-Internet Converter"
 msgstr "WWW网络转换器"
 
-#: ..\plugin.py:6474 ..\plugin.py:7667 ..\plugin_original.py:6472
-#: ..\plugin_original.py:7665
+#: ..\plugin.py:6482 ..\plugin.py:7677
 msgid "- HTTP Width"
 msgstr "- HTTP宽度"
 
-#: ..\plugin.py:6475 ..\plugin.py:7668 ..\plugin_original.py:6473
-#: ..\plugin_original.py:7666
+#: ..\plugin.py:6483 ..\plugin.py:7678
 msgid "- HTTP Height"
 msgstr "- HTTP高度"
 
-#: ..\plugin.py:6476 ..\plugin.py:7669 ..\plugin_original.py:6474
-#: ..\plugin_original.py:7667
+#: ..\plugin.py:6484 ..\plugin.py:7679
 msgid "- Cut from X"
 msgstr "- 从X剪切"
 
-#: ..\plugin.py:6477 ..\plugin.py:7670 ..\plugin_original.py:6475
-#: ..\plugin_original.py:7668
+#: ..\plugin.py:6485 ..\plugin.py:7680
 msgid "- Cut from Y"
 msgstr "- 从Y剪切"
 
-#: ..\plugin.py:6478 ..\plugin.py:7671 ..\plugin_original.py:6476
-#: ..\plugin_original.py:7669
+#: ..\plugin.py:6486 ..\plugin.py:7681
 msgid "- Cut Width [disable = 0]"
 msgstr "- 剪切宽度[禁用= 0]"
 
-#: ..\plugin.py:6479 ..\plugin.py:7672 ..\plugin_original.py:6477
-#: ..\plugin_original.py:7670
+#: ..\plugin.py:6487 ..\plugin.py:7682
 msgid "- Cut Height [disable = 0]"
 msgstr "- 剪切高度[禁用= 0]"
 
-#: ..\plugin.py:6480 ..\plugin.py:7121 ..\plugin.py:7673
-#: ..\plugin_original.py:6478 ..\plugin_original.py:7119
-#: ..\plugin_original.py:7671
+#: ..\plugin.py:6488 ..\plugin.py:7130 ..\plugin.py:7683
 msgid "Show Picture"
 msgstr "显示图片"
 
-#: ..\plugin.py:6483 ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:7124
-#: ..\plugin.py:7134 ..\plugin.py:7676 ..\plugin.py:7686 ..\plugin.py:7696
-#: ..\plugin_original.py:6481 ..\plugin_original.py:6491
-#: ..\plugin_original.py:6501 ..\plugin_original.py:7122
-#: ..\plugin_original.py:7132 ..\plugin_original.py:7674
-#: ..\plugin_original.py:7684 ..\plugin_original.py:7694
+#: ..\plugin.py:6491 ..\plugin.py:6501 ..\plugin.py:6511 ..\plugin.py:7133
+#: ..\plugin.py:7143 ..\plugin.py:7686 ..\plugin.py:7696 ..\plugin.py:7706
 msgid "- File or Path [ok]>"
 msgstr "- 文件或路径[ok]>"
 
-#: ..\plugin.py:6485 ..\plugin.py:6495 ..\plugin.py:6505 ..\plugin.py:6515
-#: ..\plugin.py:6525 ..\plugin.py:6535 ..\plugin.py:7126 ..\plugin.py:7136
-#: ..\plugin.py:7145 ..\plugin.py:7678 ..\plugin.py:7688 ..\plugin.py:7698
-#: ..\plugin.py:7708 ..\plugin.py:7718 ..\plugin.py:7728
-#: ..\plugin_original.py:6483 ..\plugin_original.py:6493
-#: ..\plugin_original.py:6503 ..\plugin_original.py:6513
-#: ..\plugin_original.py:6523 ..\plugin_original.py:6533
-#: ..\plugin_original.py:7124 ..\plugin_original.py:7134
-#: ..\plugin_original.py:7143 ..\plugin_original.py:7676
-#: ..\plugin_original.py:7686 ..\plugin_original.py:7696
-#: ..\plugin_original.py:7706 ..\plugin_original.py:7716
-#: ..\plugin_original.py:7726
+#: ..\plugin.py:6493 ..\plugin.py:6503 ..\plugin.py:6513 ..\plugin.py:6523
+#: ..\plugin.py:6533 ..\plugin.py:6543 ..\plugin.py:7135 ..\plugin.py:7145
+#: ..\plugin.py:7154 ..\plugin.py:7688 ..\plugin.py:7698 ..\plugin.py:7708
+#: ..\plugin.py:7718 ..\plugin.py:7728 ..\plugin.py:7738
 msgid "- Size max Height"
 msgstr "- 最大尺寸高度"
 
-#: ..\plugin.py:6488 ..\plugin.py:6498 ..\plugin.py:6508 ..\plugin.py:6518
-#: ..\plugin.py:6528 ..\plugin.py:6538 ..\plugin.py:7129 ..\plugin.py:7139
-#: ..\plugin.py:7681 ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711
-#: ..\plugin.py:7721 ..\plugin.py:7731 ..\plugin_original.py:6486
-#: ..\plugin_original.py:6496 ..\plugin_original.py:6506
-#: ..\plugin_original.py:6516 ..\plugin_original.py:6526
-#: ..\plugin_original.py:6536 ..\plugin_original.py:7127
-#: ..\plugin_original.py:7137 ..\plugin_original.py:7679
-#: ..\plugin_original.py:7689 ..\plugin_original.py:7699
-#: ..\plugin_original.py:7709 ..\plugin_original.py:7719
-#: ..\plugin_original.py:7729
+#: ..\plugin.py:6496 ..\plugin.py:6506 ..\plugin.py:6516 ..\plugin.py:6526
+#: ..\plugin.py:6536 ..\plugin.py:6546 ..\plugin.py:7138 ..\plugin.py:7148
+#: ..\plugin.py:7691 ..\plugin.py:7701 ..\plugin.py:7711 ..\plugin.py:7721
+#: ..\plugin.py:7731 ..\plugin.py:7741
 msgid "- Quick Update"
 msgstr "- 快速更新"
 
-#: ..\plugin.py:6490 ..\plugin.py:7131 ..\plugin.py:7683
-#: ..\plugin_original.py:6488 ..\plugin_original.py:7129
-#: ..\plugin_original.py:7681
+#: ..\plugin.py:6498 ..\plugin.py:7140 ..\plugin.py:7693
 msgid "Show Picture 2"
 msgstr "显示图片2"
 
-#: ..\plugin.py:6500 ..\plugin.py:7693 ..\plugin_original.py:6498
-#: ..\plugin_original.py:7691
+#: ..\plugin.py:6508 ..\plugin.py:7703
 msgid "Show Picture 3"
 msgstr "显示图片3"
 
-#: ..\plugin.py:6510 ..\plugin.py:7703 ..\plugin_original.py:6508
-#: ..\plugin_original.py:7701
+#: ..\plugin.py:6518 ..\plugin.py:7713
 msgid "Show Picture 4"
 msgstr "显示图片4"
 
-#: ..\plugin.py:6520 ..\plugin.py:7713 ..\plugin_original.py:6518
-#: ..\plugin_original.py:7711
+#: ..\plugin.py:6528 ..\plugin.py:7723
 msgid "Show Picture 5"
 msgstr "显示图片5"
 
-#: ..\plugin.py:6530 ..\plugin.py:7723 ..\plugin_original.py:6528
-#: ..\plugin_original.py:7721
+#: ..\plugin.py:6538 ..\plugin.py:7733
 msgid "Show Picture 6"
 msgstr "显示图片6"
 
-#: ..\plugin.py:6549 ..\plugin.py:7176 ..\plugin.py:7742
-#: ..\plugin_original.py:6547 ..\plugin_original.py:7174
-#: ..\plugin_original.py:7740
+#: ..\plugin.py:6557 ..\plugin.py:7185 ..\plugin.py:7752
 msgid "- Lines"
 msgstr "- 线"
 
-#: ..\plugin.py:6550 ..\plugin.py:7177 ..\plugin.py:7743
-#: ..\plugin_original.py:6548 ..\plugin_original.py:7175
-#: ..\plugin_original.py:7741
+#: ..\plugin.py:6558 ..\plugin.py:7186 ..\plugin.py:7753
 msgid "- Mail Konto"
 msgstr "- 邮件帐户"
 
-#: ..\plugin.py:6552 ..\plugin.py:6561 ..\plugin.py:6620 ..\plugin.py:7179
-#: ..\plugin.py:7188 ..\plugin.py:7247 ..\plugin.py:7745 ..\plugin.py:7754
-#: ..\plugin.py:7813 ..\plugin_original.py:6550 ..\plugin_original.py:6559
-#: ..\plugin_original.py:6618 ..\plugin_original.py:7177
-#: ..\plugin_original.py:7186 ..\plugin_original.py:7245
-#: ..\plugin_original.py:7743 ..\plugin_original.py:7752
-#: ..\plugin_original.py:7811
+#: ..\plugin.py:6560 ..\plugin.py:6569 ..\plugin.py:6628 ..\plugin.py:7188
+#: ..\plugin.py:7197 ..\plugin.py:7256 ..\plugin.py:7755 ..\plugin.py:7764
+#: ..\plugin.py:7823
 msgid "- max Width"
 msgstr "- 最大宽度"
 
-#: ..\plugin.py:6570 ..\plugin.py:7197 ..\plugin.py:7763
-#: ..\plugin_original.py:6568 ..\plugin_original.py:7195
-#: ..\plugin_original.py:7761
+#: ..\plugin.py:6578 ..\plugin.py:7206 ..\plugin.py:7773
 msgid "Remote Box Timer"
 msgstr "遥控盒定时器"
 
-#: ..\plugin.py:6592 ..\plugin.py:7219 ..\plugin.py:7785
-#: ..\plugin_original.py:6590 ..\plugin_original.py:7217
-#: ..\plugin_original.py:7783
+#: ..\plugin.py:6600 ..\plugin.py:7228 ..\plugin.py:7795
 msgid "- Picture Size"
 msgstr "- 图片尺寸"
 
-#: ..\plugin.py:6593 ..\plugin.py:7220 ..\plugin.py:7786
-#: ..\plugin_original.py:6591 ..\plugin_original.py:7218
-#: ..\plugin_original.py:7784
+#: ..\plugin.py:6601 ..\plugin.py:7229 ..\plugin.py:7796
 msgid "- Picture Position"
 msgstr "- 图片位置"
 
-#: ..\plugin.py:6594 ..\plugin.py:7221 ..\plugin.py:7787
-#: ..\plugin_original.py:6592 ..\plugin_original.py:7219
-#: ..\plugin_original.py:7785
+#: ..\plugin.py:6602 ..\plugin.py:7230 ..\plugin.py:7797
 msgid "- Picture Alignment"
 msgstr "- 图片对齐"
 
-#: ..\plugin.py:6606 ..\plugin.py:7233 ..\plugin.py:7799
-#: ..\plugin_original.py:6604 ..\plugin_original.py:7231
-#: ..\plugin_original.py:7797
+#: ..\plugin.py:6614 ..\plugin.py:7242 ..\plugin.py:7809
 msgid "- Layout"
 msgstr "- 布局"
 
-#: ..\plugin.py:6608 ..\plugin.py:7235 ..\plugin.py:7801
-#: ..\plugin_original.py:6606 ..\plugin_original.py:7233
-#: ..\plugin_original.py:7799
+#: ..\plugin.py:6616 ..\plugin.py:7244 ..\plugin.py:7811
 msgid "- Current Day Background Color"
 msgstr "- 当前日期背景色"
 
-#: ..\plugin.py:6609 ..\plugin.py:7236 ..\plugin.py:7802
-#: ..\plugin_original.py:6607 ..\plugin_original.py:7234
-#: ..\plugin_original.py:7800
+#: ..\plugin.py:6617 ..\plugin.py:7245 ..\plugin.py:7812
 msgid "- Caption Color"
 msgstr "- 标题颜色"
 
-#: ..\plugin.py:6612 ..\plugin.py:7239 ..\plugin.py:7805
-#: ..\plugin_original.py:6610 ..\plugin_original.py:7237
-#: ..\plugin_original.py:7803
+#: ..\plugin.py:6620 ..\plugin.py:7248 ..\plugin.py:7815
 msgid "Dates List"
 msgstr "日期列表"
 
-#: ..\plugin.py:6625 ..\plugin.py:7252 ..\plugin.py:7818
-#: ..\plugin_original.py:6623 ..\plugin_original.py:7250
-#: ..\plugin_original.py:7816
+#: ..\plugin.py:6633 ..\plugin.py:7261 ..\plugin.py:7828
 msgid "Event Icon Bar"
 msgstr "事件图标栏"
 
-#: ..\plugin.py:6633 ..\plugin.py:7260 ..\plugin.py:7826
-#: ..\plugin_original.py:6631 ..\plugin_original.py:7258
-#: ..\plugin_original.py:7824
+#: ..\plugin.py:6641 ..\plugin.py:7269 ..\plugin.py:7836
 msgid "- Popup Screen"
 msgstr "- 弹出式屏幕"
 
-#: ..\plugin.py:6634 ..\plugin.py:7261 ..\plugin.py:7827
-#: ..\plugin_original.py:6632 ..\plugin_original.py:7259
-#: ..\plugin_original.py:7825
+#: ..\plugin.py:6642 ..\plugin.py:7270 ..\plugin.py:7837
 msgid "- Popup LCD"
 msgstr "- 弹出式LCD"
 
-#: ..\plugin.py:6635 ..\plugin.py:7262 ..\plugin.py:7828
-#: ..\plugin_original.py:6633 ..\plugin_original.py:7260
-#: ..\plugin_original.py:7826
+#: ..\plugin.py:6643 ..\plugin.py:7271 ..\plugin.py:7838
 msgid "Show Text 1"
 msgstr "显示文字1"
 
-#: ..\plugin.py:6638 ..\plugin.py:6650 ..\plugin.py:7265 ..\plugin.py:7277
-#: ..\plugin.py:7831 ..\plugin.py:7843 ..\plugin_original.py:6636
-#: ..\plugin_original.py:6648 ..\plugin_original.py:7263
-#: ..\plugin_original.py:7275 ..\plugin_original.py:7829
-#: ..\plugin_original.py:7841
+#: ..\plugin.py:6646 ..\plugin.py:6658 ..\plugin.py:7274 ..\plugin.py:7286
+#: ..\plugin.py:7841 ..\plugin.py:7853
 msgid "- Text"
 msgstr "- 文本"
 
-#: ..\plugin.py:6647 ..\plugin.py:7274 ..\plugin.py:7840
-#: ..\plugin_original.py:6645 ..\plugin_original.py:7272
-#: ..\plugin_original.py:7838
+#: ..\plugin.py:6655 ..\plugin.py:7283 ..\plugin.py:7850
 msgid "Show Text 2"
 msgstr "显示文字2"
 
-#: ..\plugin.py:6659 ..\plugin.py:7286 ..\plugin.py:7852
-#: ..\plugin_original.py:6657 ..\plugin_original.py:7284
-#: ..\plugin_original.py:7850
+#: ..\plugin.py:6667 ..\plugin.py:7295 ..\plugin.py:7862
 msgid "Rectangle 1"
 msgstr "矩形1"
 
-#: ..\plugin.py:6662 ..\plugin.py:6671 ..\plugin.py:7289 ..\plugin.py:7298
-#: ..\plugin.py:7855 ..\plugin.py:7864 ..\plugin_original.py:6660
-#: ..\plugin_original.py:6669 ..\plugin_original.py:7287
-#: ..\plugin_original.py:7296 ..\plugin_original.py:7853
-#: ..\plugin_original.py:7862
+#: ..\plugin.py:6670 ..\plugin.py:6679 ..\plugin.py:7298 ..\plugin.py:7307
+#: ..\plugin.py:7865 ..\plugin.py:7874
 msgid "- Position x"
 msgstr "- 位置x"
 
-#: ..\plugin.py:6663 ..\plugin.py:6672 ..\plugin.py:7290 ..\plugin.py:7299
-#: ..\plugin.py:7856 ..\plugin.py:7865 ..\plugin_original.py:6661
-#: ..\plugin_original.py:6670 ..\plugin_original.py:7288
-#: ..\plugin_original.py:7297 ..\plugin_original.py:7854
-#: ..\plugin_original.py:7863
+#: ..\plugin.py:6671 ..\plugin.py:6680 ..\plugin.py:7299 ..\plugin.py:7308
+#: ..\plugin.py:7866 ..\plugin.py:7875
 msgid "- Position y"
 msgstr "- 位置y"
 
-#: ..\plugin.py:6664 ..\plugin.py:6673 ..\plugin.py:7291 ..\plugin.py:7300
-#: ..\plugin.py:7857 ..\plugin.py:7866 ..\plugin_original.py:6662
-#: ..\plugin_original.py:6671 ..\plugin_original.py:7289
-#: ..\plugin_original.py:7298 ..\plugin_original.py:7855
-#: ..\plugin_original.py:7864
+#: ..\plugin.py:6672 ..\plugin.py:6681 ..\plugin.py:7300 ..\plugin.py:7309
+#: ..\plugin.py:7867 ..\plugin.py:7876
 msgid "- Size x"
 msgstr "- 尺寸x"
 
-#: ..\plugin.py:6665 ..\plugin.py:6674 ..\plugin.py:7292 ..\plugin.py:7301
-#: ..\plugin.py:7858 ..\plugin.py:7867 ..\plugin_original.py:6663
-#: ..\plugin_original.py:6672 ..\plugin_original.py:7290
-#: ..\plugin_original.py:7299 ..\plugin_original.py:7856
-#: ..\plugin_original.py:7865
+#: ..\plugin.py:6673 ..\plugin.py:6682 ..\plugin.py:7301 ..\plugin.py:7310
+#: ..\plugin.py:7868 ..\plugin.py:7877
 msgid "- Size y"
 msgstr "- 尺寸y"
 
-#: ..\plugin.py:6668 ..\plugin.py:7295 ..\plugin.py:7861
-#: ..\plugin_original.py:6666 ..\plugin_original.py:7293
-#: ..\plugin_original.py:7859
+#: ..\plugin.py:6676 ..\plugin.py:7304 ..\plugin.py:7871
 msgid "Rectangle 2"
 msgstr "矩形2"
 
-#: ..\plugin.py:6677 ..\plugin.py:7304 ..\plugin.py:7870
-#: ..\plugin_original.py:6675 ..\plugin_original.py:7302
-#: ..\plugin_original.py:7868
+#: ..\plugin.py:6685 ..\plugin.py:7313 ..\plugin.py:7880
 msgid "Recording"
 msgstr "录像"
 
-#: ..\plugin.py:6686 ..\plugin_original.py:6684
+#: ..\plugin.py:6694
 msgid "Stutter TV"
 msgstr "卡顿电视"
 
-#: ..\plugin.py:6706 ..\plugin.py:7334 ..\plugin_original.py:6704
-#: ..\plugin_original.py:7332
+#: ..\plugin.py:6715 ..\plugin.py:7344
 msgid "- Screens used for Changing"
 msgstr "- 用于更改的屏幕"
 
-#: ..\plugin.py:6712 ..\plugin_original.py:6710
+#: ..\plugin.py:6721
 msgid "Title"
 msgstr "标题"
 
-#: ..\plugin.py:6724 ..\plugin_original.py:6722
+#: ..\plugin.py:6733
 msgid "Infos"
 msgstr "系统信息"
 
-#: ..\plugin.py:7141 ..\plugin_original.py:7139
+#: ..\plugin.py:7150
 msgid "Show Cover"
 msgstr "显示封面"
 
-#: ..\plugin.py:7148 ..\plugin.py:7149 ..\plugin_original.py:7146
-#: ..\plugin_original.py:7147
+#: ..\plugin.py:7157 ..\plugin.py:7158
 msgid "- Search Path [ok]>"
 msgstr "- 搜索路径 [ok]>"
 
-#: ..\plugin.py:7150 ..\plugin_original.py:7148
+#: ..\plugin.py:7159
 msgid "- Find Cover File [ok]>"
 msgstr "- 查找封面文件[ok]>"
 
-#: ..\plugin.py:7151 ..\plugin_original.py:7149
+#: ..\plugin.py:7160
 msgid "- Default Cover [ok]>"
 msgstr "- 默认封面[确定]>"
 
-#: ..\plugin.py:7152 ..\plugin_original.py:7150
+#: ..\plugin.py:7161
 msgid "- Picon First"
 msgstr "- picon优先"
 
-#: ..\plugin.py:7154 ..\plugin_original.py:7152
+#: ..\plugin.py:7163
 msgid "- Trimmed"
 msgstr "- 修剪"
 
-#: ..\plugin.py:7155 ..\plugin_original.py:7153
+#: ..\plugin.py:7164
 msgid "- Download Cover"
 msgstr "- 下载封面"
 
-#: ..\plugin.py:7156 ..\plugin_original.py:7154
+#: ..\plugin.py:7165
 msgid "- Download Type"
 msgstr "- 下载类型"
 
-#: ..\plugin.py:7157 ..\plugin_original.py:7155
+#: ..\plugin.py:7166
 msgid "- Google API-Key console.developers.google.com/apis"
 msgstr "-Google API密钥console.developers.google.com/apis"
 
-#: ..\plugin.py:7316 ..\plugin_original.py:7314
+#: ..\plugin.py:7326
 msgid "LCD Display"
 msgstr "液晶显示屏"
 
-#: ..\plugin.py:7890 ..\plugin_original.py:7888
+#: ..\plugin.py:7900
 msgid "LCD4linux Display-Mode On"
 msgstr "LCD4linux显示模式开启"
 
-#: ..\plugin.py:7891 ..\plugin_original.py:7889
+#: ..\plugin.py:7901
 msgid "Set Media >>"
 msgstr "设置媒体 >>"
 
-#: ..\plugin.py:7895 ..\plugin_original.py:7893
+#: ..\plugin.py:7904
 msgid "LCD4linux Display-Mode MediaPlayer"
 msgstr "LCD4linux显示模式媒体播放器"
 
-#: ..\plugin.py:7896 ..\plugin_original.py:7894
+#: ..\plugin.py:7905
 msgid "Set Idle >>"
 msgstr "设置空闲 >>"
 
-#: ..\plugin.py:7900 ..\plugin_original.py:7898
+#: ..\plugin.py:7908
 msgid "LCD4linux Display-Mode Idle"
 msgstr "LCD4linux显示模式空闲"
 
-#: ..\plugin.py:7901 ..\plugin_original.py:7899
+#: ..\plugin.py:7909
 msgid "Set Global >>"
 msgstr "设置全局 >>"
 
-#: ..\plugin.py:7919 ..\plugin_original.py:7917
+#: ..\plugin.py:7926
 msgid "Choose dir"
 msgstr "选择目录"
 
-#: ..\plugin.py:7922 ..\plugin.py:7925 ..\plugin.py:7931 ..\plugin.py:7934
-#: ..\plugin_original.py:7920 ..\plugin_original.py:7923
-#: ..\plugin_original.py:7929 ..\plugin_original.py:7932
+#: ..\plugin.py:7929 ..\plugin.py:7932 ..\plugin.py:7938 ..\plugin.py:7941
 msgid "Choose file"
 msgstr "选择文件"
 
-#: ..\plugin.py:7928 ..\plugin_original.py:7926
+#: ..\plugin.py:7935
 msgid "Choose font"
 msgstr "选择字体"
 
-#: ..\plugin.py:8099 ..\plugin_original.py:8097
+#: ..\plugin.py:8106
 msgid "%s - Current value: %s"
 msgstr "%s - 当前值：%s"
 
-#: ..\plugin.py:8241 ..\plugin_original.py:8239
+#: ..\plugin.py:8249
 msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
@@ -5259,114 +4131,94 @@ msgstr ""
 "需要重新启动图形用户界面以应用新的皮肤。\n"
 "是否要现在重新启动图形用户界面？"
 
-#: ..\plugin.py:8242 ..\plugin_original.py:8240
+#: ..\plugin.py:8250
 msgid "Restart GUI now?"
 msgstr "重新启动GUI吗?"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Indoor"
 msgstr "室内"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Outdoor"
 msgstr "室外"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Rain"
 msgstr "雨"
 
-#: ..\plugin.py:8798 ..\plugin_original.py:8796
+#: ..\plugin.py:8778
 msgid "Wind"
 msgstr "风向"
 
-#: ..\plugin.py:10683 ..\plugin_original.py:10681
+#: ..\plugin.py:10663
 msgid "New Moon"
 msgstr "新月"
 
-#: ..\plugin.py:10684 ..\plugin_original.py:10682
+#: ..\plugin.py:10664
 msgid "First Quarter"
 msgstr "第一季度"
 
-#: ..\plugin.py:10685 ..\plugin_original.py:10683
+#: ..\plugin.py:10665
 msgid "Waxing Crescent"
 msgstr "娥眉月"
 
-#: ..\plugin.py:10686 ..\plugin_original.py:10684
+#: ..\plugin.py:10666
 msgid "Waxing Moon"
 msgstr "月相"
 
-#: ..\plugin.py:10687 ..\plugin_original.py:10685
+#: ..\plugin.py:10667
 msgid "Full Moon"
 msgstr "满月"
 
-#: ..\plugin.py:10688 ..\plugin_original.py:10686
+#: ..\plugin.py:10668
 msgid "Waning Moon"
 msgstr "残月"
 
-#: ..\plugin.py:10689 ..\plugin_original.py:10687
+#: ..\plugin.py:10669
 msgid "Waning Crescent"
 msgstr "残月"
 
-#: ..\plugin.py:10690 ..\plugin_original.py:10688
+#: ..\plugin.py:10670
 msgid "Last Quarter"
 msgstr "第四季度"
 
-#: ..\plugin.py:11743 ..\plugin.py:11812 ..\plugin.py:11829 ..\plugin.py:11838
-#: ..\plugin_original.py:11741 ..\plugin_original.py:11810
-#: ..\plugin_original.py:11827 ..\plugin_original.py:11836
+#: ..\plugin.py:11723 ..\plugin.py:11792 ..\plugin.py:11809 ..\plugin.py:11818
 msgid "%d.%m.%Y"
 msgstr "%Y.%m.%d"
 
-#: ..\plugin.py:12011 ..\plugin_original.py:12009
+#: ..\plugin.py:11991
 msgid "Picture not available"
 msgstr "图片不可用"
 
-#: ..\plugin.py:12161 ..\plugin.py:12162 ..\plugin_original.py:12159
-#: ..\plugin_original.py:12160
+#: ..\plugin.py:12141 ..\plugin.py:12142
 msgid "no Timer"
 msgstr "没有计时器"
 
-#: ..\plugin.py:13411 ..\plugin.py:13414 ..\plugin_original.py:13409
-#: ..\plugin_original.py:13412
+#: ..\plugin.py:13391 ..\plugin.py:13394
 msgid "OSCAM not running"
 msgstr "OSCAM未运行"
 
-#: ..\plugin.py:13761 ..\plugin_original.py:13759
+#: ..\plugin.py:13741
 msgid "no Calls"
 msgstr "没有呼叫"
 
-#: ..\plugin.py:13797 ..\plugin_original.py:13795
+#: ..\plugin.py:13777
 msgid "%d Mails  %d New  %s"
 msgstr "%d 封邮件 %d 封新邮件 %s"
 
-#: ..\plugin.py:13997 ..\plugin_original.py:13995
+#: ..\plugin.py:13977
 msgid "no Netatmo-Plugin installed"
 msgstr "未安装Netatmo插件"
 
-#: ..\plugin.py:15672 ..\plugin.py:15673 ..\plugin_original.py:15669
-#: ..\plugin_original.py:15670
+#: ..\plugin.py:15652 ..\plugin.py:15653
 msgid "LCD4linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15674 ..\plugin_original.py:15671
+#: ..\plugin.py:15654
 msgid "LCD4Linux"
 msgstr "LCD4linux"
 
-#: ..\plugin.py:15675 ..\plugin_original.py:15672
+#: ..\plugin.py:15655
 msgid "LCD4linux Screen Switch"
 msgstr "LCD4linux屏幕开关"
-
-#~ msgid "yes (32bit)"
-#~ msgstr "是（32位）"
-
-#~ msgid "arrow + text"
-#~ msgstr "箭头+文字"
-
-#~ msgid "only arrow"
-#~ msgstr "只有箭头"
-
-#~ msgid "only text"
-#~ msgstr "只有文本"
-
-#~ msgid "Weather Wind direction"
-#~ msgstr "天气 风向"

--- a/LCD4linux/src/plugin.py
+++ b/LCD4linux/src/plugin.py
@@ -176,7 +176,7 @@ elif ARCH in ("aarch64"):
 	get_backend(find_library=lambda x: "/lib64/libusb-1.0.so.0")
 	print("[LCD4linux] libusb found :-)", getEnigmaVersionString())
 	USBok = True
-Version = "V5.0-r32"
+Version = "V5.0-r33"
 L4LElist = L4Lelement()
 L4LdoThread = True
 LCD4enigma2config = resolveFilename(SCOPE_CONFIG)  # /etc/enigma2/
@@ -5581,7 +5581,6 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 		self.mode = _("Idle")
 		self.LastSelect = "5"
 		self.Page()
-		self.selectionChanged()
 
 	def NextScreenKey(self):
 		NextScreen(True)
@@ -5738,7 +5737,6 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 				self.list1.append(getConfigListEntry(_("Box-Skin-LCD Enable Media-Mode"), LCD4linux.xmlType02))
 				self.list1.append(getConfigListEntry(_("Box-Skin-LCD Enable Idle-Mode"), LCD4linux.xmlType03))
 			self.list1.append(getConfigListEntry(_("OSD [display time]"), LCD4linux.OSD))
-
 			if LCD4linux.OSD.value != "0":
 				self.list1.append(getConfigListEntry(_("- which LCD"), LCD4linux.OSDLCD))
 				self.list1.append(getConfigListEntry(_("- Show in Mode"), LCD4linux.OSDshow))
@@ -5948,6 +5946,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			self.list1.append(getConfigListEntry(_("Config Restore All Settings"), LCD4linux.ConfigWriteAll))
 			self.list1.append(getConfigListEntry(_("Debug-Logging > /tmp/L4log.txt"), LCD4linux.EnableEventLog))
 			self["config"].setList(self.list1)
+
 		elif self.mode == _("On"):
 			self.list2 = []
 			self.list2.append(getConfigListEntry(_("- Backlight Off [disable set Off=On]"), LCD4linux.LCDoff))
@@ -6697,6 +6696,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 				self.list2.append(getConfigListEntry(_("- which LCD"), LCD4linux.TVLCD))
 				self.list2.append(getConfigListEntry(_("- Type"), LCD4linux.TVType))
 			self["config"].setList(self.list2)
+
 		elif self.mode == _("Media"):
 			self.list3 = []
 			self.list3.append(getConfigListEntry(_("- LCD 1 Background Color"), LCD4linux.MPLCDColor1))
@@ -6830,7 +6830,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			self.list3.append(getConfigListEntry(_("Clock"), LCD4linux.MPClock))
 			if LCD4linux.MPClock.value != "0":
 				self.list3.append(getConfigListEntry(_("- which LCD"), LCD4linux.MPClockLCD))
-				self.list3.append(getConfigListEntry(_("- Type"), LCD4linux.MPClockType))
+				self.list3.append(getConfigListEntry(_("-  Type"), LCD4linux.MPClockType))
 				if LCD4linux.MPClockType.value[0] == "5":
 					self.list3.append(getConfigListEntry(_("- Analog Clock"), LCD4linux.MPClockAnalog))
 				elif LCD4linux.MPClockType.value[0] == "1":
@@ -6845,7 +6845,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			self.list3.append(getConfigListEntry(_("Clock 2"), LCD4linux.MPClock2))
 			if LCD4linux.MPClock2.value != "0":
 				self.list3.append(getConfigListEntry(_("- which LCD"), LCD4linux.MPClock2LCD))
-				self.list3.append(getConfigListEntry(_("- Type"), LCD4linux.MPClock2Type))
+				self.list3.append(getConfigListEntry(_("-  Type"), LCD4linux.MPClock2Type))
 				if LCD4linux.MPClock2Type.value[0] == "5":
 					self.list3.append(getConfigListEntry(_("- Analog Clock"), LCD4linux.MPClock2Analog))
 				elif LCD4linux.MPClock2Type.value[0] == "1":
@@ -7320,6 +7320,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 					self.list3.append(getConfigListEntry(_("- Alignment"), LCD4linux.MPRecordingAlign))
 					self.list3.append(getConfigListEntry(_("- Split Screen"), LCD4linux.MPRecordingSplit))
 			self["config"].setList(self.list3)
+
 		elif self.mode == _("Idle"):
 			self.list4 = []
 			self.list4.append(getConfigListEntry(_("LCD Display"), LCD4linux.Standby))
@@ -7359,7 +7360,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			self.list4.append(getConfigListEntry(_("Clock"), LCD4linux.StandbyClock))
 			if LCD4linux.StandbyClock.value != "0":
 				self.list4.append(getConfigListEntry(_("- which LCD"), LCD4linux.StandbyClockLCD))
-				self.list4.append(getConfigListEntry(_("- Type"), LCD4linux.StandbyClockType))
+				self.list4.append(getConfigListEntry(_("-  Type"), LCD4linux.StandbyClockType))
 				if LCD4linux.StandbyClockType.value[0] == "5":
 					self.list4.append(getConfigListEntry(_("- Analog Clock"), LCD4linux.StandbyClockAnalog))
 				elif LCD4linux.StandbyClockType.value[0] == "1":
@@ -7374,7 +7375,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			self.list4.append(getConfigListEntry(_("Clock 2"), LCD4linux.StandbyClock2))
 			if LCD4linux.StandbyClock2.value != "0":
 				self.list4.append(getConfigListEntry(_("- which LCD"), LCD4linux.StandbyClock2LCD))
-				self.list4.append(getConfigListEntry(_("- Type"), LCD4linux.StandbyClock2Type))
+				self.list4.append(getConfigListEntry(_("-  Type"), LCD4linux.StandbyClock2Type))
 				if LCD4linux.StandbyClock2Type.value[0] == "5":
 					self.list4.append(getConfigListEntry(_("- Analog Clock"), LCD4linux.StandbyClock2Analog))
 				elif LCD4linux.StandbyClock2Type.value[0] == "1":
@@ -7898,22 +7899,20 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			self.mode = _("On")
 			self.setTitle(_("LCD4linux Display-Mode On"))
 			self["key_blue"].setText(_("Set Media >>"))
-			self.SetList()
 		elif self.mode == _("On"):
 			self.mode = _("Media")
 			self.setTitle(_("LCD4linux Display-Mode MediaPlayer"))
 			self["key_blue"].setText(_("Set Idle >>"))
-			self.SetList()
 		elif self.mode == _("Media"):
 			self.mode = _("Idle")
 			self.setTitle(_("LCD4linux Display-Mode Idle"))
 			self["key_blue"].setText(_("Set Global >>"))
-			self.SetList()
 		elif self.mode == _("Idle"):
 			self.mode = _("Global")
 			self.setTitle(_("LCD4linux Settings"))
 			self["key_blue"].setText(_("Set On >>"))
-			self.SetList()
+		self.SetList()
+		self.selectionChanged()
 		getBilder()
 		self.toggle = time()
 
@@ -7926,7 +7925,7 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 			if sel in [LCD4linux.PiconPath, LCD4linux.Picon2Path, LCD4linux.PiconCache, LCD4linux.Picon2Cache, LCD4linux.PiconPathAlt, LCD4linux.Picon2PathAlt, LCD4linux.ConfigPath, LCD4linux.WetterPath, LCD4linux.MPCoverPath1, LCD4linux.MPCoverPath2, LCD4linux.FritzPath, LCD4linux.CalPath, LCD4linux.SatPath, LCD4linux.ProvPath, LCD4linux.MoonPath]:
 				L4log("select Dir 1")
 				self.session.openWithCallback(self.dirSelected, LCDdisplayFile, text=_("Choose dir"), FileName=self["config"].getCurrent()[1].value, showFiles=False)
-			elif sel in [LCD4linux.LCDBild1, LCD4linux.LCDBild2, LCD4linux.MPLCDBild1, LCD4linux.MPLCDBild2, LCD4linux.StandbyLCDBild1, LCD4linux.StandbyLCDBild2, LCD4linux.FritzFrame]:
+			elif sel in [LCD4linux.LCDBild1, LCD4linux.LCDBild2, LCD4linux.LCDBild3, LCD4linux.MPLCDBild1, LCD4linux.MPLCDBild2, LCD4linux.MPLCDBild3, LCD4linux.StandbyLCDBild1, LCD4linux.StandbyLCDBild2, LCD4linux.StandbyLCDBild3, LCD4linux.FritzFrame]:
 				L4log("select File 1")
 				self.session.openWithCallback(self.fileSelected, LCDdisplayFile, text=_("Choose file"), FileName=self["config"].getCurrent()[1].value, showFiles=True)
 			elif sel in [LCD4linux.OSCAMFile, LCD4linux.TextFile, LCD4linux.Text2File, LCD4linux.Text3File, LCD4linux.MPTextFile, LCD4linux.MPCoverFile, LCD4linux.MPCoverFile2, LCD4linux.BildFile, LCD4linux.Bild2File, LCD4linux.Bild3File, LCD4linux.Bild4File, LCD4linux.Bild5File, LCD4linux.Bild6File, LCD4linux.RecordingPath]:
@@ -7992,14 +7991,20 @@ class LCDdisplayConfig(ConfigListScreen, Screen):
 				LCD4linux.LCDBild1.value = dirdir
 			elif sel == LCD4linux.LCDBild2:
 				LCD4linux.LCDBild2.value = dirdir
+			elif sel == LCD4linux.LCDBild3:
+				LCD4linux.LCDBild3.value = dirdir
 			elif sel == LCD4linux.MPLCDBild1:
 				LCD4linux.MPLCDBild1.value = dirdir
 			elif sel == LCD4linux.MPLCDBild2:
 				LCD4linux.MPLCDBild2.value = dirdir
+			elif sel == LCD4linux.MPLCDBild3:
+				LCD4linux.MPLCDBild3.value = dirdir
 			elif sel == LCD4linux.StandbyLCDBild1:
 				LCD4linux.StandbyLCDBild1.value = dirdir
 			elif sel == LCD4linux.StandbyLCDBild2:
 				LCD4linux.StandbyLCDBild2.value = dirdir
+			elif sel == LCD4linux.StandbyLCDBild3:
+				LCD4linux.StandbyLCDBild3.value = dirdir
 			elif sel == LCD4linux.OSCAMFile:
 				LCD4linux.OSCAMFile.value = dirdir
 			elif sel == LCD4linux.TextFile:


### PR DESCRIPTION
- LCD3 background image can now be set via the file browser
- when switching to another mode (blue button), the preview image is not immediately updated automatically
- when selecting a clock of the type "Analog...", the line "Analog clock" is now automatically shown/hidden
- all translations modified accordingly

THX to User **KenTucky @ OpenA.TV**
details see: https://www.opena.tv/viewtopic.php?p=590512#p590436

HINT: **LCD4linux** is still working under Python2 and Python3